### PR TITLE
npm run dev can now be used without tweaking webpack.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "watch:lib": "tsc -w",
     "watch:nbextension": "webpack --watch",
     "watch:labextension": "jupyter labextension watch .",
-    "dev": "webpack-cli serve --mode=development --env development --open"
+    "dev": "webpack-cli serve --config webpack-local-dev.config.js --mode=development --env development --open"
   },
   "dependencies": {
     "@jupyter-widgets/base": "^2 || ^3 || ^4 || ^6.0.0",

--- a/webpack-local-dev.config.js
+++ b/webpack-local-dev.config.js
@@ -175,26 +175,4 @@ module.exports = [
       
   },
 
-  /**
-   * Documentation widget bundle
-   *
-   * This bundle is used to embed widgets in the package documentation.
-   */
-  {
-    entry: './js/index.ts',
-    output: {
-      filename: 'embed-bundle.js',
-      path: path.resolve(__dirname, 'docs', 'source', '_static'),
-      library: 'buckaroo',
-      libraryTarget: 'amd',
-    },
-    module: {
-      rules: rules,
-    },
-    devtool: 'source-map',
-    externals,
-    resolve,
-      performance
-
-  },
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,8 +93,6 @@ const resolve = {
 };
 
 module.exports = [
-
-*/
   /**
    * Notebook extension
    *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,27 +93,6 @@ const resolve = {
 };
 
 module.exports = [
-// the following section must be commented out for the nbextension to work
-// I think it must be enabled for the dev mode of the react app to work
-/*
-  {
-      entry: './examples/index-react18.tsx',
-        output: {
-            path: path.join(__dirname, '/examples/dist'),
-            filename: 'bundle.js'
-        },
-    module: {
-	rules: demoRules,
-    },
-    devtool: 'source-map',
-    externals,
-    resolve,
-      plugins: [new HtmlWebpackPlugin({
-                //template: './examples/index.html'
-                template: './examples/index.html'
-      })],
-      performance
-  },
 
 */
   /**


### PR DESCRIPTION
Fixes  make npm run dev work without editting webpack.config.js #125 