### PR TITLE
Feat/pluggable-autocleaning-step-1

### DIFF
--- a/buckaroo/buckaroo_widget.py
+++ b/buckaroo/buckaroo_widget.py
@@ -22,7 +22,7 @@ from .pluggable_analysis_framework.analysis_management import DfStats
 from .pluggable_analysis_framework.pluggable_analysis_framework import ColAnalysis
 
 from .serialization_utils import EMPTY_DF_WHOLE
-from .dataflow import CustomizableDataflow, StylingAnalysis, exception_protect
+from .dataflow.dataflow import CustomizableDataflow, StylingAnalysis, exception_protect
 
 
 class BuckarooWidget(CustomizableDataflow, DOMWidget):

--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -6,8 +6,15 @@ from ..jlisp.lispy import s
 #from ..auto_clean.cleaning_commands import (to_bool, to_datetime, to_int, to_float, to_string)
 
 class Command(object):
-    pass
-    
+    @staticmethod 
+    def transform(df, col, val):
+        return df.with_columns(pl.col(col).fill_null(val))
+        return df
+
+    @staticmethod 
+    def transform_to_py(df, col, val):
+        return "    df = df.with_columns(pl.col('%s').fill_null(%r))" % (col, val)
+
 class FillNA(Command):
     #argument_names = ["df", "col", "fill_val"]
     command_default = [s('fillna'), s('df'), "col", 8]
@@ -21,6 +28,32 @@ class FillNA(Command):
     @staticmethod 
     def transform_to_py(df, col, val):
         return "    df = df.with_columns(pl.col('%s').fill_null(%r))" % (col, val)
+
+class NoOp(Command):
+    #used for testing command stuff
+    command_default = [s('noop'), s('df'), "col"]
+    command_pattern = [None]
+
+    @staticmethod 
+    def transform(df, col):
+        return df
+
+    @staticmethod 
+    def transform_to_py(df, col):
+        return "    #noop"
+    
+class PlSafeInt(Command):
+    command_default = [s('safe_int'), s('df'), "col"]
+    command_pattern = [None]
+
+    @staticmethod 
+    def transform(df, col):
+        return df.with_columns(pl.col(col).cast(pl.Int64, strict=False))
+        return df
+
+    @staticmethod 
+    def transform_to_py(df, col):
+        return "    df = df.with_columns(pl.col('%s').cast(pl.Int64, strict=False))" % (col)
 
 class DropCol(Command):
     #argument_names = ["df", "col"]

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -1,4 +1,4 @@
-from buckaroo.dataflow import StylingAnalysis
+from buckaroo.dataflow.dataflow import StylingAnalysis
 from typing import Any
 
 def obj_(pkey):

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -1,0 +1,154 @@
+import pandas as pd
+from buckaroo.jlisp.lisp_utils import split_operations
+from buckaroo.pluggable_analysis_framework.polars_analysis_management import PlDfStats
+from ..customizations.all_transforms import configure_buckaroo, DefaultCommandKlsList
+
+
+'''
+
+
+    def handle_ops_and_clean_orig(self, df, cleaning_method, existing_operations):
+        if self.sampled_df is None:
+            return None
+        cleaning_operations, cleaning_sd = self._run_cleaning(df, cleaning_method)
+        merged_operations = merge_ops(existing_operations, cleaning_operations)
+        cleaned_df = self._run_df_interpreter(df, merged_operations)
+        generated_code = self._run_code_generator(merged_operations)
+        self.cleaned [cleaned_df, cleaning_sd, generated_code, merged_operations]
+
+
+'''
+def dumb_merge_ops(existing_ops, cleaning_ops):
+    """ strip cleaning_ops from existing_ops, reinsert cleaning_ops at the beginning """
+    a = existing_ops.copy()
+    a.extend(cleaning_ops)
+    return a
+
+SENTINEL_DF_1 = pd.DataFrame({'foo'  :[10, 20], 'bar' : ["asdf", "iii"]})
+SENTINEL_DF_2 = pd.DataFrame({'col1' :[55, 55], 'col2': ["pppp", "333"]})
+SENTINEL_DF_3 = pd.DataFrame({'pp'   :[99, 33], 'ee':   [     6,     9]})
+SENTINEL_DF_4 = pd.DataFrame({'vvv'  :[12, 49], 'oo':   [ 'ccc', 'www']})
+
+class SentinelAutocleaning:
+
+    def handle_ops_and_clean(self, df, cleaning_method, existing_operations):
+        cleaning_ops = []
+        generated_code = ""
+        if cleaning_method == "one op":
+            cleaning_ops =  [""]
+            generated_code = "codegen 1"
+            generated_code = "codegen 2"
+        elif cleaning_method == "two op":
+            cleaning_ops = ["", ""]
+
+        merged_operations = dumb_merge_ops(existing_operations, cleaning_ops)
+        
+        if len(merged_operations) == 1:
+            cleaned_df = SENTINEL_DF_1
+        elif len(merged_operations) == 2:
+            cleaned_df = SENTINEL_DF_2
+        else:
+            cleaned_df = df
+        return [cleaned_df, {}, generated_code, merged_operations]
+
+def merge_ops(existing_ops, cleaning_ops):
+    """ strip cleaning_ops from existing_ops, reinsert cleaning_ops at the beginning """
+    old_cleaning_ops, user_gen_ops = split_operations(existing_ops)
+    merged = cleaning_ops.copy()
+    merged.extend(user_gen_ops)
+    return merged
+
+
+
+def format_ops(column_meta):
+    ret_ops = []
+    for k,v in column_meta.items():
+        ops = v['cleaning_ops']
+        if len(ops) > 0:
+            temp_ops = ops.copy()
+            temp_ops.insert(2, k)
+            ret_ops.append(temp_ops)
+    return ret_ops
+
+def make_origs(raw_df, cleaned_df):
+    clauses = []
+    for col in raw_df.columns:
+        clauses.append(cleaned_df[col])
+        clauses.append(raw_df[col].alias(col+"_orig"))
+        # clauses.append(
+        #     pl.when((raw_df[col] - cleaned_df[col]).eq(0)).then(None).otherwise(raw_df[col]).alias(col+"_orig"))
+    ret_df = cleaned_df.select(clauses)
+    return ret_df
+
+
+class AutocleaningConfig:
+    command_klasses = [DefaultCommandKlsList]
+    autocleaning_analysis_klasses = []
+
+    name = 'default'
+    
+
+class Autocleaning:
+    # def add_command(self, incomingCommandKls):
+    #     without_incoming = [x for x in self.command_classes if not x.__name__ == incomingCommandKls.__name__]
+    #     without_incoming.append(incomingCommandKls)
+    #     self.command_klasses = without_incoming
+    #     self.setup_from_command_kls_list()
+
+
+    def __init__(self, ac_configs):
+
+        self.config_dict = {}
+        for conf in ac_configs:
+            self.config_dict[conf.name] = conf
+        #self._setup_from_command_kls_list()
+
+    ### start code interpreter block
+    def _setup_from_command_kls_list(self, name):
+        #used to initially setup the interpreter, and when a command
+        #is added interactively
+        if name not in self.config_dict:
+            options = list(self.config_dict.keys())
+            raise Exception(
+                "Unknown autocleaning conf of %s, available options are %r" % (name, options))
+        conf = self.config_dict[name]
+        c_klasses, self.autocleaning_analysis_klasses = conf.command_klasses, conf.autocleaning_analysis_klasses
+
+        c_defaults, c_patterns, df_interpreter, gencode_interpreter = configure_buckaroo(c_klasses)
+        self.df_interpreter, self.gencode_interpreter = df_interpreter, gencode_interpreter
+        self.commandConfig = dict(argspecs=c_patterns, defaultArgs=c_defaults)
+        #self.autocleaning_genops = filter_analysis(analysis_klasses, "autocleaning_ops")
+
+
+    def _run_df_interpreter(self, df, operations):
+        full_ops = [{'symbol': 'begin'}]
+        full_ops.extend(operations)
+        print("*"*80)
+        print(full_ops)
+        print("*"*80)
+        if len(full_ops) == 1:
+            return df
+        return self.df_interpreter(full_ops , df)
+
+    def _run_code_generator(self, operations):
+        if len(operations) == 0:
+            return 'no operations'
+        return self.gencode_interpreter(operations)
+
+    def _run_cleaning(self, df, cleaning_method):
+        dfs = PlDfStats(df, self.autocleaning_analysis_klasses, debug=True)
+        gen_ops = format_ops(dfs.sdf)
+
+        cleaning_sd = {}
+        return gen_ops, cleaning_sd
+
+    def handle_ops_and_clean(self, df, cleaning_method, existing_operations):
+        if df is None:
+            return None
+        self._setup_from_command_kls_list(cleaning_method)
+        cleaning_operations, cleaning_sd = self._run_cleaning(df, cleaning_method)
+        merged_operations = merge_ops(existing_operations, cleaning_operations)
+        cleaned_df = self._run_df_interpreter(df, merged_operations)
+        merged_cleaned_df = make_origs(df, cleaned_df)
+        generated_code = self._run_code_generator(merged_operations)
+        return [merged_cleaned_df, cleaning_sd, generated_code, merged_operations]

--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -8,7 +8,6 @@ from buckaroo.pluggable_analysis_framework.utils import (filter_analysis)
 from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import (ColAnalysis)
 from buckaroo.pluggable_analysis_framework.analysis_management import DfStats
 
-from ..customizations.all_transforms import configure_buckaroo, DefaultCommandKlsList
 
 SENTINEL_DF_1 = pd.DataFrame({'foo'  :[10, 20], 'bar' : ["asdf", "iii"]})
 SENTINEL_DF_2 = pd.DataFrame({'col1' :[55, 55], 'col2': ["pppp", "333"]})

--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -3,10 +3,12 @@ import sys
 import warnings
 import pandas as pd
 from traitlets import Unicode, Any, observe, HasTraits, Dict
-from .serialization_utils import pd_to_obj    
+from ..serialization_utils import pd_to_obj    
+from buckaroo.pluggable_analysis_framework.utils import (filter_analysis)
 from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import (ColAnalysis)
 from buckaroo.pluggable_analysis_framework.analysis_management import DfStats
-from .customizations.all_transforms import configure_buckaroo, DefaultCommandKlsList
+
+from ..customizations.all_transforms import configure_buckaroo, DefaultCommandKlsList
 
 SENTINEL_DF_1 = pd.DataFrame({'foo'  :[10, 20], 'bar' : ["asdf", "iii"]})
 SENTINEL_DF_2 = pd.DataFrame({'col1' :[55, 55], 'col2': ["pppp", "333"]})
@@ -14,13 +16,23 @@ SENTINEL_DF_3 = pd.DataFrame({'pp'   :[99, 33], 'ee':   [     6,     9]})
 SENTINEL_DF_4 = pd.DataFrame({'vvv'  :[12, 49], 'oo':   [ 'ccc', 'www']})
 
 
-
-
 def merge_ops(existing_ops, cleaning_ops):
     """ strip cleaning_ops from existing_ops, reinsert cleaning_ops at the beginning """
     a = existing_ops.copy()
     a.extend(cleaning_ops)
     return a
+
+def merge_sds(*sds):
+    """merge sds with later args taking precedence
+
+    sub-merging of "overide_config"??
+    """
+    base_sd = {}
+    for sd in sds:
+        for column in sd.keys():
+            base_sd[column] = merge_column(base_sd.get(column, {}), sd[column])
+    return base_sd
+
 
 def merge_column(base, new):
     """
@@ -36,17 +48,6 @@ def merge_column(base, new):
     if len(base_override) > 0:
         ret['column_config_override'] = base_override
     return ret
-
-def merge_sds(*sds):
-    """merge sds with later args taking precedence
-
-    sub-merging of "overide_config"??
-    """
-    base_sd = {}
-    for sd in sds:
-        for column in sd.keys():
-            base_sd[column] = merge_column(base_sd.get(column, {}), sd[column])
-    return base_sd
 
 SENTINEL_COLUMN_CONFIG_1 = "ASDF"
 SENTINEL_COLUMN_CONFIG_2 = "FOO-BAR"
@@ -118,11 +119,12 @@ class DataFlow(HasTraits):
         super().__init__()
         self.summary_sd = {}
         self.existing_operations = []
-
         try:
             self.raw_df = raw_df
         except Exception:
             six.reraise(self.exception[0], self.exception[1], self.exception[2])
+
+    #autocleaning_klass = SentinelAutocleaning
 
     raw_df = Any('')
     sample_method = Unicode('default')
@@ -201,6 +203,7 @@ class DataFlow(HasTraits):
         cleaned_df = self._run_df_interpreter(self.sampled_df, merged_operations)
         generated_code = self._run_code_generator(merged_operations)
         self.cleaned = [cleaned_df, cleaning_sd, generated_code, merged_operations]
+
 
     @property
     def cleaned_df(self):
@@ -335,13 +338,6 @@ class StylingAnalysis(ColAnalysis):
             'column_config': ret_col_config}
 
 
-def filter_analysis(klasses, attr):
-    ret_klses = {}
-    for k in klasses:
-        attr_val = getattr(k, attr, None)
-        if attr_val is not None:
-            ret_klses[attr_val] = k
-    return ret_klses
             
 class PostProcessingException(Exception):
     pass
@@ -379,7 +375,6 @@ class CustomizableDataflow(DataFlow):
     This allows targetd extension and customization of DataFlow
     """
     analysis_klasses = [StylingAnalysis]
-    command_klasses = DefaultCommandKlsList
     commandConfig = Dict({}).tag(sync=True)
     DFStatsClass = DfStats
     sampling_klass = Sampling
@@ -400,7 +395,6 @@ class CustomizableDataflow(DataFlow):
         self.setup_options_from_analysis()
         super().__init__(self.sampling_klass.pre_stats_sample(df))
 
-        self._setup_from_command_kls_list()
         self.populate_df_meta()
         #self.raw_df = df
         warnings.filterwarnings('default')
@@ -449,34 +443,6 @@ class CustomizableDataflow(DataFlow):
     #empty needs to always be present, it enables startup
     df_data_dict = Any({'empty':[]}).tag(sync=True)
 
-
-    ### start code interpreter block
-    def _setup_from_command_kls_list(self):
-        #used to initially setup the interpreter, and when a command
-        #is added interactively
-        c_klasses = self.command_klasses
-        c_defaults, c_patterns, df_interpreter, gencode_interpreter = configure_buckaroo(c_klasses)
-        self.df_interpreter, self.gencode_interpreter = df_interpreter, gencode_interpreter
-        self.commandConfig = dict(argspecs=c_patterns, defaultArgs=c_defaults)
-
-    def add_command(self, incomingCommandKls):
-        without_incoming = [x for x in self.command_classes if not x.__name__ == incomingCommandKls.__name__]
-        without_incoming.append(incomingCommandKls)
-        self.command_klasses = without_incoming
-        self.setup_from_command_kls_list()
-
-    def _run_df_interpreter(self, df, operations):
-        full_ops = [{'symbol': 'begin'}]
-        full_ops.extend(operations)
-        if len(full_ops) == 1:
-            return df
-        return self.buckaroo_transform(full_ops , df)
-
-    def run_code_generator(self, operations):
-        if len(operations) == 0:
-            return 'no operations'
-        return self.gencode_interpreter(operations)
-    ### end code interpeter block
 
     def _compute_processed_result(self, cleaned_df, post_processing_method):
         if post_processing_method == '':

--- a/buckaroo/pluggable_analysis_framework/utils.py
+++ b/buckaroo/pluggable_analysis_framework/utils.py
@@ -3,6 +3,7 @@ import sys
 import pandas as pd
 import numpy as np
 
+
 BASE_COL_HINT = {
     'type':'string',
     'is_numeric': False,
@@ -81,3 +82,10 @@ def json_postfix(postfix):
     return lambda nm: json.dumps([nm, postfix])
     
 
+def filter_analysis(klasses, attr):
+    ret_klses = {}
+    for k in klasses:
+        attr_val = getattr(k, attr, None)
+        if attr_val is not None:
+            ret_klses[attr_val] = k
+    return ret_klses

--- a/buckaroo/polars_buckaroo.py
+++ b/buckaroo/polars_buckaroo.py
@@ -8,7 +8,7 @@ from buckaroo.customizations.polars_commands import (
     DropCol, FillNA, GroupBy #, OneHot, GroupBy, reindex
 )
 from .customizations.styling import DefaultSummaryStatsStyling, DefaultMainStyling
-from .dataflow import Sampling
+from .dataflow.dataflow import Sampling
 
 
 class PLSampling(Sampling):

--- a/js/components/ColumnsEditor.tsx
+++ b/js/components/ColumnsEditor.tsx
@@ -20,7 +20,6 @@ export function ColumnsEditor({
   setOperations,
   operationResult,
   commandConfig,
-  widgetConfig,
 }: {
   df_viewer_config: DFViewerConfig;
   activeColumn: string;
@@ -28,30 +27,25 @@ export function ColumnsEditor({
   setOperations: OperationSetter;
   operationResult: OperationResult;
   commandConfig: CommandConfigT;
-  widgetConfig: WidgetConfig;
 }) {
   const allColumns = df_viewer_config.column_config.map(
     (field) => field.col_name
   );
   return (
     <div className="columns-editor" style={{ width: '100%' }}>
-      {widgetConfig.showCommands ? (
-        <div>
-          <OperationViewer
-            operations={operations}
-            setOperations={setOperations}
-            activeColumn={activeColumn}
-            allColumns={allColumns}
-            commandConfig={commandConfig}
-          />
-          <DependentTabs
-            filledOperations={operations}
-            operationResult={operationResult}
-          />
-        </div>
-      ) : (
-        <span></span>
-      )}
+      <div>
+        <OperationViewer
+          operations={operations}
+          setOperations={setOperations}
+          activeColumn={activeColumn}
+          allColumns={allColumns}
+          commandConfig={commandConfig}
+        />
+        <DependentTabs
+          filledOperations={operations}
+          operationResult={operationResult}
+        />
+      </div>
     </div>
   );
 }
@@ -72,7 +66,6 @@ export function ColumnsEditorEx() {
       operations={operations}
       setOperations={setOperations}
       operationResult={baseOperationResults}
-      widgetConfig={{ showCommands: true }}
     />
   );
 }

--- a/js/components/DCFCell.tsx
+++ b/js/components/DCFCell.tsx
@@ -1,7 +1,7 @@
 import React, { useState, Dispatch, SetStateAction } from 'react';
 import _ from 'lodash';
 import { OperationResult, baseOperationResults } from './DependentTabs';
-import { ColumnsEditor, WidgetConfig } from './ColumnsEditor';
+import { ColumnsEditor } from './ColumnsEditor';
 import {
   dfviewer_config_no_pinned,
   realSummaryConfig,
@@ -45,7 +45,6 @@ export function WidgetDCFCell({
   on_buckaroo_state,
   buckaroo_options,
 }: {
-  //  df_dict: Record<string, DFWhole>;
   df_meta: DFMeta;
   df_data_dict: Record<string, DFData>;
   df_display_args: Record<string, IDisplayArgs>;
@@ -58,13 +57,14 @@ export function WidgetDCFCell({
   buckaroo_options: BuckarooOptions;
 }) {
   const [activeCol, setActiveCol] = useState('stoptime');
-  const widgetConfig: WidgetConfig = {
-    showCommands: buckaroo_state.show_commands ? true : false,
-  };
 
   const cDisp = df_display_args[buckaroo_state.df_display];
   if (cDisp === undefined) {
-    //  console.log("cDisp undefined", buckaroo_state.df_display, buckaroo_options.df_display)
+    console.log(
+      'cDisp undefined',
+      buckaroo_state.df_display,
+      buckaroo_options.df_display
+    );
   } else {
     //  console.log("cDisp", cDisp);
   }
@@ -95,7 +95,7 @@ export function WidgetDCFCell({
           setActiveCol={setActiveCol}
         />
       </div>
-      {widgetConfig.showCommands ? (
+      {buckaroo_state.show_commands ? (
         <ColumnsEditor
           df_viewer_config={cDisp.df_viewer_config}
           activeColumn={activeCol}
@@ -103,7 +103,6 @@ export function WidgetDCFCell({
           setOperations={on_operations}
           operationResult={operation_results}
           commandConfig={commandConfig}
-          widgetConfig={widgetConfig}
         />
       ) : (
         <span></span>

--- a/tests/unit/dataflow/autocleaning_test.py
+++ b/tests/unit/dataflow/autocleaning_test.py
@@ -1,0 +1,175 @@
+import polars as pl
+from buckaroo.customizations.polars_analysis import (
+    VCAnalysis, PLCleaningStats, BasicAnalysis)
+from buckaroo.pluggable_analysis_framework.polars_analysis_management import PlDfStats, PolarsAnalysis
+from buckaroo.dataflow.autocleaning import Autocleaning, merge_ops, format_ops, make_origs, AutocleaningConfig
+from buckaroo.customizations.polars_commands import (
+    PlSafeInt, DropCol, FillNA, GroupBy, NoOp
+)
+
+
+
+dirty_df = pl.DataFrame({
+    'a':[10,  20,  30,   40,  10, 20.3,   5, None, None, None],
+    'b':["3", "4", "a", "5", "5",  "b", "b", None, None, None]})
+
+
+def make_default_analysis(**kwargs):
+    class DefaultAnalysis(PolarsAnalysis):
+        requires_summary = []
+        provides_defaults = kwargs
+    return DefaultAnalysis
+
+class CleaningGenOps(PolarsAnalysis):
+    requires_summary = ['int_parse_fail', 'int_parse']
+    provides_defaults = {'cleaning_ops': []}
+
+    int_parse_threshhold = .3
+    @classmethod
+    def computed_summary(kls, column_metadata):
+        if column_metadata['int_parse'] > kls.int_parse_threshhold:
+            return {'cleaning_ops': [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}]}
+        else:
+            return {'cleaning_ops': []}
+
+
+def test_cleaning_stats():
+    dfs = PlDfStats(dirty_df, [VCAnalysis, PLCleaningStats, BasicAnalysis])
+
+    # "3", "4", "5", "5"   4 out of 10
+    assert dfs.sdf['b']['int_parse'] == 0.4
+    assert dfs.sdf['b']['int_parse_fail'] == 0.6
+
+
+SAFE_INT_TOKEN = [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}]
+def test_ops_gen():
+
+    dfs = PlDfStats(dirty_df, [make_default_analysis(int_parse=.4, int_parse_fail=.6),
+                               CleaningGenOps], debug=True)
+    assert dfs.sdf['b']['cleaning_ops'] == SAFE_INT_TOKEN
+    dfs = PlDfStats(dirty_df, [make_default_analysis(int_parse=.2, int_parse_fail=.8),
+                               CleaningGenOps])
+    assert dfs.sdf['b']['cleaning_ops'] == []
+
+
+
+def test_format_ops():
+    column_meta = {
+        'a': {'cleaning_ops':SAFE_INT_TOKEN },
+        'b': {'cleaning_ops': [
+            {'symbol': 'replace_dirty', 'meta':{'auto_clean': True}},
+            {'symbol': 'df'}, '\n', None]}}
+
+    expected_ops = [
+        [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}, 'a'],
+        [{'symbol': 'replace_dirty', 'meta':{'auto_clean': True}}, {'symbol': 'df'}, 'b', '\n', None]]
+    assert format_ops(column_meta) == expected_ops
+
+
+
+
+class AlwaysSafeIntGenOps(PolarsAnalysis):
+    requires_summary = []
+    provides_defaults = {'cleaning_ops': []}
+
+    @classmethod
+    def computed_summary(kls, column_metadata):
+        return {'cleaning_ops': [{'symbol': 'safe_int', 'meta':{'auto_clean': True}},
+                                 {'symbol': 'df'}]}
+
+def test_merge_ops():
+    existing_ops = [
+        [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, 'a'],
+        [{'symbol': 'usergen'}, 'foo_column']
+    ]
+
+    cleaning_ops = [
+        [{'symbol': 'new_cleaning', 'meta':{'auto_clean': True}}, 'a']]
+
+    expected_merged = [
+        [{'symbol': 'new_cleaning', 'meta':{'auto_clean': True}}, 'a'],
+        [{'symbol': 'usergen'}, 'foo_column']
+    ]
+    print( merge_ops(existing_ops, cleaning_ops))
+    print("@"*80)
+    assert merge_ops(existing_ops, cleaning_ops) == expected_merged
+
+class ACConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = [VCAnalysis, PLCleaningStats, BasicAnalysis, CleaningGenOps]
+    command_klasses = [PlSafeInt, DropCol, FillNA, GroupBy, NoOp]
+    name="default"
+
+
+    
+def test_handle_user_ops():
+
+    ac = Autocleaning([ACConf])
+    df = pl.DataFrame({'a': [10, 20, 30]})
+    cleaning_result = ac.handle_ops_and_clean(df, cleaning_method='default', existing_operations=[])
+    cleaned_df, cleaning_sd, generated_code, merged_operations = cleaning_result
+    assert merged_operations == [
+        [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}, 'a']]
+
+    existing_ops = [
+        [{'symbol': 'old_safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}, 'a']]
+    cleaning_result2 = ac.handle_ops_and_clean(
+        df, cleaning_method='default', existing_operations=existing_ops)
+    cleaned_df, cleaning_sd, generated_code, merged_operations2 = cleaning_result2
+    assert merged_operations2 == [
+        [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}, 'a']]
+
+    user_ops = [
+        [{'symbol': 'noop'}, {'symbol': 'df'}, 'b']]
+    cleaning_result3 = ac.handle_ops_and_clean(
+        df, cleaning_method='default', existing_operations=user_ops)
+    cleaned_df, cleaning_sd, generated_code, merged_operations3 = cleaning_result3
+    assert merged_operations3 == [
+        [{'symbol': 'safe_int', 'meta':{'auto_clean': True}}, {'symbol': 'df'}, 'a'],
+        [{'symbol': 'noop'}, {'symbol': 'df'}, 'b']
+    ]
+
+
+def desired_test_make_origs():
+    # I can't make this work in a sensible way because it is not
+    # possible to quickly run comparisons against different dtype
+    # columns, and object dtypes are serverely limited
+    df_a = pl.DataFrame({'a': [10, 20, 30, 40], 'b': [1, 2, 3, 4]})
+    df_b = pl.DataFrame({'a': [10, 20,  0, 40], 'b': [1, 2, 3, 4]})    
+
+    expected = pl.DataFrame(
+        [pl.Series("a",      [  10,   20,    0,   40], dtype=pl.Int64),
+         pl.Series("a_orig", [None, None,   30, None], dtype=pl.Int64),
+         pl.Series("b",      [   1,    2,    3,    4], dtype=pl.Int64),
+         pl.Series("b_orig", [None, None, None, None], dtype=pl.Int64)])
+
+    assert make_origs(df_a, df_b).to_dicts() == expected.to_dicts()
+
+def test_make_origs_different_dtype():
+    raw = pl.DataFrame({'a': [30, "40"]})
+    cleaned = pl.DataFrame({'a': [30,  40]})
+    expected = pl.DataFrame({
+        'a': [30, 40],
+        'a_orig': [30,  "40"]})
+    assert make_origs(raw, cleaned).to_dicts() == expected.to_dicts()
+
+def test_handle_clean_df():
+    ac = Autocleaning([ACConf])
+    df = pl.DataFrame({'a': ["30", "40"]})
+    cleaning_result = ac.handle_ops_and_clean(df, cleaning_method='default', existing_operations=[])
+    cleaned_df, cleaning_sd, generated_code, merged_operations = cleaning_result
+    expected = pl.DataFrame({
+        'a': [30, 40],
+        'a_orig': ["30",  "40"]})
+    assert cleaned_df.to_dicts() == expected.to_dicts()
+
+EXPECTED_GEN_CODE = """def clean(df):
+    df = df.with_columns(pl.col('a').cast(pl.Int64, strict=False))
+    return df"""
+
+def test_autoclean_codegen():
+    ac = Autocleaning([ACConf])
+    df = pl.DataFrame({'a': ["30", "40"]})
+    cleaning_result = ac.handle_ops_and_clean(df, cleaning_method='default', existing_operations=[])
+    cleaned_df, cleaning_sd, generated_code, merged_operations = cleaning_result
+
+    assert generated_code == EXPECTED_GEN_CODE

--- a/tests/unit/dataflow/customizable_dataflow_test.py
+++ b/tests/unit/dataflow/customizable_dataflow_test.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 from ..fixtures import (DistinctCount)
 from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import (ColAnalysis)
-from buckaroo.dataflow import CustomizableDataflow, StylingAnalysis
+from buckaroo.dataflow.dataflow import CustomizableDataflow, StylingAnalysis
 from buckaroo.buckaroo_widget import BuckarooWidget
          
 

--- a/tests/unit/dataflow/dataflow_polars_test.py
+++ b/tests/unit/dataflow/dataflow_polars_test.py
@@ -1,4 +1,4 @@
-from buckaroo.dataflow import StylingAnalysis
+from buckaroo.dataflow.dataflow import StylingAnalysis
 from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import (ColAnalysis)
 from buckaroo.polars_buckaroo import PolarsBuckarooWidget
 import polars as pl 

--- a/tests/unit/dataflow/dataflow_test.py
+++ b/tests/unit/dataflow/dataflow_test.py
@@ -1,7 +1,8 @@
 import sys
 import pandas as pd
-from buckaroo.dataflow import DataFlow
-from buckaroo import dataflow as dft
+from buckaroo.dataflow.dataflow import DataFlow
+from buckaroo.dataflow import dataflow as dft
+from buckaroo.dataflow.dataflow import SENTINEL_DF_1, SENTINEL_DF_2
 
 simple_df = pd.DataFrame({'int_col':[1, 2, 3], 'str_col':['a', 'b', 'c']})
 
@@ -20,9 +21,9 @@ def test_dataflow_cleaned():
     d_flow = DataFlow(simple_df)
     assert d_flow.cleaned_df is simple_df
     d_flow.existing_operations = ["one"]
-    assert d_flow.cleaned_df is dft.SENTINEL_DF_1
+    assert d_flow.cleaned_df is SENTINEL_DF_1
     d_flow.cleaning_method = "one op"
-    assert d_flow.cleaned_df is dft.SENTINEL_DF_2
+    assert d_flow.cleaned_df is SENTINEL_DF_2
 
 def test_dataflow_processed():
 

--- a/tests/unit/polars_basic_widget_test.py
+++ b/tests/unit/polars_basic_widget_test.py
@@ -7,7 +7,7 @@ from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import (
     ColAnalysis)
 from buckaroo.pluggable_analysis_framework.utils import (json_postfix)
 from buckaroo.polars_buckaroo import PolarsBuckarooWidget
-from buckaroo.dataflow import StylingAnalysis
+from buckaroo.dataflow.dataflow import StylingAnalysis
 
 def test_basic_instantiation():
     PolarsBuckarooWidget(


### PR DESCRIPTION
Makes management of lowcode JLisp interpreter, and autocleaning methods swappable like styling and postprocessing.

Decided to sideline the full implementation for now because it is too involved... and polars makes some autocleaning functionality very difficult, particularly comparing original to modfified across different dtypes. This makes it much more difficult to color and add tooltips to the resulting dataframe based on modifications.

Nothing is integrated into the main flow yet.  This just makes the autocleaning module which will be integrated