### PR TITLE
add  PNGImageDisplayer

### DIFF
--- a/buckaroo/customizations/histogram.py
+++ b/buckaroo/customizations/histogram.py
@@ -91,6 +91,9 @@ class Histogram(ColAnalysis):
                     
     @staticmethod
     def series_summary(sampled_ser, ser):
+        """
+        https://stackoverflow.com/questions/11882393/matplotlib-disregard-outliers-when-plotting
+        """
         if not pd.api.types.is_numeric_dtype(ser):
             return dict(histogram_args={})
         if pd.api.types.is_bool_dtype(ser):

--- a/docs/source/articles/histograms.rst
+++ b/docs/source/articles/histograms.rst
@@ -67,7 +67,7 @@ Other research
 
 https://edwinth.github.io/blog/outlier-bin/
 
-https://stackoverflow.com/questions/11882393/matplotlib-disregard-outliers-when-plotting
+
 references
 
         Boris Iglewicz and David Hoaglin (1993), "Volume 16: How to Detect and

--- a/example-notebooks/styling-gallery.ipynb
+++ b/example-notebooks/styling-gallery.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "99218d54-79db-4c3c-8ca5-373e3c1ed677",
    "metadata": {
     "tags": []
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "840e09f3-8153-4800-a383-636556af4f32",
    "metadata": {
     "tags": []
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "4697fa58-9609-412f-b2d0-48a63fed0c99",
    "metadata": {
     "tags": []
@@ -95,12 +95,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "6e84d497-539f-4c62-810f-1cef72f417d2",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "f1de7ec8051b4cdfa908edb2b3f69291",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "GalleryBuckaroo(buckaroo_options={'sampled': ['random'], 'auto_clean': ['aggressive', 'conservative'], 'post_p…"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "obj_df = pl.DataFrame({\n",
     "    'bools':[True, True, False, False, True, None],\n",
@@ -299,7 +315,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "fd4dd7b5-ed26-42b6-aa20-f9d7211b7e95",
    "metadata": {
     "tags": []
@@ -311,12 +327,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "0f6231ea-a570-40d7-ab9d-86e8ce08c5a9",
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "65cbba804f404b3fa5ed81c9e3bc877d",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "PolarsBuckarooWidget(buckaroo_options={'sampled': ['random'], 'auto_clean': ['aggressive', 'conservative'], 'p…"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "img_df = DataFrame({'raw':            [png_smiley, None],\n",
     "                    'img_displayer' : [png_smiley, None]})\n",
@@ -650,7 +682,702 @@
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {
-    "state": {},
+    "state": {
+     "65cbba804f404b3fa5ed81c9e3bc877d": {
+      "model_module": "buckaroo",
+      "model_module_version": "^0.6.2",
+      "model_name": "DCEFWidgetModel",
+      "state": {
+       "_model_module_version": "^0.6.2",
+       "_view_module_version": "^0.6.2",
+       "_view_name": "DCEFWidgetView",
+       "buckaroo_options": {
+        "auto_clean": [
+         "aggressive",
+         "conservative"
+        ],
+        "df_display": [
+         "summary",
+         "main"
+        ],
+        "post_processing": [
+         ""
+        ],
+        "sampled": [
+         "random"
+        ],
+        "show_commands": [
+         "on"
+        ],
+        "summary_stats": [
+         "all"
+        ]
+       },
+       "buckaroo_state": {
+        "auto_clean": "conservative",
+        "df_display": "main",
+        "post_processing": "",
+        "sampled": false,
+        "search_string": "",
+        "show_commands": false
+       },
+       "commandConfig": {},
+       "df_data_dict": {
+        "all_stats": [
+         {
+          "img_displayer": "shape: (2,)\nSeries: '' [struct[2]]\n[\n\t{\"iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=\",1}\n\t{null,1}\n]",
+          "index": "value_counts",
+          "raw": "shape: (2,)\nSeries: '' [struct[2]]\n[\n\t{\"iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=\",1}\n\t{null,1}\n]"
+         },
+         {
+          "img_displayer": "String",
+          "index": "dtype",
+          "raw": "String"
+         },
+         {
+          "img_displayer": "string",
+          "index": "_type",
+          "raw": "string"
+         },
+         {
+          "img_displayer": false,
+          "index": "is_numeric",
+          "raw": false
+         },
+         {
+          "img_displayer": false,
+          "index": "is_integer",
+          "raw": false
+         },
+         {
+          "img_displayer": 2,
+          "index": "length",
+          "raw": 2
+         },
+         {
+          "img_displayer": 1,
+          "index": "nan_count",
+          "raw": 1
+         },
+         {
+          "img_displayer": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=",
+          "index": "min",
+          "raw": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+         },
+         {
+          "img_displayer": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=",
+          "index": "max",
+          "raw": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+         },
+         {
+          "img_displayer": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=",
+          "index": "mode",
+          "raw": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+         },
+         {
+          "img_displayer": null,
+          "index": "mean",
+          "raw": null
+         },
+         {
+          "img_displayer": 2,
+          "index": "unique_count",
+          "raw": 2
+         },
+         {
+          "img_displayer": 0,
+          "index": "empty_count",
+          "raw": 0
+         },
+         {
+          "img_displayer": 2,
+          "index": "distinct_count",
+          "raw": 2
+         },
+         {
+          "img_displayer": 1,
+          "index": "distinct_per",
+          "raw": 1
+         },
+         {
+          "img_displayer": 0,
+          "index": "empty_per",
+          "raw": 0
+         },
+         {
+          "img_displayer": 1,
+          "index": "unique_per",
+          "raw": 1
+         },
+         {
+          "img_displayer": 0.5,
+          "index": "nan_per",
+          "raw": 0.5
+         },
+         {
+          "img_displayer": {
+           "None": 0.5,
+           "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=": 0.5,
+           "longtail": -1,
+           "unique": 1
+          },
+          "index": "categorical_histogram",
+          "raw": {
+           "None": 0.5,
+           "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=": 0.5,
+           "longtail": -1,
+           "unique": 1
+          }
+         },
+         {
+          "img_displayer": [
+           {
+            "cat_pop": 50,
+            "name": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+           },
+           {
+            "cat_pop": 50,
+            "name": null
+           },
+           {
+            "name": "unique",
+            "unique": 100
+           },
+           {
+            "NA": 50,
+            "name": "NA"
+           }
+          ],
+          "index": "histogram",
+          "raw": [
+           {
+            "cat_pop": 50,
+            "name": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+           },
+           {
+            "cat_pop": 50,
+            "name": null
+           },
+           {
+            "name": "unique",
+            "unique": 100
+           },
+           {
+            "NA": 50,
+            "name": "NA"
+           }
+          ]
+         },
+         {
+          "img_displayer": [
+           "faked"
+          ],
+          "index": "histogram_bins",
+          "raw": [
+           "faked"
+          ]
+         }
+        ],
+        "empty": [],
+        "main": [
+         {
+          "img_displayer": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=",
+          "index": 0,
+          "raw": "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII="
+         },
+         {
+          "img_displayer": null,
+          "index": 1,
+          "raw": null
+         }
+        ]
+       },
+       "df_display_args": {
+        "main": {
+         "data_key": "main",
+         "df_viewer_config": {
+          "column_config": [
+           {
+            "col_name": "index",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "raw",
+            "displayer_args": {
+             "displayer": "string",
+             "max_length": 40
+            }
+           },
+           {
+            "ag_grid_specs": {
+             "width": 150
+            },
+            "col_name": "img_displayer",
+            "displayer_args": {
+             "displayer": "Base64PNGImageDisplayer"
+            }
+           }
+          ],
+          "pinned_rows": [
+           {
+            "displayer_args": {
+             "displayer": "obj"
+            },
+            "primary_key_val": "dtype"
+           },
+           {
+            "displayer_args": {
+             "displayer": "histogram"
+            },
+            "primary_key_val": "histogram"
+           }
+          ]
+         },
+         "summary_stats_key": "all_stats"
+        },
+        "summary": {
+         "data_key": "empty",
+         "df_viewer_config": {
+          "column_config": [
+           {
+            "col_name": "index",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "raw",
+            "displayer_args": {
+             "displayer": "string",
+             "max_length": 40
+            }
+           },
+           {
+            "ag_grid_specs": {
+             "width": 150
+            },
+            "col_name": "img_displayer",
+            "displayer_args": {
+             "displayer": "Base64PNGImageDisplayer"
+            }
+           }
+          ],
+          "pinned_rows": [
+           {
+            "displayer_args": {
+             "displayer": "obj"
+            },
+            "primary_key_val": "dtype"
+           },
+           {
+            "displayer_args": {
+             "displayer": "float",
+             "max_fraction_digits": 3,
+             "min_fraction_digits": 3
+            },
+            "primary_key_val": "min"
+           },
+           {
+            "displayer_args": {
+             "displayer": "float",
+             "max_fraction_digits": 3,
+             "min_fraction_digits": 3
+            },
+            "primary_key_val": "mean"
+           },
+           {
+            "displayer_args": {
+             "displayer": "float",
+             "max_fraction_digits": 3,
+             "min_fraction_digits": 3
+            },
+            "primary_key_val": "max"
+           },
+           {
+            "displayer_args": {
+             "displayer": "float",
+             "max_fraction_digits": 0,
+             "min_fraction_digits": 0
+            },
+            "primary_key_val": "unique_count"
+           },
+           {
+            "displayer_args": {
+             "displayer": "float",
+             "max_fraction_digits": 0,
+             "min_fraction_digits": 0
+            },
+            "primary_key_val": "distinct_count"
+           },
+           {
+            "displayer_args": {
+             "displayer": "float",
+             "max_fraction_digits": 0,
+             "min_fraction_digits": 0
+            },
+            "primary_key_val": "empty_count"
+           }
+          ]
+         },
+         "summary_stats_key": "all_stats"
+        }
+       },
+       "df_meta": {
+        "columns": 2,
+        "rows_shown": 2,
+        "total_rows": 2
+       },
+       "layout": "IPY_MODEL_c5d9e4c6ea08435daa316270b5977d54",
+       "operation_results": {
+        "generated_py_code": "# instantiation, unused",
+        "transformed_df": {
+         "column_config": [],
+         "data": [],
+         "pinned_rows": []
+        }
+       },
+       "operations": []
+      }
+     },
+     "c5d9e4c6ea08435daa316270b5977d54": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "dee2e1643b05493fa3422d21b0f0817d": {
+      "model_module": "@jupyter-widgets/base",
+      "model_module_version": "2.0.0",
+      "model_name": "LayoutModel",
+      "state": {}
+     },
+     "f1de7ec8051b4cdfa908edb2b3f69291": {
+      "model_module": "buckaroo",
+      "model_module_version": "^0.6.2",
+      "model_name": "DCEFWidgetModel",
+      "state": {
+       "_model_module_version": "^0.6.2",
+       "_view_module_version": "^0.6.2",
+       "_view_name": "DCEFWidgetView",
+       "buckaroo_options": {
+        "auto_clean": [
+         "aggressive",
+         "conservative"
+        ],
+        "df_display": [
+         "main"
+        ],
+        "post_processing": [
+         ""
+        ],
+        "sampled": [
+         "random"
+        ],
+        "show_commands": [
+         "on"
+        ],
+        "summary_stats": [
+         "all"
+        ]
+       },
+       "buckaroo_state": {
+        "auto_clean": "conservative",
+        "df_display": "main",
+        "post_processing": "",
+        "sampled": false,
+        "search_string": "",
+        "show_commands": false
+       },
+       "commandConfig": {},
+       "df_data_dict": {
+        "all_stats": [
+         {
+          "bools": "Boolean",
+          "dicts": "Struct({'a': Int64, 'b': Int64, 'c': String})",
+          "index": "dtype",
+          "ints": "Int64",
+          "lists": "List(String)",
+          "lists-int": "List(Int64)",
+          "lists-string": "List(String)",
+          "nested_dicts": "Struct({'level_1': Struct({'a': Int64, 'b': Int64, 'c': String})})",
+          "timestamp": "String"
+         },
+         {
+          "bools": "boolean",
+          "dicts": "unknown",
+          "index": "_type",
+          "ints": "integer",
+          "lists": "unknown",
+          "lists-int": "unknown",
+          "lists-string": "unknown",
+          "nested_dicts": "unknown",
+          "timestamp": "string"
+         },
+         {
+          "bools": false,
+          "dicts": false,
+          "index": "is_numeric",
+          "ints": true,
+          "lists": false,
+          "lists-int": false,
+          "lists-string": false,
+          "nested_dicts": false,
+          "timestamp": false
+         },
+         {
+          "bools": false,
+          "dicts": false,
+          "index": "is_integer",
+          "ints": true,
+          "lists": false,
+          "lists-int": false,
+          "lists-string": false,
+          "nested_dicts": false,
+          "timestamp": false
+         }
+        ],
+        "empty": [],
+        "main": [
+         {
+          "bools": true,
+          "dicts": {
+           "a": 10,
+           "b": 20,
+           "c": "some string"
+          },
+          "index": 0,
+          "ints": 5,
+          "lists": [
+           "a",
+           "b"
+          ],
+          "lists-int": [
+           10,
+           20
+          ],
+          "lists-string": [
+           "a",
+           "b"
+          ],
+          "nested_dicts": {
+           "level_1": {
+            "a": 10,
+            "b": 20,
+            "c": "some string"
+           }
+          },
+          "timestamp": "2020-01-01 01:00Z"
+         },
+         {
+          "bools": true,
+          "dicts": {
+           "a": null,
+           "b": null,
+           "c": null
+          },
+          "index": 1,
+          "ints": 20,
+          "lists": [
+           "1",
+           "2"
+          ],
+          "lists-int": [
+           100,
+           500
+          ],
+          "lists-string": [
+           "foo",
+           "bar"
+          ],
+          "nested_dicts": {
+           "level_1": {
+            "a": null,
+            "b": null,
+            "c": null
+           }
+          },
+          "timestamp": "2020-01-01 02:00Z"
+         },
+         {
+          "bools": false,
+          "dicts": {
+           "a": null,
+           "b": null,
+           "c": null
+          },
+          "index": 2,
+          "ints": 30,
+          "lists": null,
+          "lists-int": [
+           8
+          ],
+          "lists-string": null,
+          "nested_dicts": {
+           "level_1": {
+            "a": null,
+            "b": null,
+            "c": null
+           }
+          },
+          "timestamp": "2020-02-28 02:00Z"
+         },
+         {
+          "bools": false,
+          "dicts": {
+           "a": null,
+           "b": null,
+           "c": null
+          },
+          "index": 3,
+          "ints": -10,
+          "lists": null,
+          "lists-int": null,
+          "lists-string": null,
+          "nested_dicts": {
+           "level_1": {
+            "a": null,
+            "b": null,
+            "c": null
+           }
+          },
+          "timestamp": "2020-03-15 02:00Z"
+         },
+         {
+          "bools": true,
+          "dicts": {
+           "a": null,
+           "b": null,
+           "c": null
+          },
+          "index": 4,
+          "ints": 7772,
+          "lists": null,
+          "lists-int": null,
+          "lists-string": null,
+          "nested_dicts": {
+           "level_1": {
+            "a": null,
+            "b": null,
+            "c": null
+           }
+          },
+          "timestamp": null
+         },
+         {
+          "bools": null,
+          "dicts": {
+           "a": null,
+           "b": null,
+           "c": null
+          },
+          "index": 5,
+          "ints": null,
+          "lists": null,
+          "lists-int": null,
+          "lists-string": null,
+          "nested_dicts": {
+           "level_1": {
+            "a": null,
+            "b": null,
+            "c": null
+           }
+          },
+          "timestamp": null
+         }
+        ]
+       },
+       "df_display_args": {
+        "main": {
+         "data_key": "main",
+         "df_viewer_config": {
+          "column_config": [
+           {
+            "col_name": "index",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "bools",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "ints",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "timestamp",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "dicts",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "nested_dicts",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "lists",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "lists-string",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           },
+           {
+            "col_name": "lists-int",
+            "displayer_args": {
+             "displayer": "obj"
+            }
+           }
+          ],
+          "pinned_rows": [
+           {
+            "displayer_args": {
+             "displayer": "obj"
+            },
+            "primary_key_val": "dtype"
+           }
+          ]
+         },
+         "summary_stats_key": "all_stats"
+        }
+       },
+       "df_meta": {
+        "columns": 8,
+        "rows_shown": 6,
+        "total_rows": 6
+       },
+       "layout": "IPY_MODEL_dee2e1643b05493fa3422d21b0f0817d",
+       "operation_results": {
+        "generated_py_code": "# instantiation, unused",
+        "transformed_df": {
+         "column_config": [],
+         "data": [],
+         "pinned_rows": []
+        }
+       },
+       "operations": []
+      }
+     }
+    },
     "version_major": 2,
     "version_minor": 0
    }

--- a/example-notebooks/styling-gallery.ipynb
+++ b/example-notebooks/styling-gallery.ipynb
@@ -11,7 +11,7 @@
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
-    "from buckaroo.dataflow import StylingAnalysis\n",
+    "from buckaroo.dataflow.dataflow import StylingAnalysis\n",
     "from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import ColAnalysis\n",
     "import polars as pl\n",
     "from buckaroo.polars_buckaroo import PolarsBuckarooWidget\n",
@@ -295,6 +295,35 @@
     "                   column_config_overrides={\n",
     "                    'histogram_props': {'displayer_args': {'displayer': 'histogram'}}})\n",
     "#Fixme, this doesn't work with polars right now, probably related to the object dtype problem"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd4dd7b5-ed26-42b6-aa20-f9d7211b7e95",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "png_smiley = 'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=';"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f6231ea-a570-40d7-ab9d-86e8ce08c5a9",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "img_df = DataFrame({'raw':            [png_smiley, None],\n",
+    "                    'img_displayer' : [png_smiley, None]})\n",
+    "BUCKAROOWidget(img_df,\n",
+    "               column_config_overrides={\n",
+    "                   'raw':           {'displayer_args': {'displayer': 'string', 'max_length':40}},\n",
+    "                   'img_displayer': {'displayer_args': {'displayer': 'Base64PNGImageDisplayer'}, 'ag_grid_specs' : {'width':150}}})"
    ]
   },
   {

--- a/js/baked_data/staticData.ts
+++ b/js/baked_data/staticData.ts
@@ -133,6 +133,9 @@ export const histograms = {
   ],
 };
 
+export const smileyPNGString =
+  'iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURBVEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kovIHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00YFsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvPFxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQbqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96CutRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFthatyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlithJtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosXVTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCDV1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wbwLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjLYCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=';
+
 //export const tableDf2:DFWhole = {
 export const foo: DFWhole = {
   dfviewer_config: {
@@ -179,6 +182,7 @@ export const foo: DFWhole = {
       bikeid: 19578,
       'birth year': '1987',
       gender: 2,
+      img_: smileyPNGString,
     },
     {
       index: 1,
@@ -296,7 +300,13 @@ export const tableDf: DFWhole = {
           val_column: 'start station name',
         },
       },
+      {
+        col_name: 'img_',
+        displayer_args: { displayer: 'Base64PNGImageDisplayer' },
+        ag_grid_specs: { width: 150 },
+      },
     ],
+    extra_grid_config: { rowHeight: 35 },
     pinned_rows: [
       { primary_key_val: 'dtype', displayer_args: { displayer: 'obj' } },
       //      {        primary_key_val: 'histogram',        displayer_args: { displayer: 'histogram' },      },
@@ -313,6 +323,7 @@ export const tableDf: DFWhole = {
       nanObject: null,
       nanFloat: null,
       link_column: 'https://buckaroo.dev',
+      img_: smileyPNGString,
     },
     {
       index: 1,

--- a/js/components/DFViewerParts/DFViewer.tsx
+++ b/js/components/DFViewerParts/DFViewer.tsx
@@ -47,7 +47,6 @@ export function DFViewer(
     df_viewer_config,
     summary_stats_data || []
   );
-  //agColsPure[0].minWidth=150;
 
   const styledColumns = replaceAtMatch(
     _.clone(agColsPure),
@@ -79,6 +78,9 @@ export function DFViewer(
         setActiveCol(colName);
       }
     },
+    ...(df_viewer_config.extra_grid_config
+      ? df_viewer_config.extra_grid_config
+      : {}),
   };
   const gridRef = useRef<AgGridReact<unknown>>(null);
   const pinned_rows = df_viewer_config.pinned_rows;

--- a/js/components/DFViewerParts/DFWhole.ts
+++ b/js/components/DFViewerParts/DFWhole.ts
@@ -1,6 +1,6 @@
 // I'm not sure about adding underlying types too
 
-import { ColDef } from 'ag-grid-community';
+import { ColDef, GridOptions } from 'ag-grid-community';
 import _ from 'lodash';
 
 type AGGrid_ColDef = ColDef;
@@ -58,13 +58,23 @@ export interface BooleanCheckboxDisplayerA {
   displayer: 'boolean_checkbox';
 }
 
+export interface Base64PNGImageDisplayerA {
+  displayer: 'Base64PNGImageDisplayer';
+}
+
 export type CellRendererArgs =
   | HistogramDisplayerA
   | LinkifyDisplayerA
-  | BooleanCheckboxDisplayerA;
+  | BooleanCheckboxDisplayerA
+  | Base64PNGImageDisplayerA;
+
 export type DisplayerArgs = FormatterArgs | CellRendererArgs;
 
-export const cellRendererDisplayers = ['histogram', 'linkify'];
+export const cellRendererDisplayers = [
+  'histogram',
+  'linkify',
+  'Base64PNGImageDisplayer',
+];
 
 //ColorMapRules
 export interface ColorMapRules {
@@ -122,6 +132,7 @@ export type PinnedRowConfig = {
 export interface DFViewerConfig {
   pinned_rows: PinnedRowConfig[];
   column_config: ColumnConfig[];
+  extra_grid_config?: GridOptions;
 }
 
 export type DFDataRow = Record<

--- a/js/components/DFViewerParts/Displayer.ts
+++ b/js/components/DFViewerParts/Displayer.ts
@@ -8,7 +8,11 @@ import {
   StringDisplayerA,
 } from './DFWhole';
 import _ from 'lodash';
-import { HistogramCell, LinkCellRenderer } from './HistogramCell';
+import {
+  Base64PNGDisplayer,
+  HistogramCell,
+  LinkCellRenderer,
+} from './HistogramCell';
 import { CellRendererArgs, FormatterArgs } from './DFWhole';
 
 /*
@@ -194,6 +198,8 @@ export function getCellRenderer(crArgs: CellRendererArgs) {
       return HistogramCell;
     case 'linkify':
       return LinkCellRenderer;
+    case 'Base64PNGImageDisplayer':
+      return Base64PNGDisplayer;
     case 'boolean_checkbox':
       return 'agCheckboxCellRenderer';
   }

--- a/js/components/DFViewerParts/HistogramCell.tsx
+++ b/js/components/DFViewerParts/HistogramCell.tsx
@@ -140,6 +140,11 @@ export const LinkCellRenderer = (props: any) => {
   return <a href={props.value}>{props.value}</a>;
 };
 
+export const Base64PNGDisplayer = (props: any) => {
+  const imgString = 'data:image/png;base64,' + props.value;
+  return <img src={imgString}></img>;
+};
+
 export const HistogramCell = (props: any) => {
   //debugger;
   if (props === undefined || props.value === undefined) {


### PR DESCRIPTION
This is a very clean example of adding a new displayer, then using it from the styling gallery.

here is the sample code to call it
```python
img_df = DataFrame({'raw':            [png_smiley, None],
                    'img_displayer' : [png_smiley, None]})
BUCKAROOWidget(img_df,
               column_config_overrides={
                   'raw':           {'displayer_args': {'displayer': 'string', 'max_length':40}},
                   'img_displayer': {'displayer_args': {'displayer': 'Base64PNGImageDisplayer'}, 'ag_grid_specs' : {'width':150}}})
```