### PR TITLE
Chore/fix jupyterlite

### DIFF
--- a/buckaroo/_version.py
+++ b/buckaroo/_version.py
@@ -13,4 +13,4 @@ except Exception:
         __version__ = json.loads(open(full_path / "../package.json").read())['version']
     except Exception:
         #Jupyter lite can't read this file for some reason
-        __version__ = "0.7.jupyterlite"
+        __version__ = "0.7.8"

--- a/buckaroo/_version.py
+++ b/buckaroo/_version.py
@@ -5,7 +5,12 @@ from importlib import metadata
 import json
 import pathlib
 full_path = pathlib.Path(__file__).parent.resolve()
+__version__ = "unknown"
 try:
     __version__ = metadata.version('buckaroo')
 except Exception:
-    __version__ = json.loads(open(full_path / "../package.json").read())['version']
+    try:
+        __version__ = json.loads(open(full_path / "../package.json").read())['version']
+    except Exception:
+        #Jupyter lite can't read this file for some reason
+        __version__ = "0.7.jupyterlite"

--- a/buckaroo/customizations/analysis.py
+++ b/buckaroo/customizations/analysis.py
@@ -2,7 +2,7 @@ import warnings
 
 import pandas as pd
 import numpy as np
-from packaging.version import Version
+
 
 from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import ColAnalysis
 
@@ -26,7 +26,20 @@ def probable_datetime(ser):
         warnings.filterwarnings('default')
         return False
 
+
 def get_mode(ser):
+    try:
+        from packaging.version import Version
+    except Exception:
+        #this package isn't available in jupyterlite
+        
+        # but in jupyterlite envs, we have a recent version of pandas
+        # without this problem
+        mode_raw = ser.mode()
+        if len(mode_raw) == 0:
+            return np.nan
+        return mode_raw.values[0]
+        
     try:
         mode_raw = ser.mode()
         if len(mode_raw) == 0:

--- a/buckaroo/pluggable_analysis_framework/analysis_management.py
+++ b/buckaroo/pluggable_analysis_framework/analysis_management.py
@@ -4,7 +4,7 @@ import warnings
 
 import pandas as pd
 import numpy as np
-from packaging.version import Version
+
 
 from buckaroo.pluggable_analysis_framework.safe_summary_df import output_full_reproduce, output_reproduce_preamble
 
@@ -122,6 +122,12 @@ class AnalysisPipeline(object):
         summary_df, summary_errs = produce_summary_df(
             df, series_stat_dict, ordered_objs, df_name, debug)
         series_errs.update(summary_errs)
+        try:
+            from packaging.version import Version
+        except Exception:
+            # probably in jupyterlite
+            # we have a recent pandas version here, so it's fine to just return the obj
+            return summary_df, series_errs
         if Version(pd.__version__) < Version("2.0.7"):
             for col, summary_dict in summary_df.items():
                 del_keys = []

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckaroo",
-  "version": "0.7.6",
+  "version": "0.7.8",
   "description": "Fast Datagrid widget for the Jupyter Notebook and JupyterLab",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "graphlib_backport>=1.0.0",
     "packaging>=18"
 ]
-version = "0.7.6"
+version = "0.7.8"
 
 [project.license]
 file = "LICENSE.txt"
@@ -52,7 +52,8 @@ test = [
     "polars[timezone]",
     "pydantic>=2.5.2",
     "pyarrow",
-    "geopandas<1.0"
+    "geopandas<1.0",
+    "ruff"
 ]
 polars = ["polars>=1.0,<1.6",
        "polars[timezone]"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const version = require('./package.json').version;
 //import {TsconfigPathsPlugin} from 'tsconfig-paths-webpack-plugin';
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+const  TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 //import HtmlWebpackPlugin from 'html-webpack-plugin';
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -14,15 +14,35 @@ const cryptoOrigCreateHash = crypto.createHash;
 crypto.createHash = (algorithm) =>
   cryptoOrigCreateHash(algorithm == 'md4' ? 'sha256' : algorithm);
 
-const performance = {
-  maxAssetSize: 100_000_000,
+const  performance = {
+    maxAssetSize: 100_000_000,
 };
 
 // Custom webpack rules
-const rules = [
-  { test: /\.tsx?$/, loader: 'ts-loader' },
+const baseRules = [
+
   { test: /\.js$/, loader: 'source-map-loader' },
   { test: /\.css$/, use: ['style-loader', 'css-loader'] },
+                {
+                    test: /\.scss$/,
+                    use: [
+                        // We're in dev and want HMR, SCSS is handled in JS
+                        // In production, we want our css as files
+                        "style-loader",
+                        "css-loader",
+                        {
+                            loader: "postcss-loader",
+                            options: {
+                                postcssOptions: {
+                                    plugins: [
+                                        ["postcss-preset-env"],
+                                    ],
+                                },
+                            },
+                        },
+                        "sass-loader"
+                    ],
+                },
   {
     test: luminoThemeImages,
     issuer: /\.css$/,
@@ -35,10 +55,10 @@ const rules = [
     exclude: luminoThemeImages,
     use: ['file-loader'],
   },
-  {
-    test: /\.md$/,
-    use: ['html-loader', 'markdown-loader'],
-  },
+    {
+        test: /\.md$/,
+        use: ['html-loader', 'markdown-loader']
+    },
   {
     test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
     issuer: /\.css$/,
@@ -50,17 +70,56 @@ const rules = [
 ];
 
 
+const rules = [...baseRules,   { test: /\.tsx?$/, loader: 'ts-loader' }];
+const demoRules = [...baseRules,
+                {
+                    test: /\.tsx?$/,
+                    loader: 'ts-loader',
+                    options: {
+                        transpileOnly: true,
+                        configFile: 'examples/tsconfig.json'
+                    }
+                }]
+
+		   
 // Packages that shouldn't be bundled but loaded at runtime
 const externals = ['@jupyter-widgets/base'];
 
 const resolve = {
   // Add '.ts' and '.tsx' as resolvable extensions.
   extensions: ['.webpack.js', '.web.js', '.ts', '.js', '.tsx'],
-  plugins: [new TsconfigPathsPlugin()],
+    plugins: [new TsconfigPathsPlugin()],
   fallback: { crypto: false },
 };
 
 module.exports = [
+  /**
+   * Notebook extension
+   *
+   * This bundle only contains the part of the JavaScript that is run on load of
+   * the notebook.
+   */
+  {
+    entry: './js/extension.ts',
+    output: {
+      filename: 'index.js',
+      path: path.resolve(__dirname, 'buckaroo', 'nbextension'),
+      libraryTarget: 'amd',
+    },
+    module: {
+      rules: rules,
+    },
+    devtool: 'source-map',
+    externals,
+    resolve,
+      // plugins: [new HtmlWebpackPlugin({
+      //           template: './examples/index.html'
+      //       })]
+      performance
+
+
+  },
+
   /**
    * Embeddable buckaroo bundle
    *
@@ -86,9 +145,33 @@ module.exports = [
     },
     externals,
     resolve,
-    devServer: {
-      port: 8030,
+        devServer: {
+            port: 8030
+        },
+      performance
+      
+  },
+
+  /**
+   * Documentation widget bundle
+   *
+   * This bundle is used to embed widgets in the package documentation.
+   */
+  {
+    entry: './js/index.ts',
+    output: {
+      filename: 'embed-bundle.js',
+      path: path.resolve(__dirname, 'docs', 'source', '_static'),
+      library: 'buckaroo',
+      libraryTarget: 'amd',
     },
-    performance,
+    module: {
+      rules: rules,
+    },
+    devtool: 'source-map',
+    externals,
+    resolve,
+      performance
+
   },
 ];


### PR DESCRIPTION
This build works for jupyterlite-xeus locally.  It reverts to the old webpack.config.js before https://github.com/paddymul/buckaroo/commit/0fd9aec465860892e8794512958d72ca717f0f63 0fd9aec46

Removes bare imports of psutil and packaging which don't exist in jupyterlite.

Goes back to a hardcoded `_version.py` because jupyterlite can't read package.json - this is a dev-experience regression