### PR TITLE
Chore/marimo compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,10 @@ dependencies = [
     "anywidget >= 0.9.0",
     "graphlib_backport>=1.0.0",
     "hatch>=1.14.0",
-    "packaging>=18",
+    "packaging>=18,<=23.2",
     "twine>=6.0.1",
 ]
-version = "0.8.3"
+version = "0.8.4"
 
 [project.license]
 file = "LICENSE.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,11 @@ classifiers = [
 dependencies = [
     "anywidget >= 0.9.0",
     "graphlib_backport>=1.0.0",
-    "hatch>=1.14.0",
+    "hatch",
     "packaging>=18,<=23.2",
-    "twine>=6.0.1",
+    "twine"
 ]
-version = "0.8.4"
+version = "0.8.5"
 
 [project.license]
 file = "LICENSE.txt"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,8 @@ classifiers = [
 dependencies = [
     "anywidget >= 0.9.0",
     "graphlib_backport>=1.0.0",
-    "hatch",
-    "packaging>=18,<=23.2",
-    "twine"
 ]
-version = "0.8.5"
+version = "0.8.6"
 
 [project.license]
 file = "LICENSE.txt"


### PR DESCRIPTION
fixed some packaging/dependency incompatibility with marimo that was preventing Buckaroo from installing in their WASM playground. 