### PR TITLE
Feat/fix panel styling

### DIFF
--- a/buckaroo/customizations/pandas_commands.py
+++ b/buckaroo/customizations/pandas_commands.py
@@ -419,7 +419,6 @@ class DropCol(Command):
     @staticmethod 
     def transform(df, col):
         df.drop(col, axis=1, inplace=True)
-        print("dropcol.transform")
         return df
 
     @staticmethod 

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -216,7 +216,6 @@ class PandasAutocleaning:
 
         # [{'meta':'no-op'}] is a sentinel for the initial state
         if ops_eq(existing_operations, [{'meta':'no-op'}]) and cleaning_method == "NoCleaning":
-            print("cleaning_method", cleaning_method)
             final_ops = self.produce_final_ops(cleaning_ops, quick_command_args, [])
             #FIXME, a little bit of a hack to reset cleaning_sd, but it helps tests pass. I
             # don't know how any other properties could really be set

--- a/js/widget.tsx
+++ b/js/widget.tsx
@@ -5,127 +5,6 @@ import srt from "buckaroo-js-core";
 import "./widget.css";
 import "../packages/buckaroo-js-core/dist/style.css";
 
-const realSummaryConfig = {
-	pinned_rows: [
-		{ primary_key_val: "dtype", displayer_args: { displayer: "obj" } },
-		{
-			primary_key_val: "min",
-			displayer_args: {
-				displayer: "float",
-				min_fraction_digits: 3,
-				max_fraction_digits: 3,
-			},
-		},
-		{
-			primary_key_val: "mean",
-			displayer_args: {
-				displayer: "float",
-				min_fraction_digits: 3,
-				max_fraction_digits: 3,
-			},
-		},
-		{
-			primary_key_val: "max",
-			displayer_args: {
-				displayer: "float",
-				min_fraction_digits: 3,
-				max_fraction_digits: 3,
-			},
-		},
-		{
-			primary_key_val: "unique_count",
-			displayer_args: {
-				displayer: "float",
-				min_fraction_digits: 0,
-				max_fraction_digits: 0,
-			},
-		},
-		{
-			primary_key_val: "distinct_count",
-			displayer_args: {
-				displayer: "float",
-				min_fraction_digits: 0,
-				max_fraction_digits: 0,
-			},
-		},
-		{
-			primary_key_val: "empty_count",
-			displayer_args: {
-				displayer: "float",
-				min_fraction_digits: 0,
-				max_fraction_digits: 0,
-			},
-		},
-	],
-	column_config: [
-		{
-			col_name: "index",
-			displayer_args: { displayer: "string" },
-			ag_grid_specs: { minWidth: 150, pinned: "left" },
-		},
-		{ col_name: "int_col", displayer_args: { displayer: "obj" } },
-		{ col_name: "float_col", displayer_args: { displayer: "obj" } },
-		{ col_name: "str_col", displayer_args: { displayer: "obj" } },
-	],
-};
-
-const realSummaryTableData = [
-	{ index: "dtype", int_col: "int64", float_col: "float64", str_col: "object" },
-	{ index: "min", int_col: 1, float_col: 1.4285714286 },
-	{ index: "max", int_col: 49, float_col: 41.4285714286, str_col: null },
-	{ index: "mean", int_col: 24.75, float_col: 22.4714285714 },
-	{ index: "unique_count", int_col: 4, float_col: 0, str_col: 0 },
-	{ index: "empty_count", int_col: 0, float_col: 0, str_col: 0 },
-	{ index: "distinct_count", int_col: 49, float_col: 29, str_col: 1 },
-];
-
-const ex_df_data = [
-	{
-		index: 0,
-		int_col: 111111,
-		b: 111111,
-	},
-	{
-		index: 1,
-		int_col: 77777,
-		b: 555555,
-	},
-	{
-		index: 2,
-		int_col: 777777,
-		b: 0,
-	},
-	{
-		index: 3,
-		int_col: 1000000,
-		b: 28123,
-	},
-	{
-		index: 4,
-		int_col: 2111111,
-		b: 482388,
-	},
-	{
-		index: 5,
-		int_col: 1235999,
-		b: 5666,
-	},
-];
-
-const renderBaked = createRender(() => {
-	// used to test if the widget is properly rendering in an environment with baked data
-	console.log("renderBaked");
-	return (
-		<div className="buckaroo_anywidget">
-			<srt.DFViewer
-				df_data={realSummaryTableData}
-				df_viewer_config={realSummaryConfig}
-				summary_stats_data={[]}
-			/>
-		</div>
-	);
-});
-
 const renderDFV = createRender(() => {
 	console.log("renderDFV");
 	const [df_data, _set_df_meta] = useModelState("df_data");
@@ -146,7 +25,6 @@ const renderDFV = createRender(() => {
 });
 
 const renderBuckarooWidget = createRender(() => {
-	console.log("renderBuckarooWidget");
 	const [df_data_dict, _set_df_data_dict] = useModelState("df_data_dict");
 	const [df_display_args, _set_dda] = useModelState("df_display_args");
 	const [df_meta, _set_df_meta] = useModelState("df_meta");
@@ -178,8 +56,6 @@ const renderBuckarooWidget = createRender(() => {
 
 const srcClosureRBI = (src) => {
     const renderBuckarooInfiniteWidget = createRender((a,b,c) => {
-	console.log("178 renderBuckarooInfiniteWidget", src);
-	
 	const model = useModel()
 	const [df_data_dict, _set_df_data_dict] = useModelState("df_data_dict");
 	const [df_display_args, _set_dda] = useModelState("df_display_args");
@@ -191,7 +67,9 @@ const srcClosureRBI = (src) => {
 	const [buckaroo_state, on_buckaroo_state] = useModelState("buckaroo_state");
 	const [buckaroo_options, _set_boptions] = useModelState("buckaroo_options");
 	return (
+	    <div className="buckaroo_anywidget">
 	    <srt.BuckarooInfiniteWidget
+	    
 	    df_data_dict={df_data_dict}
 	    df_display_args={df_display_args}
 	    df_meta={df_meta}
@@ -204,17 +82,16 @@ const srcClosureRBI = (src) => {
 	    buckaroo_options={buckaroo_options}
 	    src={src}
 		/>
+		</div>
 	);
     });
     return renderBuckarooInfiniteWidget
 }
 
 export default async () => {
-    console.log("224, export default async");
     let extraState = {};
     return {
 	initialize({ model }) {
-	    console.log("initialize 262")
 	    // we only want to create KeyAwareSmartRowCache once, it caches sourceName too
 	    // so having it live between relaods is key
 	    //const [respError, setRespError] = useState<string | undefined>(undefined);
@@ -230,8 +107,6 @@ export default async () => {
 		renderBuckarooWidget({ el, model, experimental });
 	    } else if (render_func_name === "BuckarooInfiniteWidget") {
 		extraState['rbiFunc']({ el, model, experimental });
-	    } else {
-		renderBaked({ el, model, experimental });
 	    }
 	}
     }

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -261,6 +261,17 @@ edit box moves up and is only half visible */
 }
 
 
+/* unspecific rule that should only apply in a shaddow dom */
+.buckaroo_anywidget {
+  min-width:900px;
+}
+/* this should override the above rule.  for some reason in jupyter, the .buckaroo_anywidget div isn't injected */
+div div div .buckaroo_anywidget {
+  min-width:inherit;
+  /* border:5px solid brown; */
+}
+
+
 /* These are important to remove the blue outlines around the  */
 
 /*

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -249,15 +249,7 @@ div.dependent-tabs ul.tabs li.active {
 .ag-root-wrapper-body .ag-cell-inline-editing {
     /* this is trying to remove the weird styling thing that sometimes happens with the editted cell where the
 edit box moves up and is only half visible */
-    
     height: 100%;
-
-}
-
-.marimo .buckaroo_anwidget {
-    width:800px;
-    height:500px;
-    border:7px solid orange;
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "fastparquet"
 ]
 
-version = "0.9.11"
+version = "0.9.12"
 
 [project.license]
 file = "LICENSE.txt"


### PR DESCRIPTION
* Release 0.9.12
* Fixes a bug where when buckaroo was inserted into panel, the surrounding element had no widget.  now `min-width:900px` is set for all buckaroo widgets
* Removes a couple of print and console.logs