### PR TITLE
attempt at fixing the unstyled DFViewer that only shows up in marimo-…

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -36,25 +36,7 @@ ModuleRegistry.registerModules([InfiniteRowModelModule]);
 
 
 const AccentColor = "#2196F3"
-const myTheme = themeAlpine.withPart(colorSchemeDark).withParams({
-    spacing:5,
-    browserColorScheme: "dark",
-    cellHorizontalPaddingScale: 0.3,
-    columnBorder: true,
-    rowBorder: false,
-    rowVerticalPaddingScale: 0.5,
-    wrapperBorder: false,
-    fontSize: 12,
-    dataFontSize: "12px",
-    headerFontSize: 14,
-    iconSize: 10,
-    backgroundColor: "#181D1F",
 
-    oddRowBackgroundColor: '#222628',
-    headerVerticalPaddingScale: 0.6,
-//    cellHorizontalPadding: 3,
-
-})
 
 
 export interface DatasourceWrapper {
@@ -284,7 +266,25 @@ export function DFViewerInfiniteInner({
         },
         [outside_df_params],
     );
+    const myTheme = useMemo(() => themeAlpine.withPart(colorSchemeDark).withParams({
+        spacing: 5,
+        browserColorScheme: "dark",
+        cellHorizontalPaddingScale: 0.3,
+        columnBorder: true,
+        rowBorder: false,
+        rowVerticalPaddingScale: 0.5,
+        wrapperBorder: false,
+        fontSize: 12,
+        dataFontSize: "12px",
+        headerFontSize: 14,
+        iconSize: 10,
+        backgroundColor: "#181D1F",
 
+        oddRowBackgroundColor: '#222628',
+        headerVerticalPaddingScale: 0.6,
+        //    cellHorizontalPadding: 3,
+
+    }), []);
     const gridOptions: GridOptions = useMemo( () => {
         return {
         ...outerGridOptions(setActiveCol, df_viewer_config.extra_grid_config),

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -1,5 +1,5 @@
 // https://plnkr.co/edit/QTNwBb2VEn81lf4t?open=index.tsx
-import React, { useRef, useCallback, useState, memo, useEffect } from "react";
+import React, { useRef, useCallback, useState, memo, useEffect, useMemo } from "react";
 import _ from "lodash";
 import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
 import { ColDef, GridApi, GridOptions, ModuleRegistry } from "@ag-grid-community/core";
@@ -363,10 +363,10 @@ export function StatusBar({
         cellStyle: { textAlign: "left" },
     };
 
-    const statusTheme: Theme = myTheme.withParams({
+    const statusTheme: Theme = useMemo(()=> myTheme.withParams({
         headerFontSize: 14,
         rowVerticalPaddingScale: 0.8,    
-    })
+    }), []);
     return (
         <div className="status-bar">
             <div 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "fastparquet"
 ]
 
-version = "0.10.2"
+version = "0.10.3"
 
 
 [project.license]


### PR DESCRIPTION
…WASM for two or more buckaroo widgets.  I think it was because of how theme was defined as a global vs function local variable and the difference between status bar and dfviewer. it was defined inside the StatusBar function and at module level for DFViewerInfinite.  moving both to inside the function and wrapping in useMemo