### PR TITLE
Investigate UV cache optimization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
       - name: Install the project
         run: uv sync --locked --all-extras --dev
       - name: Run ruff
@@ -72,6 +73,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           python-version: ${{ matrix.python-version }}
 
       - name: setup js files
@@ -117,6 +119,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
+          prune-cache: false
           python-version: ${{ matrix.python-version }}
 
       - name: setup js files


### PR DESCRIPTION
## Goal
Investigate and optimize UV caching in CI to reduce package download times.

## Current State  
- UV cache with `enable-cache: true` is saving ~3 MB
- But packages are still being downloaded on every run (28 packages, ~152ms)
- Cache appears to only store metadata, not actual wheel files

## Changes in This PR
- Set `prune-cache: false` to prevent aggressive removal of cached wheels
- This will test if cache pruning is removing the actual package files

## Testing Plan
1. Run CI and check cache size after first run
2. Run CI again and verify if packages are reused from cache
3. Compare download counts between runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)