### PR TITLE
Fix blank rows when scrolling small DataFrames

### DIFF
--- a/packages/buckaroo-js-core/pw-tests/small-df-scroll.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/small-df-scroll.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '@playwright/test';
+import { Page } from '@playwright/test';
+
+const STORY_URL =
+  'http://localhost:6006/iframe.html?viewMode=story&id=buckaroo-dfviewer-smalldfscroll--primary&globals=&args=';
+
+/**
+ * Wait for AG-Grid to render its first data cells.
+ */
+async function waitForAgGrid(page: Page, timeout = 10000) {
+  await page.locator('.ag-root-wrapper').first().waitFor({ state: 'attached', timeout });
+  await page.locator('.ag-cell').first().waitFor({ state: 'visible', timeout });
+}
+
+/**
+ * Get the main scrollable viewport element info.
+ */
+async function getViewportInfo(page: Page) {
+  return page.evaluate(() => {
+    const vp = document.querySelector('.ag-body-viewport');
+    if (!vp) return null;
+    return {
+      scrollHeight: vp.scrollHeight,
+      clientHeight: vp.clientHeight,
+      scrollTop: vp.scrollTop,
+    };
+  });
+}
+
+/**
+ * Scroll the AG-Grid body viewport to a specific scrollTop.
+ */
+async function scrollTo(page: Page, scrollTop: number) {
+  await page.evaluate((target) => {
+    const vp = document.querySelector('.ag-body-viewport');
+    if (vp) vp.scrollTop = target;
+  }, scrollTop);
+}
+
+/**
+ * Collect visible row data. Returns info about each rendered row including
+ * whether it has real data or appears blank/undefined.
+ */
+async function getVisibleRowsInfo(page: Page) {
+  return page.evaluate(() => {
+    const rows = document.querySelectorAll('.ag-row:not(.ag-row-pinned)');
+    const infos: Array<{
+      rowIndex: number;
+      cellTexts: string[];
+      isBlank: boolean;
+    }> = [];
+
+    for (const row of rows) {
+      const rowIndex = parseInt(row.getAttribute('row-index') || '-1', 10);
+      if (rowIndex < 0) continue;
+
+      const cells = row.querySelectorAll('.ag-cell');
+      const cellTexts: string[] = [];
+      for (const cell of cells) {
+        cellTexts.push((cell.textContent || '').trim());
+      }
+
+      // A row is blank if all non-index cells are empty, 'None', 'null', or 'undefined'
+      const nonIndexTexts = cellTexts.slice(1); // skip first cell (index)
+      const isBlank = nonIndexTexts.length === 0 ||
+        nonIndexTexts.every(t => t === '' || t === 'None' || t === 'null' || t === 'undefined');
+
+      infos.push({ rowIndex, cellTexts, isBlank });
+    }
+    return infos.sort((a, b) => a.rowIndex - b.rowIndex);
+  });
+}
+
+test.describe('Small DataFrame scroll blank rows (Storybook)', () => {
+
+  test('no blank rows after scrolling to bottom of 200-row DataFrame', async ({ page }) => {
+    // Collect console errors for debugging
+    const consoleErrors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+    page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+    await page.goto(STORY_URL);
+    await waitForAgGrid(page);
+    // Let initial data settle
+    await page.waitForTimeout(1500);
+
+    // Verify initial rows have data
+    const initialRows = await getVisibleRowsInfo(page);
+    expect(initialRows.length).toBeGreaterThan(0);
+    const initialBlank = initialRows.filter(r => r.isBlank);
+    expect(initialBlank.length).toBe(0);
+
+    // Scroll to bottom
+    const vpInfo = await getViewportInfo(page);
+    expect(vpInfo).not.toBeNull();
+    await scrollTo(page, vpInfo!.scrollHeight);
+    await page.waitForTimeout(2000);
+
+    // Check for blank rows at bottom
+    const bottomRows = await getVisibleRowsInfo(page);
+    const bottomBlank = bottomRows.filter(r => r.isBlank);
+
+    if (bottomBlank.length > 0) {
+      console.log(`Found ${bottomBlank.length} blank rows at bottom:`);
+      for (const r of bottomBlank.slice(0, 5)) {
+        console.log(`  row ${r.rowIndex}: [${r.cellTexts.join(', ')}]`);
+      }
+    }
+    if (consoleErrors.length > 0) {
+      console.log('Console errors:', consoleErrors.slice(0, 5));
+    }
+
+    expect(bottomBlank.length).toBe(0);
+  });
+
+  test('no blank rows after scrolling to middle of 200-row DataFrame', async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(1500);
+
+    const vpInfo = await getViewportInfo(page);
+    expect(vpInfo).not.toBeNull();
+
+    // Scroll to middle
+    const mid = Math.floor(vpInfo!.scrollHeight / 2);
+    await scrollTo(page, mid);
+    await page.waitForTimeout(2000);
+
+    const midRows = await getVisibleRowsInfo(page);
+    const midBlank = midRows.filter(r => r.isBlank);
+
+    if (midBlank.length > 0) {
+      console.log(`Found ${midBlank.length} blank rows at middle:`);
+      for (const r of midBlank.slice(0, 5)) {
+        console.log(`  row ${r.rowIndex}: [${r.cellTexts.join(', ')}]`);
+      }
+    }
+
+    expect(midBlank.length).toBe(0);
+  });
+
+  test('no blank rows after rapid back-and-forth scrolling', async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(1500);
+
+    const vpInfo = await getViewportInfo(page);
+    expect(vpInfo).not.toBeNull();
+    const maxScroll = vpInfo!.scrollHeight;
+
+    // Rapid back-and-forth scrolling to stress the cache
+    const positions = [
+      maxScroll * 0.7,
+      maxScroll * 0.2,
+      maxScroll * 0.9,
+      maxScroll * 0.1,
+      maxScroll,
+      0,
+      maxScroll * 0.5,
+      maxScroll,
+    ];
+
+    for (const pos of positions) {
+      await scrollTo(page, Math.floor(pos));
+      await page.waitForTimeout(200);
+    }
+
+    // Let everything settle
+    await page.waitForTimeout(3000);
+
+    const finalRows = await getVisibleRowsInfo(page);
+    const finalBlank = finalRows.filter(r => r.isBlank);
+
+    if (finalBlank.length > 0) {
+      console.log(`Found ${finalBlank.length} blank rows after rapid scroll:`);
+      for (const r of finalBlank.slice(0, 5)) {
+        console.log(`  row ${r.rowIndex}: [${r.cellTexts.join(', ')}]`);
+      }
+    }
+
+    expect(finalBlank.length).toBe(0);
+  });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
@@ -643,6 +643,109 @@ describe('KeyAwareSmartRowCache tests', () => {
 	expect(sentLength2).toStrictEqual(800)
     })
 
+    test('KeyAwareSmartRowCache small DataFrame scroll does not return extra rows', () => {
+	// Regression test: 200-row DataFrame, AG-Grid requests [0,55] with overshoot end=1000.
+	// Before fix, getRows() returned [0,200] instead of [0,55], causing blank rows.
+	let src:KeyAwareSmartRowCache;
+	const mockRequestFn = jest.fn((pa:PayloadArgs) => {
+	    // Server returns all 200 rows for any request starting at 0
+	    const dataEnd = Math.min(pa.end, 200);
+	    const resp:PayloadResponse = {
+		key:pa,
+		data:genRows(pa.start, dataEnd, pa.sourceName)[1],
+		length:200
+	    }
+	    src.addPayloadResponse(resp)
+	})
+
+	src = new KeyAwareSmartRowCache(mockRequestFn);
+
+	// AG-Grid asks for [0,55] but getDs() sets end=1000
+	const pa1: PayloadArgs = {
+	    sourceName:"foo", start:0, end:1000, origEnd:55}
+
+	const mockCbFn = jest.fn((_df:DFData, _length:number) => {})
+	src.getRequestRows(pa1, mockCbFn, failNOP)
+
+	expect(mockCbFn.mock.calls).toHaveLength(1);
+	const [respData, sentLength] = mockCbFn.mock.calls[0];
+	// Must return exactly 55 rows (origEnd), NOT 200 (sentLength)
+	expect(respData.length).toStrictEqual(55);
+	expect(sentLength).toStrictEqual(200);
+    })
+
+    test('KeyAwareSmartRowCache small DataFrame mid-scroll does not return extra rows', () => {
+	// Regression: scrolling down in a 200-row DataFrame, AG-Grid requests [50,105]
+	// with overshoot end=1050. Should return exactly 55 rows, not up to sentLength.
+	let src:KeyAwareSmartRowCache;
+	const mockRequestFn = jest.fn((pa:PayloadArgs) => {
+	    const dataEnd = Math.min(pa.end, 200);
+	    if (dataEnd <= pa.start) return; // no data to send
+	    const resp:PayloadResponse = {
+		key:pa,
+		data:genRows(pa.start, dataEnd, pa.sourceName)[1],
+		length:200
+	    }
+	    src.addPayloadResponse(resp)
+	})
+
+	src = new KeyAwareSmartRowCache(mockRequestFn);
+
+	// First request primes cache with [0,200]
+	const pa0: PayloadArgs = {
+	    sourceName:"foo", start:0, end:1000, origEnd:55}
+	const mockCb0 = jest.fn((_df:DFData, _length:number) => {})
+	src.getRequestRows(pa0, mockCb0, failNOP)
+
+	// Now scroll down: AG-Grid asks [50,105], overshoot end=1050
+	const pa1: PayloadArgs = {
+	    sourceName:"foo", start:50, end:1050, origEnd:105}
+	const mockCbFn = jest.fn((_df:DFData, _length:number) => {})
+	src.getRequestRows(pa1, mockCbFn, failNOP)
+
+	expect(mockCbFn.mock.calls).toHaveLength(1);
+	const [respData, sentLength] = mockCbFn.mock.calls[0];
+	// Must return exactly 55 rows ([50,105]), NOT [50,200]
+	expect(respData.length).toStrictEqual(55);
+	expect(sentLength).toStrictEqual(200);
+    })
+
+    test('KeyAwareSmartRowCache small DataFrame scroll near end clamps to sentLength', () => {
+	// When scrolling near the end: AG-Grid asks [170,225] with overshoot end=1170,
+	// but only 200 rows exist. Should return [170,200] = 30 rows.
+	let src:KeyAwareSmartRowCache;
+	const mockRequestFn = jest.fn((pa:PayloadArgs) => {
+	    const dataEnd = Math.min(pa.end, 200);
+	    if (dataEnd <= pa.start) return;
+	    const resp:PayloadResponse = {
+		key:pa,
+		data:genRows(pa.start, dataEnd, pa.sourceName)[1],
+		length:200
+	    }
+	    src.addPayloadResponse(resp)
+	})
+
+	src = new KeyAwareSmartRowCache(mockRequestFn);
+
+	// Prime cache
+	const pa0: PayloadArgs = {
+	    sourceName:"foo", start:0, end:1000, origEnd:55}
+	const mockCb0 = jest.fn((_df:DFData, _length:number) => {})
+	src.getRequestRows(pa0, mockCb0, failNOP)
+
+	// Scroll near end: origEnd=225 exceeds sentLength=200
+	const pa1: PayloadArgs = {
+	    sourceName:"foo", start:170, end:1170, origEnd:225}
+	const mockCbFn = jest.fn((_df:DFData, _length:number) => {})
+	src.getRequestRows(pa1, mockCbFn, failNOP)
+
+	expect(mockCbFn.mock.calls).toHaveLength(1);
+	const [respData, sentLength] = mockCbFn.mock.calls[0];
+	// Clamped to sentLength: [170, min(225, 200)] = [170, 200] = 30 rows
+	expect(respData.length).toStrictEqual(30);
+	expect(sentLength).toStrictEqual(200);
+    })
+
         test('test trim functionality', () => {
 	//these tests aren't perfect, basically I'm trying to verify that trim got called at all.  But it depends heavily on internal settings inside of KeyAwareSmartRowCache and SmartRowCache, because it is checking for exact numbers of rows returned.
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
@@ -443,16 +443,16 @@ export class SmartRowCache {
         try {
             console.log("[SmartRowCache.getRows] range", range, "extents", this.safeGetExtents(), "segments", this.segments);
         } catch (_e) {}
+        if (this.sentLength > 0 && range[1] > this.sentLength) {
+            return this.getRows([range[0], this.sentLength]);
+        }
         if (this.hasRows(range) === true) {
             if(range[0] === 0 && range[1] === 0) {
                 console.log("unexpected setting lastRequest to [0,0] in getRows")
             }
             this.lastRequest = range;
             return getRange(this.segments, this.dfs, range)
-        } else if (range[0] === 0 && range[1] > this.sentLength && this.sentLength !== 0) {
-	    const fullSeg: Segment = [0, this.sentLength];
-	    return getRange(this.segments, this.dfs, fullSeg)
-	}
+        }
         console.error("[SmartRowCache.getRows] Missing rows error. range", range, "extents", this.safeGetExtents(), "segments", this.segments, "sentLength", this.sentLength);
         throw new Error(`Missing rows for {range}`)
     }
@@ -542,8 +542,8 @@ export class KeyAwareSmartRowCache {
 	this.srcAccesses.set(srcKey, src);
 
 	if (src.sentLength !== 0 &&  src.sentLength < pa.end) {
-	    const newSeg:Segment = [pa.start, src.sentLength];
-	    //console.log("at failing point", newSeg, src.getExtents())
+	    const clampedEnd = Math.min(pa.origEnd, src.sentLength);
+	    const newSeg:Segment = [pa.start, clampedEnd];
 	    return src.getRows(newSeg);
 	}
         return src.getRows(seg);
@@ -633,15 +633,13 @@ export class KeyAwareSmartRowCache {
         const cbKey = getPayloadKey(resp.key)
         //const preExtents = src.safeGetExtents()
 
-	if(resp.length < resp.key.end && resp.key.start === 0) {
-	    // add tests
-	    const entireSeg: Segment = [0, resp.length];
-            src.addRows(entireSeg, resp.data)
+        src.sentLength = resp.length;
+	if(resp.data.length < (seg[1] - seg[0])) {
+	    const actualSeg: Segment = [resp.key.start, resp.key.start + resp.data.length];
+            src.addRows(actualSeg, resp.data)
 	} else {
             src.addRows(seg, resp.data)
 	}
-        //console.log(`response before ${[resp.key.start, resp.key.origEnd, resp.key.end]} before add, preExtents ${preExtents}, post extents ${src.safeGetExtents()}`)
-        src.sentLength = resp.length;
         if (_.has(this.waitingCallbacks, cbKey)) {
             const [success, fail] = this.waitingCallbacks[cbKey];
             if(verifyResp(resp)) {

--- a/packages/buckaroo-js-core/src/stories/SmallDFScroll.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/SmallDFScroll.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useMemo } from "react";
+import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
+import { DFViewerConfig, NormalColumnConfig } from "../components/DFViewerParts/DFWhole";
+import { DatasourceWrapper } from "../components/DFViewerParts/DFViewerDataHelper";
+import { getDs } from "../components/DFViewerParts/gridUtils";
+import {
+  KeyAwareSmartRowCache,
+  PayloadArgs,
+  PayloadResponse,
+} from "../components/DFViewerParts/SmartRowCache";
+
+/**
+ * Generates deterministic test data: 200 rows with index, a (integer), b (string).
+ */
+const TOTAL_ROWS = 200;
+const allData = Array.from({ length: TOTAL_ROWS }, (_, i) => ({
+  index: i,
+  a: i * 10,
+  b: `row_${i}`,
+}));
+
+/**
+ * A component that wires up KeyAwareSmartRowCache + getDs(),
+ * exercising the real infinite scroll cache path with a small dataset.
+ * This reproduces the blank-rows-on-scroll bug.
+ */
+const SmallDFScrollComponent = () => {
+  const src = useMemo(() => {
+    const cache = new KeyAwareSmartRowCache((pa: PayloadArgs) => {
+      // Simulate server: slice from allData, cap at TOTAL_ROWS
+      const dataEnd = Math.min(pa.end, TOTAL_ROWS);
+      if (dataEnd <= pa.start) return;
+      const resp: PayloadResponse = {
+        key: pa,
+        data: allData.slice(pa.start, dataEnd),
+        length: TOTAL_ROWS,
+      };
+      // Async response like a real server
+      setTimeout(() => cache.addPayloadResponse(resp), 10);
+    });
+    return cache;
+  }, []);
+
+  const dataWrapper: DatasourceWrapper = useMemo(() => {
+    const ds = getDs(src);
+    return {
+      datasource: ds,
+      data_type: "DataSource" as const,
+      length: TOTAL_ROWS,
+    };
+  }, [src]);
+
+  return (
+    <div style={{ height: 500, width: 800 }}>
+      <DFViewerInfinite
+        data_wrapper={dataWrapper}
+        df_viewer_config={dfViewerConfig}
+        setActiveCol={() => {}}
+      />
+    </div>
+  );
+};
+
+const INDEX_COL_CONFIG: NormalColumnConfig = {
+  col_name: "index",
+  header_name: "index",
+  displayer_args: { displayer: "string" },
+};
+
+const dfViewerConfig: DFViewerConfig = {
+  column_config: [
+    {
+      col_name: "a",
+      header_name: "a",
+      displayer_args: { displayer: "integer", min_digits: 1, max_digits: 5 },
+    },
+    {
+      col_name: "b",
+      header_name: "b",
+      displayer_args: { displayer: "obj" },
+    },
+  ],
+  pinned_rows: [],
+  left_col_configs: [INDEX_COL_CONFIG],
+};
+
+const meta = {
+  title: "Buckaroo/DFViewer/SmallDFScroll",
+  component: SmallDFScrollComponent,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof SmallDFScrollComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};


### PR DESCRIPTION
## Summary
- **KeyAwareSmartRowCache.getRows()** was returning `[start, sentLength]` instead of `[start, min(origEnd, sentLength)]` when the dataset was smaller than the 1000-row overshoot, giving AG-Grid more rows than its block cache expected and causing blank/None rows on scroll
- Generalized `addPayloadResponse()` truncated response handling to all `start` values (was `start===0` only) and moved `sentLength` assignment before `addRows`
- Added early `sentLength` clamping in `SmartRowCache.getRows()` for requests near the end of the dataset

## Test plan
- [x] 67/67 jest unit tests pass (3 new regression tests added)
- [x] 3/3 Playwright/Storybook tests pass — verified to **fail against buggy code** and **pass with the fix**
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)