### PR TITLE
CI: prove diagnostics tests fail without handler

### DIFF
--- a/buckaroo/__init__.py
+++ b/buckaroo/__init__.py
@@ -6,16 +6,20 @@ from .buckaroo_widget import BuckarooWidget, BuckarooInfiniteWidget, Autocleanin
 from .dataflow.widget_extension_utils import DFViewer
 from .widget_utils import is_in_ipython, is_in_marimo, enable, disable, determine_jupter_env
 from .read_utils import read
-from .file_cache.cache_utils import (
-    get_global_file_cache,
-    get_global_executor_log,
-    ensure_executor_sqlite,
-    get_cache_size,
-    clear_file_cache,
-    clear_executor_log,
-    clear_oldest_cache_entries,
-    format_cache_size,
-)
+try:
+    from .file_cache.cache_utils import (
+        get_global_file_cache,
+        get_global_executor_log,
+        ensure_executor_sqlite,
+        get_cache_size,
+        clear_file_cache,
+        clear_executor_log,
+        clear_oldest_cache_entries,
+        format_cache_size,
+    )
+except ImportError:
+    # file_cache requires polars; make these available only when polars is installed
+    pass
 
 
 

--- a/buckaroo/buckaroo_widget.py
+++ b/buckaroo/buckaroo_widget.py
@@ -26,7 +26,7 @@ from .pluggable_analysis_framework.analysis_management import DfStats
 from .pluggable_analysis_framework.col_analysis import ColAnalysis
 from buckaroo.extension_utils import copy_extend
 
-from .serialization_utils import EMPTY_DF_WHOLE, check_and_fix_df, pd_to_obj, to_parquet
+from .serialization_utils import EMPTY_DF_WHOLE, check_and_fix_df, pd_to_obj, to_parquet, sd_to_parquet_b64
 from .dataflow.dataflow import CustomizableDataflow
 from .dataflow.dataflow_extras import (Sampling, exception_protect)
 from .dataflow.styling_core import (ComponentConfig, DFViewerConfig, DisplayArgs, OverrideColumnConfig, PinnedRowConfig, StylingAnalysis, merge_column_config, EMPTY_DFVIEWER_CONFIG)
@@ -238,9 +238,11 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
         self.buckaroo_state = temp_buckaroo_state
 
     def _sd_to_jsondf(self, sd):
-        """exists so this can be overriden for polars  """
-        temp_sd = sd.copy()
-        return self._df_to_obj(pd.DataFrame(temp_sd))
+        """Serialize summary stats dict. Returns parquet-b64 tagged dict by default.
+
+        Exists so this can be overridden for polars/geopandas.
+        """
+        return sd_to_parquet_b64(sd)
 
 
 
@@ -266,7 +268,9 @@ class RawDFViewerWidget(BuckarooWidgetBase):
         'first_col_configs':[]}).tag(sync=True)
 
 
-    summary_stats_data = List([
+    # Can be DFData (list of row dicts) for JSON, or
+    # {'format': 'parquet_b64', 'data': '<base64>'} for parquet
+    summary_stats_data = Any([
         { 'index': 'mean',  'a':      28,   'b':      14, 'c': 'Padarget' },
         { 'index': 'dtype', 'a': 'float64', 'b': 'int64', 'c': 'object' }]).tag(sync=True)
 

--- a/buckaroo/dataflow/column_executor_dataflow.py
+++ b/buckaroo/dataflow/column_executor_dataflow.py
@@ -9,7 +9,6 @@ import logging
 import threading
 
 import polars as pl
-import pandas as pd
 from traitlets import Dict as TDict, Any as TAny, Unicode, observe
 
 from .styling_core import merge_sds
@@ -20,7 +19,7 @@ from buckaroo.file_cache.base import FileCache, ProgressNotification, ProgressLi
 from buckaroo.file_cache.multiprocessing_executor import MultiprocessingExecutor
 from buckaroo.file_cache.paf_column_executor import PAFColumnExecutor
 from .abc_dataflow import ABCDataflow
-from buckaroo.serialization_utils import pd_to_obj, sd_to_parquet_b64
+from buckaroo.serialization_utils import sd_to_parquet_b64
 
 logger = logging.getLogger("buckaroo.dataflow")
 

--- a/buckaroo/dataflow/column_executor_dataflow.py
+++ b/buckaroo/dataflow/column_executor_dataflow.py
@@ -20,7 +20,7 @@ from buckaroo.file_cache.base import FileCache, ProgressNotification, ProgressLi
 from buckaroo.file_cache.multiprocessing_executor import MultiprocessingExecutor
 from buckaroo.file_cache.paf_column_executor import PAFColumnExecutor
 from .abc_dataflow import ABCDataflow
-from buckaroo.serialization_utils import pd_to_obj
+from buckaroo.serialization_utils import pd_to_obj, sd_to_parquet_b64
 
 logger = logging.getLogger("buckaroo.dataflow")
 
@@ -273,8 +273,7 @@ class ColumnExecutorDataflow(ABCDataflow):
                     current_summary = self.summary_sd.copy() if self.summary_sd else {}
                     current_summary.update(aggregated_summary)
                     self.summary_sd = current_summary
-                    rows = pd_to_obj(pd.DataFrame(current_summary))
-                    self.df_data_dict = {'main': [], 'all_stats': rows, 'empty': []}
+                    self.df_data_dict = {'main': [], 'all_stats': sd_to_parquet_b64(current_summary), 'empty': []}
                     # Update merged_sd as stats come in (important for async executors)
                     # Merge with existing to preserve any cached columns
                     current_merged = self.merged_sd.copy() if self.merged_sd else {}

--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -6,7 +6,7 @@ import pandas as pd
 from traitlets import Unicode, Any, observe, Dict
 
 from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis, SDType
-from ..serialization_utils import pd_to_obj    
+from ..serialization_utils import pd_to_obj, sd_to_parquet_b64
 from buckaroo.pluggable_analysis_framework.utils import (filter_analysis)
 from buckaroo.pluggable_analysis_framework.analysis_management import DfStats
 from .autocleaning import SentinelAutocleaning
@@ -416,9 +416,11 @@ class CustomizableDataflow(DataFlow):
     # ### end summary stats block        
 
     def _sd_to_jsondf(self, sd:SDType):
-        """exists so this can be overriden for polars  """
-        temp_sd = sd.copy()
-        return self._df_to_obj(pd.DataFrame(temp_sd))
+        """Serialize summary stats dict. Returns parquet-b64 tagged dict by default.
+
+        Exists so this can be overridden for polars/geopandas.
+        """
+        return sd_to_parquet_b64(sd)
 
     def _df_to_obj(self, df:pd.DataFrame) -> TDict[str, TAny]:
         return pd_to_obj(self.sampling_klass.serialize_sample(df))

--- a/buckaroo/geopandas_buckaroo.py
+++ b/buckaroo/geopandas_buckaroo.py
@@ -4,7 +4,7 @@ import buckaroo
 from buckaroo.customizations.styling import DefaultMainStyling, StylingAnalysis
 from buckaroo.pluggable_analysis_framework.pluggable_analysis_framework import ColAnalysis
 from .dataflow.dataflow_extras import (Sampling)
-from buckaroo.serialization_utils import pd_to_obj
+from buckaroo.serialization_utils import pd_to_obj, sd_to_parquet_b64
 from buckaroo.customizations.analysis import (TypingStats)
 import geopandas
 
@@ -61,16 +61,11 @@ class GeopandasBase(buckaroo.BuckarooWidget):
         return pd_to_obj(self.sampling_klass.serialize_sample(pd_df))
 
     def _sd_to_jsondf(self, sd):
-        """exists so this can be overriden for polars  """
+        """Serialize summary stats dict as parquet-b64."""
         temp_sd = sd.copy()
-        #FIXME add actual test around weird index behavior
         if 'index' in temp_sd:
             del temp_sd['index']
-        # we need this to go through the regular pandas path, not our
-        # special serialization the special serialization gives
-        # numeric indexes, when summary stats needs string indexes of
-        # the stats name
-        return pd_to_obj(pd.DataFrame(temp_sd))
+        return sd_to_parquet_b64(temp_sd)
 
 class GeopandasBuckarooWidget(GeopandasBase):
     pass

--- a/buckaroo/lazy_infinite_polars_widget.py
+++ b/buckaroo/lazy_infinite_polars_widget.py
@@ -16,7 +16,6 @@ import sys
 import anywidget
 import polars as pl
 from polars import functions as F
-import pandas as pd
 import logging
 from traitlets import Dict as TDict, Unicode
 
@@ -26,7 +25,7 @@ from buckaroo.pluggable_analysis_framework.utils import json_postfix
 from buckaroo.styling_helpers import obj_, pinned_histogram
 from .pluggable_analysis_framework.polars_analysis_management import PolarsAnalysis
 from .df_util import old_col_new_col
-from .serialization_utils import pd_to_obj, sd_to_parquet_b64
+from .serialization_utils import sd_to_parquet_b64
 from buckaroo.file_cache.base import AbstractFileCache, Executor as _SyncExec, ExecutorLog  # type: ignore
 from buckaroo.file_cache.multiprocessing_executor import MultiprocessingExecutor as _ParExec
 from buckaroo.file_cache.cache_utils import get_global_file_cache, get_global_executor_log

--- a/buckaroo/lazy_infinite_polars_widget.py
+++ b/buckaroo/lazy_infinite_polars_widget.py
@@ -26,7 +26,7 @@ from buckaroo.pluggable_analysis_framework.utils import json_postfix
 from buckaroo.styling_helpers import obj_, pinned_histogram
 from .pluggable_analysis_framework.polars_analysis_management import PolarsAnalysis
 from .df_util import old_col_new_col
-from .serialization_utils import pd_to_obj
+from .serialization_utils import pd_to_obj, sd_to_parquet_b64
 from buckaroo.file_cache.base import AbstractFileCache, Executor as _SyncExec, ExecutorLog  # type: ignore
 from buckaroo.file_cache.multiprocessing_executor import MultiprocessingExecutor as _ParExec
 from buckaroo.file_cache.cache_utils import get_global_file_cache, get_global_executor_log
@@ -480,18 +480,18 @@ class LazyInfinitePolarsBuckarooWidget(anywidget.AnyWidget):
         self,
         all_cols: List[str],
         summary_sd: Dict[str, Dict[str, Any]],
-        summary_rows: List[Dict[str, Any]]
+        summary_rows: Any
     ) -> None:
         """
         Ensure that df_display_args and df_data_dict are set up for the widget.
-        
+
         Builds the column configuration (from summary or schema fallback), creates the
         df_viewer_config with pinned rows, and sets both df_data_dict and df_display_args.
-        
+
         Args:
             all_cols: List of all column names in the LazyFrame
             summary_sd: Summary dictionary with column statistics
-            summary_rows: List of summary rows for display
+            summary_rows: Serialized summary stats (parquet_b64 payload or JSON list)
         """
         # Build initial column_config: fall back to schema so raw data appears immediately.
         def _schema_column_config() -> list[dict[str, object]]:
@@ -715,14 +715,21 @@ class LazyInfinitePolarsBuckarooWidget(anywidget.AnyWidget):
         # Ensure summary is ready for initial display (checks if computation completed synchronously)
         summary_sd = self.ensure_initial_summary_for_display(initial_summary_sd)
         summary_rows = self._summary_to_rows(summary_sd)
-        logger.info(
-            "Initial all_stats prepared: len=%s sample=%s",
-            len(summary_rows),
-            (summary_rows[0] if summary_rows else None),
+        if isinstance(summary_rows, dict) and summary_rows.get('format') == 'parquet_b64':
+            logger.info("Initial all_stats prepared as parquet_b64, b64_len=%s", len(summary_rows.get('data', '')))
+        else:
+            logger.info(
+                "Initial all_stats prepared: len=%s sample=%s",
+                len(summary_rows),
+                (summary_rows[0] if summary_rows else None),
+            )
+        # Check if __status__ is in the summary stats (check summary_sd dict directly)
+        has_status = any(
+            '__status__' in col_stats
+            for col_stats in summary_sd.values()
+            if isinstance(col_stats, dict)
         )
-        # Check if __status__ is in the summary rows
-        status_row = next((row for row in summary_rows if row.get('index') == '__status__'), None)
-        logger.info(f"LazyInfinitePolarsBuckarooWidget.__init__: __status__ row present: {status_row is not None}, show_message_box trait: {self.show_message_box}, message_log messages count: {len(self.message_log.get('messages', []))}")
+        logger.info(f"LazyInfinitePolarsBuckarooWidget.__init__: __status__ present: {has_status}, show_message_box trait: {self.show_message_box}, message_log messages count: {len(self.message_log.get('messages', []))}")
 
         # Ensure df_display_args and df_data_dict are set up
         self.ensure_df_display_args(all_cols, summary_sd, summary_rows)
@@ -751,12 +758,11 @@ class LazyInfinitePolarsBuckarooWidget(anywidget.AnyWidget):
 
     # no schema-only column config helper needed for sync path
 
-    def _summary_to_rows(self, summary: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _summary_to_rows(self, summary: Dict[str, Dict[str, Any]]):
+        """Convert summary dict to parquet-b64 tagged payload (or JSON fallback)."""
         if not summary:
             return []
-        df = pd.DataFrame(summary)
-        rows = pd_to_obj(df)
-        return rows
+        return sd_to_parquet_b64(summary)
 
     # selection and retry now delegated to dataflow
     def _build_column_config(self, summary: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/buckaroo/polars_buckaroo.py
+++ b/buckaroo/polars_buckaroo.py
@@ -9,7 +9,7 @@ from buckaroo.df_util import old_col_new_col
 from .customizations.polars_analysis import PL_Analysis_Klasses
 from .pluggable_analysis_framework.polars_analysis_management import (
     PlDfStats)
-from .serialization_utils import pd_to_obj
+from .serialization_utils import pd_to_obj, sd_to_parquet_b64
 from .customizations.styling import DefaultSummaryStatsStyling, DefaultMainStyling
 from .customizations.pl_autocleaning_conf import NoCleaningConfPl
 from .dataflow.dataflow import Sampling
@@ -57,14 +57,8 @@ class PolarsBuckarooWidget(BuckarooWidget):
     sampling_klass = PLSampling
 
     def _sd_to_jsondf(self, sd):
-        """exists so this can be overriden for polars  """
-        import pandas as pd
-        temp_sd = sd.copy()
-
-        #FIXME add actual test around weird index behavior
-        # if 'index' in temp_sd:
-        #     del temp_sd['index']
-        return pd_to_obj(pd.DataFrame(temp_sd))
+        """Serialize summary stats dict as parquet-b64."""
+        return sd_to_parquet_b64(sd)
 
     def _build_error_dataframe(self, e):
         return pl.DataFrame({'err': [str(e)]})

--- a/buckaroo/serialization_utils.py
+++ b/buckaroo/serialization_utils.py
@@ -2,7 +2,7 @@ from io import BytesIO
 import base64
 import json
 import pandas as pd
-from typing import Dict, Any, List, Tuple, Union
+from typing import Dict, Any, List, Tuple
 from pandas._libs.tslibs import timezones
 from pandas.core.dtypes.dtypes import DatetimeTZDtype
 from fastparquet import json as fp_json

--- a/packages/buckaroo-js-core/playwright.config.server.ts
+++ b/packages/buckaroo-js-core/playwright.config.server.ts
@@ -2,6 +2,10 @@ import { defineConfig, devices } from '@playwright/test';
 
 const PORT = 8701;
 
+// Allow overriding the Python used to start the server.
+// In CI this points at a clean venv that only has buckaroo[mcp] installed.
+const PYTHON = process.env.BUCKAROO_SERVER_PYTHON ?? 'uv run python';
+
 export default defineConfig({
   testDir: './pw-tests',
   testMatch: ['server.spec.ts'],
@@ -25,7 +29,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: `uv run python -m buckaroo.server --no-browser --port ${PORT}`,
+    command: `${PYTHON} -m buckaroo.server --no-browser --port ${PORT}`,
     cwd: '../..',
     url: `http://localhost:${PORT}/health`,
     reuseExistingServer: !process.env.CI,

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -3,7 +3,8 @@ import _ from "lodash";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
 
-import { DFData } from "./DFViewerParts/DFWhole";
+import { DFData, DFDataOrPayload } from "./DFViewerParts/DFWhole";
+import { resolveDFData } from "./DFViewerParts/resolveDFData";
 import { StatusBar } from "./StatusBar";
 import { BuckarooState } from "./WidgetTypes";
 import { BuckarooOptions } from "./WidgetTypes";
@@ -22,7 +23,7 @@ import { MessageBox } from "./MessageBox";
 
 export const getDataWrapper = (
     data_key: string,
-    df_data_dict: Record<string, DFData>,
+    df_data_dict: Record<string, DFDataOrPayload>,
     ds: IDatasource,
     total_rows?: number
 ): DatasourceOrRaw => {
@@ -33,10 +34,11 @@ export const getDataWrapper = (
             length: total_rows || 50,
         };
     } else {
+        const resolved = resolveDFData(df_data_dict[data_key]);
         return {
             data_type: "Raw",
-            data: df_data_dict[data_key],
-            length: df_data_dict[data_key].length,
+            data: resolved,
+            length: resolved.length,
         };
     }
 };
@@ -121,7 +123,7 @@ export function BuckarooInfiniteWidget({
         src
     }: {
         df_meta: DFMeta;
-        df_data_dict: Record<string, DFData>;
+        df_data_dict: Record<string, DFDataOrPayload>;
         df_display_args: Record<string, IDisplayArgs>;
         operations: Operation[];
         on_operations: (ops: Operation[]) => void;
@@ -158,7 +160,7 @@ export function BuckarooInfiniteWidget({
         const [data_wrapper, summaryStatsData] = useMemo(
             () => [
                 getDataWrapper(cDisp.data_key, df_data_dict, mainDs, df_meta.total_rows),
-                df_data_dict[cDisp.summary_stats_key],
+                resolveDFData(df_data_dict[cDisp.summary_stats_key]),
             ],
             [cDisp, operations, buckaroo_state],
         );
@@ -218,10 +220,10 @@ export function DFViewerInfiniteDS({
         show_message_box
     }: {
         df_meta: DFMeta;
-        df_data_dict: Record<string, DFData>;
+        df_data_dict: Record<string, DFDataOrPayload>;
         df_display_args: Record<string, IDisplayArgs>;
         src: KeyAwareSmartRowCache,
-        df_id: string // the memory id 
+        df_id: string // the memory id
         message_log?: { messages?: Array<any> };
         show_message_box?: { enabled?: boolean };
     }) {
@@ -249,7 +251,7 @@ export function DFViewerInfiniteDS({
         const [data_wrapper, summaryStatsData] = useMemo(
             () => [
                 getDataWrapper(cDisp.data_key, df_data_dict, mainDs, df_meta.total_rows),
-                df_data_dict[cDisp.summary_stats_key],
+                resolveDFData(df_data_dict[cDisp.summary_stats_key]),
             ],
             [cDisp, df_data_dict, mainDs, df_meta.total_rows]
         );

--- a/packages/buckaroo-js-core/src/components/DCFCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DCFCell.tsx
@@ -3,7 +3,8 @@ import _ from "lodash";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
 
-import { DFData } from "./DFViewerParts/DFWhole";
+import { DFDataOrPayload } from "./DFViewerParts/DFWhole";
+import { resolveDFData } from "./DFViewerParts/resolveDFData";
 import { DFViewer } from "./DFViewerParts/DFViewerInfinite";
 import { StatusBar } from "./StatusBar";
 import { BuckarooState } from "./WidgetTypes";
@@ -26,7 +27,7 @@ export function WidgetDCFCell({
     buckaroo_options,
 }: {
     df_meta: DFMeta;
-    df_data_dict: Record<string, DFData>;
+    df_data_dict: Record<string, DFDataOrPayload>;
     df_display_args: Record<string, IDisplayArgs>;
     operations: Operation[];
     on_operations: (ops: Operation[]) => void;
@@ -44,8 +45,8 @@ export function WidgetDCFCell({
     } else {
         //  console.log("cDisp", cDisp);
     }
-    const dfData = df_data_dict[cDisp.data_key];
-    const summaryStatsData = df_data_dict[cDisp.summary_stats_key];
+    const dfData = resolveDFData(df_data_dict[cDisp.data_key]);
+    const summaryStatsData = resolveDFData(df_data_dict[cDisp.summary_stats_key]);
 
     return (
         <div className="dcf-root flex flex-col buckaroo-widget" style={{ width: "100%", height: "100%" }}>

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -190,6 +190,15 @@ export type DFDataRow = Record<
 
 export type DFData = DFDataRow[];
 
+// Tagged union for multi-format data transfer (JSON or parquet-b64)
+export interface ParquetB64Payload {
+    format: 'parquet_b64';
+    data: string;  // base64-encoded parquet bytes
+}
+
+// A value in df_data_dict can be plain JSON (DFData) or a tagged parquet payload
+export type DFDataOrPayload = DFData | ParquetB64Payload;
+
 /*
 When I want to start tagging metadata onto DFData
 export interface DFData {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/resolveDFData.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/resolveDFData.ts
@@ -1,0 +1,114 @@
+import { parquetRead, parquetMetadata } from 'hyparquet';
+import { DFData, DFDataRow, DFDataOrPayload, ParquetB64Payload } from './DFWhole';
+
+/**
+ * Type guard: returns true if the value is a parquet-b64 tagged payload.
+ */
+function isParquetB64(val: unknown): val is ParquetB64Payload {
+    return (
+        val !== null &&
+        typeof val === 'object' &&
+        !Array.isArray(val) &&
+        (val as any).format === 'parquet_b64' &&
+        typeof (val as any).data === 'string'
+    );
+}
+
+// Simple LRU-ish cache keyed by the b64 string (reference equality would miss
+// when the trait is re-serialised with the same content).
+const _cache = new Map<string, DFData>();
+const MAX_CACHE = 8;
+
+function cacheSet(key: string, value: DFData) {
+    if (_cache.size >= MAX_CACHE) {
+        // evict oldest
+        const first = _cache.keys().next().value;
+        if (first !== undefined) _cache.delete(first);
+    }
+    _cache.set(key, value);
+}
+
+/**
+ * Decode a base64 string to an ArrayBuffer.
+ */
+function b64ToArrayBuffer(b64: string): ArrayBuffer {
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) {
+        bytes[i] = bin.charCodeAt(i);
+    }
+    return bytes.buffer;
+}
+
+/**
+ * JSON-parse each cell value in a row from parquet-decoded data.
+ *
+ * The Python side JSON-encodes every cell before writing to parquet
+ * (because summary stats have mixed types per column). We need to
+ * JSON.parse each value back to its original type.
+ *
+ * The 'index' column is left as a plain string (stat name like 'mean', 'dtype').
+ */
+function parseParquetRow(row: Record<string, any>): DFDataRow {
+    const parsed: DFDataRow = {};
+    for (const [key, val] of Object.entries(row)) {
+        if (key === 'index' || key === 'level_0') {
+            // index/level_0 columns are stat names — keep as-is
+            parsed[key] = val;
+        } else if (typeof val === 'string') {
+            try {
+                parsed[key] = JSON.parse(val);
+            } catch {
+                parsed[key] = val;
+            }
+        } else {
+            parsed[key] = val;
+        }
+    }
+    return parsed;
+}
+
+/**
+ * Synchronously resolve a DFDataOrPayload to DFData.
+ *
+ * - If the input is already a plain DFData array, return it as-is.
+ * - If it is a parquet-b64 payload, decode and parse the parquet into DFData.
+ * - Falls back to an empty array on errors.
+ *
+ * hyparquet's parquetRead with onComplete fires synchronously when given an
+ * in-memory ArrayBuffer, so this function is synchronous.
+ */
+export function resolveDFData(val: DFDataOrPayload | undefined | null): DFData {
+    if (val === undefined || val === null) return [];
+    if (Array.isArray(val)) return val as DFData;
+
+    if (isParquetB64(val)) {
+        // Check cache
+        const cached = _cache.get(val.data);
+        if (cached) return cached;
+
+        try {
+            const buf = b64ToArrayBuffer(val.data);
+            const metadata = parquetMetadata(buf);
+            let result: DFData = [];
+            parquetRead({
+                file: buf,
+                metadata,
+                rowFormat: 'object',
+                onComplete: (data: any[]) => {
+                    // JSON-parse each cell to recover typed values
+                    result = (data as DFDataRow[]).map(parseParquetRow);
+                },
+            });
+            cacheSet(val.data, result);
+            return result;
+        } catch (e) {
+            console.error('resolveDFData: failed to decode parquet_b64', e);
+            return [];
+        }
+    }
+
+    // Unknown format — treat as empty
+    console.warn('resolveDFData: unknown payload format', val);
+    return [];
+}

--- a/packages/buckaroo-js-core/src/index.ts
+++ b/packages/buckaroo-js-core/src/index.ts
@@ -13,6 +13,7 @@ import { WidgetDCFCell } from "./components/DCFCell";
 import { BuckarooInfiniteWidget, DFViewerInfiniteDS, getKeySmartRowCache } from "./components/BuckarooWidgetInfinite";
 // Re-export hyparquet functions for transcript parsing in widget.tsx
 import { parquetRead, parquetMetadata } from 'hyparquet';
+import { resolveDFData } from './components/DFViewerParts/resolveDFData';
 
 import { HistogramCell } from "./components/DFViewerParts/HistogramCell";
 import { InfiniteEx } from "./components/DFViewerParts/TableInfinite";
@@ -49,6 +50,7 @@ export default {
     // Parquet parsing for transcript replay
     parquetRead,
     parquetMetadata,
+    resolveDFData,
 };
 
 

--- a/packages/js/widget.tsx
+++ b/packages/js/widget.tsx
@@ -238,7 +238,8 @@ const renderDFV = createRender(() => {
 	console.log("renderDFV");
 	const [df_data, _set_df_meta] = useModelState("df_data");
 	const [df_viewer_config, _set_dfvc] = useModelState("df_viewer_config");
-	const [summary_stats_data, _set_ssd] = useModelState("summary_stats_data");
+	const [summary_stats_raw, _set_ssd] = useModelState("summary_stats_data");
+	const summary_stats_data = srt.resolveDFData(summary_stats_raw);
 	console.log("df_data", df_data);
 	console.log("df_viewer_config", df_viewer_config);
 	console.log("summary_stats_data", summary_stats_data);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ test = [
     "codecov"
 ]
 
-mcp = ["mcp"]
+mcp = ["mcp", "tornado>=6.0"]
 jupyterlab = ["jupyterlab>=3.6.0"]
 notebook = ["notebook>=7.0.0"]
 packaging_tools = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "numpy >= 2.2.5; python_version >= '3.13'",
 ]
 
-version = "0.12.6"
+version = "0.12.7"
 
 
 [project.license]
@@ -116,7 +116,7 @@ Homepage = "https://github.com/paddymul/buckaroo"
 
 [tool.hatch.build]
 only-packages = true
-artifacts = ["buckaroo/static/widget.js", "buckaroo/static/compiled.css", "scripts/hatch_build.py"]
+artifacts = ["buckaroo/static/widget.js", "buckaroo/static/compiled.css", "buckaroo/static/standalone.js", "buckaroo/static/standalone.css","scripts/hatch_build.py"]
 
 [tool.hatch.build.force-include]
 "buckaroo_mcp_tool.py" = "buckaroo_mcp_tool.py"

--- a/scripts/test_playwright_server.sh
+++ b/scripts/test_playwright_server.sh
@@ -4,6 +4,8 @@
 # Verifies that `buckaroo[mcp]` contains everything needed to run
 # the standalone data server — no dev extras, no polars, no full env.
 #
+# Expects a pre-built wheel in dist/. Run full_build.sh first.
+#
 # Usage:
 #   bash scripts/test_playwright_server.sh
 set -e
@@ -31,13 +33,12 @@ error() {
 
 echo "Starting Buckaroo Server Playwright Tests"
 
-# ---------- 1. Build the wheel (skip if dist/ already has one) ----------------
+# ---------- 1. Find the pre-built wheel --------------------------------------
 
 WHEEL=$(ls "$ROOT_DIR"/dist/buckaroo-*.whl 2>/dev/null | head -1)
 if [ -z "$WHEEL" ]; then
-    log_message "Building wheel..."
-    uv build --wheel -q
-    WHEEL=$(ls "$ROOT_DIR"/dist/buckaroo-*.whl | head -1)
+    error "No wheel found in dist/. Run full_build.sh first."
+    exit 1
 fi
 log_message "Using wheel: $WHEEL"
 
@@ -46,7 +47,7 @@ log_message "Using wheel: $WHEEL"
 MCP_VENV="$ROOT_DIR/.venv-mcp-test"
 log_message "Creating clean venv at $MCP_VENV ..."
 rm -rf "$MCP_VENV"
-uv venv "$MCP_VENV" --python 3.12 -q
+uv venv "$MCP_VENV" -q
 uv pip install --python "$MCP_VENV/bin/python" "${WHEEL}[mcp]" -q
 
 # Sanity-check: server module must be importable

--- a/scripts/test_playwright_server.sh
+++ b/scripts/test_playwright_server.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
 # Playwright tests against the Buckaroo standalone server
+#
+# Verifies that `buckaroo[mcp]` contains everything needed to run
+# the standalone data server — no dev extras, no polars, no full env.
+#
 # Usage:
 #   bash scripts/test_playwright_server.sh
 set -e
 
 cd "$(dirname "$0")/.."
+ROOT_DIR="$(pwd)"
 
 # Colors for output
 RED='\033[0;31m'
@@ -17,18 +22,45 @@ log_message() {
 }
 
 success() {
-    echo -e "${GREEN}✅ $1${NC}"
+    echo -e "${GREEN}$1${NC}"
 }
 
 error() {
-    echo -e "${RED}❌ $1${NC}"
+    echo -e "${RED}$1${NC}"
 }
 
-echo "🧪 Starting Buckaroo Server Playwright Tests"
+echo "Starting Buckaroo Server Playwright Tests"
+
+# ---------- 1. Build the wheel (skip if dist/ already has one) ----------------
+
+WHEEL=$(ls "$ROOT_DIR"/dist/buckaroo-*.whl 2>/dev/null | head -1)
+if [ -z "$WHEEL" ]; then
+    log_message "Building wheel..."
+    uv build --wheel -q
+    WHEEL=$(ls "$ROOT_DIR"/dist/buckaroo-*.whl | head -1)
+fi
+log_message "Using wheel: $WHEEL"
+
+# ---------- 2. Create a clean venv with only buckaroo[mcp] -------------------
+
+MCP_VENV="$ROOT_DIR/.venv-mcp-test"
+log_message "Creating clean venv at $MCP_VENV ..."
+rm -rf "$MCP_VENV"
+uv venv "$MCP_VENV" --python 3.12 -q
+uv pip install --python "$MCP_VENV/bin/python" "${WHEEL}[mcp]" -q
+
+# Sanity-check: server module must be importable
+"$MCP_VENV/bin/python" -c "from buckaroo.server.app import make_app" 2>&1 \
+    || { error "buckaroo.server failed to import from clean [mcp] venv"; exit 1; }
+success "Clean [mcp] venv ready"
+
+# Export so playwright.config.server.ts picks it up
+export BUCKAROO_SERVER_PYTHON="$MCP_VENV/bin/python"
+
+# ---------- 3. Install npm / playwright deps ---------------------------------
 
 cd packages/buckaroo-js-core
 
-# Install npm dependencies
 log_message "Installing npm dependencies..."
 if command -v pnpm &> /dev/null; then
     pnpm install
@@ -36,7 +68,6 @@ else
     npm install
 fi
 
-# Install Playwright browsers if needed
 log_message "Ensuring Playwright browsers are installed..."
 if command -v pnpm &> /dev/null; then
     pnpm exec playwright install chromium
@@ -46,14 +77,19 @@ fi
 
 success "Dependencies ready"
 
-# Run the server tests (playwright config handles starting/stopping the server)
-log_message "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+# ---------- 4. Run the server playwright tests --------------------------------
+
 log_message "Running Playwright tests against Buckaroo server..."
-log_message "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 if pnpm test:server; then
-    success "🎉 ALL SERVER PLAYWRIGHT TESTS PASSED!"
+    success "ALL SERVER PLAYWRIGHT TESTS PASSED!"
+    EXIT_CODE=0
 else
-    error "💥 SERVER TESTS FAILED"
-    exit 1
+    error "SERVER TESTS FAILED"
+    EXIT_CODE=1
 fi
+
+# ---------- 5. Cleanup -------------------------------------------------------
+rm -rf "$MCP_VENV"
+
+exit $EXIT_CODE

--- a/tests/unit/lazy_infinite_polars_widget_test_cursor.py
+++ b/tests/unit/lazy_infinite_polars_widget_test_cursor.py
@@ -139,14 +139,14 @@ def test_lazy_widget_multiprocessing_executor_populates_stats():
 
     # If we waited long enough and async computation completed, we should have real stats
     if len(widget._df.merged_sd) > 0:
-        data_rows = [row for row in all_stats if row.get('index') not in ['orig_col_name', 'rewritten_col_name']]
-        if data_rows:
-            first_data_row = data_rows[0]
-            print(f"First data row: {first_data_row}")
-            # Should have some non-zero stats
+        # Find the 'length' stat row specifically
+        length_row = next((row for row in all_stats if row.get('index') == 'length'), None)
+        if length_row:
+            print(f"Length row: {length_row}")
+            # Should have non-zero length for at least one column
             has_stats = any(
-                first_data_row.get(k, 0) != 0 
-                for k in ['unique_count', 'null_count', 'length'] 
-                if k in first_data_row
+                length_row.get(k, 0) > 0
+                for k in ['a', 'b', 'c']
+                if k in length_row
             )
-            assert has_stats, f"First data row has no stats: {first_data_row}"
+            assert has_stats, f"Length row has no stats: {length_row}"

--- a/tests/unit/lazy_infinite_polars_widget_test_cursor.py
+++ b/tests/unit/lazy_infinite_polars_widget_test_cursor.py
@@ -3,9 +3,40 @@ Tests to diagnose why summary stats aren't being populated in LazyInfinitePolars
 """
 # state:READONLY
 
+import base64
+import json
+from io import BytesIO
+
+import pandas as pd
 import polars as pl
 from buckaroo.lazy_infinite_polars_widget import LazyInfinitePolarsBuckarooWidget
 from buckaroo.file_cache.base import Executor as SyncExecutor
+
+
+def _resolve_all_stats(all_stats):
+    """Resolve all_stats to a list of row dicts, whether it's JSON or parquet_b64."""
+    if isinstance(all_stats, list):
+        return all_stats
+    if isinstance(all_stats, dict) and all_stats.get('format') == 'parquet_b64':
+        raw = base64.b64decode(all_stats['data'])
+        df = pd.read_parquet(BytesIO(raw), engine='pyarrow')
+        rows = json.loads(df.to_json(orient='records'))
+        parsed_rows = []
+        for row in rows:
+            parsed = {}
+            for k, v in row.items():
+                if k in ('index', 'level_0'):
+                    parsed[k] = v
+                elif isinstance(v, str):
+                    try:
+                        parsed[k] = json.loads(v)
+                    except (json.JSONDecodeError, ValueError):
+                        parsed[k] = v
+                else:
+                    parsed[k] = v
+            parsed_rows.append(parsed)
+        return parsed_rows
+    return all_stats
 
 
 def test_lazy_widget_sync_executor_populates_stats():
@@ -37,12 +68,12 @@ def test_lazy_widget_sync_executor_populates_stats():
     assert len(widget._df.merged_sd) > 0, f"merged_sd is empty: {widget._df.merged_sd}"
     
     # all_stats should have real values, not just defaults
-    all_stats = widget.df_data_dict.get('all_stats', [])
+    all_stats = _resolve_all_stats(widget.df_data_dict.get('all_stats', []))
     print(f"all_stats length: {len(all_stats)}")
-    
+
     # Check that we have at least one column with stats
     assert len(all_stats) > 0, "all_stats is empty"
-    
+
     # Check that stats contain real data (not just default 0s)
     # all_stats is formatted as rows keyed by stat name, so find a stat row with real values
     # Look for 'length' row which should have non-zero values for each column
@@ -100,12 +131,12 @@ def test_lazy_widget_multiprocessing_executor_populates_stats():
         print(f"all_stats: {widget.df_data_dict.get('all_stats', [])[:3]}")
     
     # Check all_stats
-    all_stats = widget.df_data_dict.get('all_stats', [])
+    all_stats = _resolve_all_stats(widget.df_data_dict.get('all_stats', []))
     print(f"all_stats length: {len(all_stats)}")
-    
+
     # At least check that we got something (even if it's defaults)
     assert len(all_stats) > 0, "all_stats is empty"
-    
+
     # If we waited long enough and async computation completed, we should have real stats
     if len(widget._df.merged_sd) > 0:
         data_rows = [row for row in all_stats if row.get('index') not in ['orig_col_name', 'rewritten_col_name']]

--- a/tests/unit/polars_basic_widget_test.py
+++ b/tests/unit/polars_basic_widget_test.py
@@ -12,6 +12,9 @@ from buckaroo.pluggable_analysis_framework.col_analysis import (
     ColAnalysis)
 
 from buckaroo.pluggable_analysis_framework.utils import (json_postfix)
+from buckaroo.polars_buckaroo import PolarsBuckarooWidget, PolarsBuckarooInfiniteWidget, to_parquet
+from buckaroo.dataflow.dataflow import StylingAnalysis
+from buckaroo.jlisp.lisp_utils import (s, sQ)
 
 
 def _resolve_all_stats(all_stats):
@@ -38,9 +41,6 @@ def _resolve_all_stats(all_stats):
             parsed_rows.append(parsed)
         return parsed_rows
     return all_stats
-from buckaroo.polars_buckaroo import PolarsBuckarooWidget, PolarsBuckarooInfiniteWidget, to_parquet
-from buckaroo.dataflow.dataflow import StylingAnalysis
-from buckaroo.jlisp.lisp_utils import (s, sQ)
 
 def test_basic_instantiation():
     PolarsBuckarooWidget(

--- a/tests/unit/test_lazy_widget_status_and_messages.py
+++ b/tests/unit/test_lazy_widget_status_and_messages.py
@@ -51,7 +51,6 @@ def test_stats_start_with_pending_status():
             for key, val in status_row.items() 
             if key != 'index'
         ), f"Expected at least one column with 'pending' status, got: {status_row}"
-        assert status_row is not None or len(all_stats) > 0, "Should have stats data"
 
 
 def test_stats_clear_status_on_success():

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 
 [[package]]
 name = "buckaroo"
-version = "0.12.6"
+version = "0.12.7"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },

--- a/uv.lock
+++ b/uv.lock
@@ -232,6 +232,7 @@ jupyterlab = [
 ]
 mcp = [
     { name = "mcp" },
+    { name = "tornado" },
 ]
 notebook = [
     { name = "notebook" },
@@ -336,6 +337,7 @@ requires-dist = [
     { name = "solara", extras = ["pytest"], marker = "extra == 'dev'" },
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "toml", marker = "extra == 'dev'" },
+    { name = "tornado", marker = "extra == 'mcp'", specifier = ">=6.0" },
     { name = "twine", marker = "extra == 'packaging-tools'" },
     { name = "watchfiles", marker = "extra == 'dev'" },
 ]


### PR DESCRIPTION
Temporary branch to prove the diagnostics tests fail before the fix commit.

This branch has commit `01c90e6` which adds:
- Tests for `/diagnostics` endpoint (doesn't exist yet)
- Tests for `static_files` in `/health` response (not implemented yet)

**Expected: server playwright tests FAIL on the 2 diagnostics tests.**

Will delete this branch after CI runs.