### PR TITLE
Auto-kill old server on upgrade when version mismatches

### DIFF
--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -48,10 +48,12 @@ def _check_dependency(module_name: str) -> bool:
 
 class HealthHandler(tornado.web.RequestHandler):
     def get(self):
+        import buckaroo
         start_time = self.application.settings.get("server_start_time", 0)
         static_path = self.application.settings.get("static_path", "")
         self.write({
             "status": "ok",
+            "version": getattr(buckaroo, "__version__", "unknown"),
             "pid": os.getpid(),
             "started": start_time,
             "uptime_s": round(time.time() - start_time, 1),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
     "numpy >= 2.2.5; python_version >= '3.13'",
 ]
 
-version = "0.12.7"
+version = "0.12.8"
 
 
 [project.license]

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ wheels = [
 
 [[package]]
 name = "buckaroo"
-version = "0.12.7"
+version = "0.12.8"
 source = { editable = "." }
 dependencies = [
     { name = "anywidget" },


### PR DESCRIPTION
## Summary
- Add `version` field to `/health` endpoint so the MCP tool can detect stale servers
- `ensure_server()` now compares running server version to expected version — if they differ, it kills the old process and starts a new one
- Eliminates the need for users to manually `pkill -f buckaroo.server` after upgrading

## Test plan
- [ ] Verify `/health` returns `version` field
- [ ] Upgrade from 0.12.7 → 0.12.8 and confirm old server is auto-killed
- [ ] Confirm same-version reuse still works (no unnecessary restarts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)