### PR TITLE
Add pre-commit hook for GitHub Actions YAML linting

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-latest
+    - depot-windows-2025

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.11
+    hooks:
+      - id: actionlint


### PR DESCRIPTION
## Summary
- Adds [actionlint](https://github.com/rhysd/actionlint) as a pre-commit hook to catch GitHub Actions workflow errors before they hit CI
- Adds `.github/actionlint.yaml` config to register `depot-ubuntu-latest` / `depot-windows-2025` as known custom runner labels

## What actionlint catches
- YAML syntax errors
- Invalid `needs:` dependency references
- Unknown runner labels (unless registered in config)
- Bad cron expressions
- Shellcheck on embedded `run:` scripts
- Invalid action input names

## Setup for contributors
```bash
pip install pre-commit   # or: uv tool install pre-commit
pre-commit install
```

Then it runs automatically on every commit that touches `.github/workflows/`.

## Test plan
- [x] `pre-commit run --all-files` passes locally
- [x] `actionlint` passes with zero errors (depot runners registered in config)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)