### PR TITLE
Add light/dark theme screenshot audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,6 @@ jobs:
         run: |
           bash scripts/test_playwright_screenshots.sh
 
-      - name: Upload Theme Screenshots
-        if: matrix.python-version == '3.13' && always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: theme-screenshots
-          path: packages/buckaroo-js-core/screenshots/
-          if-no-files-found: ignore
-
       - name: Run Server Playwright Tests
         run: |
           bash scripts/test_playwright_server.sh
@@ -112,6 +104,14 @@ jobs:
       - name: Run Marimo Playwright Tests
         run: |
           bash scripts/test_playwright_marimo.sh
+
+      - name: Upload Theme Screenshots
+        if: matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: theme-screenshots
+          path: packages/buckaroo-js-core/screenshots/
+          if-no-files-found: ignore
 
       # - name: Run JupyterLab Playwright Tests
       #   run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,19 @@ jobs:
         run: |
           bash scripts/test_playwright_storybook.sh
 
+      - name: Capture Theme Screenshots
+        if: matrix.python-version == '3.13'
+        run: |
+          bash scripts/test_playwright_screenshots.sh
+
+      - name: Upload Theme Screenshots
+        if: matrix.python-version == '3.13' && always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: theme-screenshots
+          path: packages/buckaroo-js-core/screenshots/
+          if-no-files-found: ignore
+
       - name: Run Server Playwright Tests
         run: |
           bash scripts/test_playwright_server.sh

--- a/packages/buckaroo-js-core/.gitignore
+++ b/packages/buckaroo-js-core/.gitignore
@@ -28,3 +28,6 @@ dist-ssr
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Theme screenshot audit
+/screenshots/

--- a/packages/buckaroo-js-core/playwright.config.marimo.ts
+++ b/packages/buckaroo-js-core/playwright.config.marimo.ts
@@ -4,7 +4,7 @@ const PORT = 2718;
 
 export default defineConfig({
   testDir: './pw-tests',
-  testMatch: ['marimo.spec.ts'],
+  testMatch: ['marimo.spec.ts', 'theme-screenshots-marimo.spec.ts'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/packages/buckaroo-js-core/playwright.config.server.ts
+++ b/packages/buckaroo-js-core/playwright.config.server.ts
@@ -8,7 +8,7 @@ const PYTHON = process.env.BUCKAROO_SERVER_PYTHON ?? 'uv run python';
 
 export default defineConfig({
   testDir: './pw-tests',
-  testMatch: ['server.spec.ts', 'server-buckaroo-search.spec.ts', 'server-buckaroo-summary.spec.ts'],
+  testMatch: ['server.spec.ts', 'server-buckaroo-search.spec.ts', 'server-buckaroo-summary.spec.ts', 'theme-screenshots-server.spec.ts'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots-marimo.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots-marimo.spec.ts
@@ -1,0 +1,62 @@
+import { test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const SCHEMES = ['light', 'dark'] as const;
+
+const screenshotsDir = path.resolve(__dirname, '..', 'screenshots');
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+for (const scheme of SCHEMES) {
+  test(`marimo full page [${scheme}]`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: scheme });
+    await page.goto('/');
+
+    // Wait for buckaroo widgets and AG-Grid cells to render
+    await page.locator('.buckaroo_anywidget').first().waitFor({ state: 'visible', timeout: 30_000 });
+    await page.locator('.ag-cell').first().waitFor({ state: 'visible', timeout: 30_000 });
+
+    // Wait for the second widget (BuckarooInfiniteWidget) too
+    const widgets = page.locator('.buckaroo_anywidget');
+    await widgets.nth(1).waitFor({ state: 'visible', timeout: 30_000 });
+    await widgets.nth(1).locator('.ag-cell').first().waitFor({ state: 'visible', timeout: 30_000 });
+
+    await page.waitForTimeout(1000);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, `marimo-full-page--${scheme}.png`),
+      fullPage: true,
+    });
+  });
+
+  test(`marimo lowcode widget [${scheme}]`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: scheme });
+    await page.goto('/');
+
+    // Wait for the first BuckarooWidget (which has the lowcode/operations UI)
+    await page.locator('.buckaroo_anywidget').first().waitFor({ state: 'visible', timeout: 30_000 });
+    await page.locator('.buckaroo_anywidget').first().locator('.ag-cell').first()
+      .waitFor({ state: 'visible', timeout: 30_000 });
+
+    // Click on Columns tab to open the lowcode UI if available
+    const firstWidget = page.locator('.buckaroo_anywidget').first();
+    const columnsTab = firstWidget.locator('text=Columns');
+    if (await columnsTab.isVisible()) {
+      await columnsTab.click();
+      await page.waitForTimeout(500);
+    }
+
+    await page.waitForTimeout(500);
+
+    // Screenshot just the first widget area
+    await firstWidget.screenshot({
+      path: path.join(screenshotsDir, `marimo-lowcode-widget--${scheme}.png`),
+    });
+  });
+}

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots-server.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots-server.spec.ts
@@ -1,0 +1,132 @@
+import { test } from '@playwright/test';
+import { loadSession, waitForGrid } from './server-helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PORT = 8701;
+const BASE = `http://localhost:${PORT}`;
+
+const SCHEMES = ['light', 'dark'] as const;
+
+const screenshotsDir = path.resolve(__dirname, '..', 'screenshots');
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+// ---------- test data --------------------------------------------------------
+
+function writeTempCsv(rowCount: number): string {
+  const header = 'name,age,score';
+  const rows = [];
+  for (let i = 0; i < rowCount; i++) {
+    rows.push(`row${i},${20 + (i % 50)},${(i * 1.7).toFixed(1)}`);
+  }
+  const content = [header, ...rows].join('\n') + '\n';
+  const tmpPath = path.join(os.tmpdir(), `buckaroo_screenshot_${Date.now()}_${rowCount}.csv`);
+  fs.writeFileSync(tmpPath, content);
+  return tmpPath;
+}
+
+function cleanupFile(p: string) {
+  if (p && fs.existsSync(p)) fs.unlinkSync(p);
+}
+
+async function loadDefault(request: any, session: string, filePath: string) {
+  const resp = await request.post(`${BASE}/load`, {
+    data: { session, path: filePath },
+  });
+  if (!resp.ok()) throw new Error(`/load failed (${resp.status()}): ${await resp.text()}`);
+  return resp.json();
+}
+
+async function loadBuckaroo(request: any, session: string, filePath: string) {
+  const resp = await request.post(`${BASE}/load`, {
+    data: { session, path: filePath, mode: 'buckaroo' },
+  });
+  if (!resp.ok()) throw new Error(`/load failed (${resp.status()}): ${await resp.text()}`);
+  return resp.json();
+}
+
+// ---------- screenshots: default viewer mode ---------------------------------
+
+test.describe('Server theme screenshots', () => {
+  let csv5: string;
+  let csv100: string;
+
+  test.beforeAll(() => {
+    csv5 = writeTempCsv(5);
+    csv100 = writeTempCsv(100);
+  });
+
+  test.afterAll(() => {
+    cleanupFile(csv5);
+    cleanupFile(csv100);
+  });
+
+  for (const scheme of SCHEMES) {
+    test(`default mode 5 rows [${scheme}]`, async ({ page, request }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      const session = `ss-default-${scheme}-${Date.now()}`;
+      await loadDefault(request, session, csv5);
+      await page.goto(`${BASE}/s/${session}`);
+      await waitForGrid(page);
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `server-default-5rows--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+
+    test(`buckaroo mode 5 rows [${scheme}]`, async ({ page, request }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      const session = `ss-buck-${scheme}-${Date.now()}`;
+      await loadBuckaroo(request, session, csv5);
+      await page.goto(`${BASE}/s/${session}`);
+      // Wait for the full buckaroo widget (data grid + summary stats)
+      await page.locator('.df-viewer .ag-cell').first().waitFor({ state: 'visible', timeout: 15_000 });
+      await page.waitForTimeout(1000);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `server-buckaroo-5rows--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+
+    test(`large dataset 100 rows [${scheme}]`, async ({ page, request }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      const session = `ss-large-${scheme}-${Date.now()}`;
+      await loadDefault(request, session, csv100);
+      await page.goto(`${BASE}/s/${session}`);
+      await waitForGrid(page);
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `server-large-100rows--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+
+    test(`buckaroo mode lowcode UI [${scheme}]`, async ({ page, request }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      const session = `ss-lowcode-${scheme}-${Date.now()}`;
+      await loadBuckaroo(request, session, csv5);
+      await page.goto(`${BASE}/s/${session}`);
+      // Wait for the buckaroo widget with operations panel
+      await page.locator('.df-viewer .ag-cell').first().waitFor({ state: 'visible', timeout: 15_000 });
+      // Click on the operations/columns editor to open lowcode UI
+      const columnsTab = page.locator('text=Columns');
+      if (await columnsTab.isVisible()) {
+        await columnsTab.click();
+        await page.waitForTimeout(500);
+      }
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `server-buckaroo-lowcode--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+  }
+});

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots.spec.ts
@@ -1,6 +1,9 @@
 import { test } from '@playwright/test';
 import path from 'path';
 import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const STORYBOOK_BASE = 'http://localhost:6006/iframe.html?viewMode=story&id=';
 

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots.spec.ts
@@ -1,0 +1,81 @@
+import { test } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+
+const STORYBOOK_BASE = 'http://localhost:6006/iframe.html?viewMode=story&id=';
+
+// Representative stories covering the main UI surfaces
+const STORIES = [
+  // Main data viewer
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteshadow--primary', name: 'InfiniteShadow-Primary' },
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteshadow--large', name: 'InfiniteShadow-Large' },
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteshadow--pinned-rows', name: 'InfiniteShadow-PinnedRows' },
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteshadow--color-map-example', name: 'InfiniteShadow-ColorMap' },
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteshadow--multi-index', name: 'InfiniteShadow-MultiIndex' },
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteshadow--three-level-column-index', name: 'InfiniteShadow-ThreeLevelCol' },
+
+  // Non-infinite DFViewer
+  { id: 'buckaroo-dfviewer-dfviewer--primary', name: 'DFViewer-Primary' },
+  { id: 'buckaroo-dfviewer-dfviewer--color-from-col', name: 'DFViewer-ColorFromCol' },
+  { id: 'buckaroo-dfviewer-dfviewer--chart', name: 'DFViewer-Chart' },
+
+  // Raw infinite viewer
+  { id: 'buckaroo-dfviewer-dfviewerinfiniteraw--primary', name: 'InfiniteRaw-Primary' },
+
+  // Full widget
+  { id: 'buckaroo-buckaroowidgettest--primary', name: 'BuckarooWidget-Primary' },
+
+  // Chrome / controls
+  { id: 'buckaroo-statusbar--primary', name: 'StatusBar-Primary' },
+  { id: 'buckaroo-columnseditor--default', name: 'ColumnsEditor-Default' },
+  { id: 'buckaroo-chrome-operationviewer-in-stories-dir--default', name: 'OperationViewer-Default' },
+
+  // Cell renderers
+  { id: 'buckaroo-dfviewer-renderers-histogram--primary', name: 'Histogram-Primary' },
+  { id: 'buckaroo-dfviewer-renderers-chartcell--primary', name: 'ChartCell-Primary' },
+  { id: 'buckaroo-dfviewer-renderers-chartcell--composed', name: 'ChartCell-Composed' },
+
+  // MessageBox
+  { id: 'buckaroo-messagebox--mixed-messages', name: 'MessageBox-Mixed' },
+];
+
+const SCHEMES = ['light', 'dark'] as const;
+
+// Ensure screenshots directory exists
+const screenshotsDir = path.resolve(__dirname, '..', 'screenshots');
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+for (const story of STORIES) {
+  for (const scheme of SCHEMES) {
+    test(`screenshot ${story.name} [${scheme}]`, async ({ page }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      await page.goto(`${STORYBOOK_BASE}${story.id}`);
+
+      // Wait for AG-Grid cells or any visible content to render
+      const cell = page.locator('.ag-cell');
+      const cellWrapper = page.locator('.ag-cell-wrapper');
+      const noRows = page.locator('.ag-overlay-no-rows-center');
+      const fullWidth = page.locator('.ag-full-width-row');
+      const sbContent = page.locator('#storybook-root');
+
+      await cell
+        .or(cellWrapper)
+        .or(noRows)
+        .or(fullWidth)
+        .or(sbContent)
+        .first()
+        .waitFor({ state: 'visible', timeout: 15000 });
+
+      // Small settle time for animations / lazy rendering
+      await page.waitForTimeout(500);
+
+      await page.screenshot({
+        path: path.join(screenshotsDir, `${story.name}--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+  }
+}

--- a/scripts/test_playwright_screenshots.sh
+++ b/scripts/test_playwright_screenshots.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# Capture light/dark theme screenshots of every important Storybook story.
+# Usage:
+#   bash scripts/test_playwright_screenshots.sh
+set -e
+
+cd "$(dirname "$0")/.."
+ROOT_DIR="$(pwd)"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_message() { echo -e "${BLUE}[$(date +'%H:%M:%S')]${NC} $1"; }
+success()     { echo -e "${GREEN}$1${NC}"; }
+error()       { echo -e "${RED}$1${NC}"; }
+
+echo "Capturing theme screenshots"
+
+cd packages/buckaroo-js-core
+
+# Install deps
+log_message "Installing dependencies..."
+if command -v pnpm &> /dev/null; then
+    pnpm install
+else
+    npm install
+fi
+
+log_message "Ensuring Playwright browsers are installed..."
+if command -v pnpm &> /dev/null; then
+    pnpm exec playwright install chromium
+else
+    npx playwright install chromium
+fi
+success "Dependencies ready"
+
+# Kill any existing storybook on port 6006
+log_message "Cleaning up port 6006..."
+lsof -ti:6006 | xargs kill -9 2>/dev/null || true
+
+# Start Storybook
+log_message "Starting Storybook..."
+if command -v pnpm &> /dev/null; then
+    pnpm storybook --no-open &
+else
+    npm run storybook -- --no-open &
+fi
+STORYBOOK_PID=$!
+
+cleanup() {
+    log_message "Cleaning up..."
+    kill $STORYBOOK_PID 2>/dev/null || true
+    lsof -ti:6006 | xargs kill -9 2>/dev/null || true
+}
+trap cleanup EXIT
+
+MAX_WAIT=60
+COUNTER=0
+log_message "Waiting for Storybook to start..."
+while ! curl -s -f http://localhost:6006 > /dev/null 2>&1; do
+    if [ $COUNTER -ge $MAX_WAIT ]; then
+        error "Storybook failed to start within $MAX_WAIT seconds"
+        exit 1
+    fi
+    sleep 2
+    COUNTER=$((COUNTER + 2))
+done
+success "Storybook is ready at http://localhost:6006"
+
+# Run only the screenshot spec
+log_message "Running theme screenshot capture..."
+npx playwright test pw-tests/theme-screenshots.spec.ts --reporter=line
+
+SCREENSHOT_COUNT=$(ls -1 screenshots/*.png 2>/dev/null | wc -l | tr -d ' ')
+success "Captured $SCREENSHOT_COUNT screenshots in packages/buckaroo-js-core/screenshots/"


### PR DESCRIPTION
## Summary
- Adds Playwright spec that captures screenshots of 19 key Storybook stories in both light and dark color schemes
- New CI step uploads screenshots as a downloadable artifact for visual inspection
- No assertions — purely a visual audit tool before making themes switchable

## Test plan
- [ ] CI passes
- [ ] Download `theme-screenshots` artifact and inspect PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)