### PR TITLE
Add lazy polars mode to headless server

### DIFF
--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Any, Optional
 import pandas as pd
+# polars is optional — only used in lazy mode
 
 
 @dataclass
@@ -13,8 +14,12 @@ class SessionState:
     df_display_args: dict = field(default_factory=dict)
     df_data_dict: dict = field(default_factory=dict)
     df_meta: dict = field(default_factory=dict)
+    # Lazy polars mode fields
+    ldf: Optional[Any] = None  # polars LazyFrame (mode="lazy")
+    orig_to_rw: dict = field(default_factory=dict)
+    rw_to_orig: dict = field(default_factory=dict)
     # Buckaroo mode fields
-    mode: str = "viewer"  # "viewer" or "buckaroo"
+    mode: str = "viewer"  # "viewer", "buckaroo", or "lazy"
     dataflow: Any = None  # ServerDataflow instance when mode="buckaroo"
     buckaroo_state: dict = field(default_factory=dict)
     buckaroo_options: dict = field(default_factory=dict)


### PR DESCRIPTION
Adds mode="lazy" to LoadHandler, backed by polars LazyFrame rather than loading the full file into pandas.  Arbitrarily large parquet/csv/json files can now be served via infinite scroll without exhausting memory.

New helpers in data_loading.py (ported from LazyInfinitePolarsBuckarooWidget):
- load_file_lazy()              — pl.scan_parquet / scan_csv / scan_ndjson
- get_metadata_lazy()          — schema + row count without full read
- get_display_state_lazy()     — display config from schema
- handle_infinite_request_lazy() — lazy slice + polars column rename

SessionState gains ldf, orig_to_rw, rw_to_orig fields. LoadHandler, DataStreamHandler, and websocket_handler all dispatch to the lazy path when mode="lazy".

NOTE: this work originated in xorq-mcp and is intended to be ported back into the main buckaroo MCP server.