### PR TITLE
Add Pluggable Analysis Framework v2 with typed DAG

### DIFF
--- a/buckaroo/buckaroo_widget.py
+++ b/buckaroo/buckaroo_widget.py
@@ -22,7 +22,7 @@ from .customizations.analysis import (TypingStats, ComputedDefaultSummaryStats, 
 from .customizations.histogram import (Histogram)
 from .customizations.pd_autoclean_conf import (CleaningConf, NoCleaningConf, AggressiveAC, ConservativeAC)
 from .customizations.styling import (DefaultSummaryStatsStyling, DefaultMainStyling, CleaningDetailStyling)
-from .pluggable_analysis_framework.analysis_management import DfStats
+from .pluggable_analysis_framework.df_stats_v2 import DfStatsV2
 from .pluggable_analysis_framework.col_analysis import ColAnalysis
 from buckaroo.extension_utils import copy_extend
 
@@ -164,7 +164,7 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
 
     sampling_klass = PdSampling
     autocleaning_klass = PandasAutocleaning #override the base CustomizableDataFlow klass
-    DFStatsClass = DfStats # Pandas Specific
+    DFStatsClass = DfStatsV2 # Pandas Specific
     autoclean_conf = tuple([CleaningConf, NoCleaningConf]) #override the base CustomizableDataFlow conf
 
 

--- a/buckaroo/customizations/pd_stats_v2.py
+++ b/buckaroo/customizations/pd_stats_v2.py
@@ -1,0 +1,447 @@
+"""V2 @stat function equivalents of the v1 ColAnalysis classes.
+
+Provides the same stat keys as the v1 classes, but using the v2
+@stat function API with typed DAG dependencies.
+
+Usage::
+
+    from buckaroo.customizations.pd_stats_v2 import PD_ANALYSIS_V2
+
+    pipeline = StatPipeline(PD_ANALYSIS_V2)
+    result, errors = pipeline.process_df(my_df)
+
+Individual stat groups can also be composed:
+
+    pipeline = StatPipeline([
+        typing_stats, _type,
+        default_summary_stats,
+        computed_default_summary_stats,
+        histogram_series, histogram,
+    ])
+"""
+from typing import Any, TypedDict
+
+import numpy as np
+import pandas as pd
+
+from buckaroo.pluggable_analysis_framework.stat_func import (
+    StatFunc, StatKey, stat, RawSeries,
+)
+
+# Helper functions from v1 modules (not rewritten - pure utilities)
+from buckaroo.customizations.analysis import get_mode
+from buckaroo.customizations.histogram import (
+    categorical_histogram, numeric_histogram,
+)
+from buckaroo.customizations.pd_fracs import (
+    regular_int_parse_frac as _regular_int_parse_frac,
+    strip_int_parse_frac as _strip_int_parse_frac,
+    str_bool_frac as _str_bool_frac,
+    us_dates_frac as _us_dates_frac,
+)
+
+
+# ============================================================
+# Column metadata
+# ============================================================
+
+@stat()
+def orig_col_name(ser: RawSeries) -> Any:
+    """Provide the original column name as a stat key."""
+    return ser.name
+
+
+# ============================================================
+# Typing Stats (replaces TypingStats ColAnalysis)
+# ============================================================
+
+TypingResult = TypedDict('TypingResult', {
+    'dtype': str,
+    'is_numeric': bool,
+    'is_integer': bool,
+    'is_datetime': bool,
+    'is_bool': bool,
+    'is_float': bool,
+    'is_string': bool,
+    'memory_usage': int,
+})
+
+
+@stat()
+def typing_stats(ser: RawSeries) -> TypingResult:
+    """Compute dtype and type flags for a column."""
+    return {
+        'dtype': str(ser.dtype),
+        'is_numeric': pd.api.types.is_numeric_dtype(ser),
+        'is_integer': pd.api.types.is_integer_dtype(ser),
+        'is_datetime': pd.api.types.is_datetime64_any_dtype(ser),
+        'is_bool': pd.api.types.is_bool_dtype(ser),
+        'is_float': pd.api.types.is_float_dtype(ser),
+        'is_string': pd.api.types.is_string_dtype(ser),
+        'memory_usage': ser.memory_usage(),
+    }
+
+
+@stat()
+def _type(is_bool: Any, is_numeric: Any, is_float: Any,
+          is_datetime: Any, is_string: Any) -> str:
+    """Derive the human-readable column type string."""
+    if is_bool:
+        return "boolean"
+    elif is_numeric:
+        if is_float:
+            return "float"
+        return "integer"
+    elif is_datetime:
+        return "datetime"
+    elif is_string:
+        return "string"
+    return "obj"
+
+
+# ============================================================
+# Default Summary Stats (replaces DefaultSummaryStats ColAnalysis)
+# ============================================================
+
+DefaultSummaryResult = TypedDict('DefaultSummaryResult', {
+    'length': int,
+    'null_count': int,
+    'value_counts': Any,
+    'mode': Any,
+    'min': Any,
+    'max': Any,
+    'mean': Any,
+    'std': Any,
+    'median': Any,
+})
+
+
+@stat()
+def default_summary_stats(ser: RawSeries) -> DefaultSummaryResult:
+    """Compute basic summary stats for a column."""
+    length = len(ser)
+    value_counts = ser.value_counts()
+    is_numeric = pd.api.types.is_numeric_dtype(ser)
+    is_bool = pd.api.types.is_bool_dtype(ser)
+
+    result = {
+        'length': length,
+        'null_count': ser.isna().sum(),
+        'value_counts': value_counts,
+        'mode': get_mode(ser),
+        'min': np.nan,
+        'max': np.nan,
+        'mean': 0,
+        'std': 0,
+        'median': 0,
+    }
+
+    if is_numeric and not is_bool and result['null_count'] < length:
+        result['std'] = ser.std()
+        result['mean'] = ser.mean()
+        result['median'] = ser.median()
+        result['min'] = ser.dropna().min()
+        result['max'] = ser.dropna().max()
+
+    return result
+
+
+# ============================================================
+# Computed Default Summary Stats
+# (replaces ComputedDefaultSummaryStats ColAnalysis)
+# ============================================================
+
+ComputedSummaryResult = TypedDict('ComputedSummaryResult', {
+    'non_null_count': int,
+    'most_freq': Any,
+    '2nd_freq': Any,
+    '3rd_freq': Any,
+    '4th_freq': Any,
+    '5th_freq': Any,
+    'unique_count': int,
+    'empty_count': int,
+    'distinct_count': int,
+    'distinct_per': float,
+    'empty_per': float,
+    'unique_per': float,
+    'nan_per': float,
+})
+
+
+@stat()
+def computed_default_summary_stats(
+    length: Any, value_counts: Any, null_count: Any,
+) -> ComputedSummaryResult:
+    """Compute derived stats from basic summary stats."""
+    try:
+        empty_count = value_counts.get('', 0)
+    except Exception:
+        empty_count = 0
+    distinct_count = len(value_counts)
+    unique_count = len(value_counts[value_counts == 1])
+
+    def vc_nth(pos):
+        if pos >= len(value_counts):
+            return None
+        return value_counts.index[pos]
+
+    return {
+        'non_null_count': length - null_count,
+        'most_freq': vc_nth(0),
+        '2nd_freq': vc_nth(1),
+        '3rd_freq': vc_nth(2),
+        '4th_freq': vc_nth(3),
+        '5th_freq': vc_nth(4),
+        'unique_count': unique_count,
+        'empty_count': empty_count,
+        'distinct_count': distinct_count,
+        'distinct_per': distinct_count / length,
+        'empty_per': empty_count / length,
+        'unique_per': unique_count / length,
+        'nan_per': null_count / length,
+    }
+
+
+# ============================================================
+# Histogram (replaces Histogram ColAnalysis)
+# ============================================================
+
+HistogramSeriesResult = TypedDict('HistogramSeriesResult', {
+    'histogram_args': Any,
+    'histogram_bins': Any,
+})
+
+
+@stat()
+def histogram_series(ser: RawSeries) -> HistogramSeriesResult:
+    """Compute histogram args from raw series (numeric path)."""
+    if not pd.api.types.is_numeric_dtype(ser):
+        return {'histogram_args': {}, 'histogram_bins': []}
+    if pd.api.types.is_bool_dtype(ser):
+        return {'histogram_args': {}, 'histogram_bins': []}
+    if not ser.index.is_unique:
+        ser = ser.copy()
+        ser.index = pd.RangeIndex(len(ser))
+    vals = ser.dropna()
+    if len(vals) == 0:
+        return {'histogram_args': {}, 'histogram_bins': []}
+    low_tail = np.quantile(vals, 0.01)
+    high_tail = np.quantile(vals, 0.99)
+    low_pass = ser > low_tail
+    high_pass = ser < high_tail
+    meat = vals[low_pass & high_pass]
+    if len(meat) == 0:
+        return {'histogram_args': {}, 'histogram_bins': []}
+
+    meat_histogram = np.histogram(meat, 10)
+    populations, _ = meat_histogram
+    return {
+        'histogram_bins': meat_histogram[1],
+        'histogram_args': dict(
+            meat_histogram=meat_histogram,
+            normalized_populations=(populations / populations.sum()).tolist(),
+            low_tail=low_tail,
+            high_tail=high_tail,
+        ),
+    }
+
+
+@stat()
+def histogram(
+    value_counts: Any, nan_per: Any, is_numeric: Any,
+    length: Any, min: Any, max: Any,
+    histogram_args: Any,
+) -> list:
+    """Compute histogram from summary stats and histogram args."""
+    if is_numeric and len(value_counts) > 5 and histogram_args:
+        min_, max_ = min, max
+        temp_histo = numeric_histogram(histogram_args, min_, max_, nan_per)
+        if len(temp_histo) > 5:
+            return temp_histo
+    return categorical_histogram(length, value_counts, nan_per)
+
+
+# ============================================================
+# PdCleaningStats (replaces PdCleaningStats ColAnalysis)
+# ============================================================
+
+PdCleaningResult = TypedDict('PdCleaningResult', {
+    'int_parse_fail': float,
+    'int_parse': float,
+})
+
+
+@stat()
+def pd_cleaning_stats(value_counts: Any, length: Any) -> PdCleaningResult:
+    """Compute int parsing stats for cleaning."""
+    vc = value_counts
+    coerced_ser = pd.to_numeric(
+        vc.index.values, errors='coerce', downcast='integer',
+        dtype_backend='pyarrow',
+    )
+    nan_sum = (pd.Series(coerced_ser).isna() * 1 * vc.values).sum()
+    return {
+        'int_parse_fail': nan_sum / length,
+        'int_parse': (length - nan_sum) / length,
+    }
+
+
+# ============================================================
+# Heuristic Fracs (replaces HeuristicFracs ColAnalysis)
+# ============================================================
+
+HeuristicFracsResult = TypedDict('HeuristicFracsResult', {
+    'str_bool_frac': float,
+    'regular_int_parse_frac': float,
+    'strip_int_parse_frac': float,
+    'us_dates_frac': float,
+})
+
+
+@stat()
+def heuristic_fracs(ser: RawSeries) -> HeuristicFracsResult:
+    """Compute heuristic parsing fractions for string/object columns."""
+    if not (
+        pd.api.types.is_string_dtype(ser)
+        or pd.api.types.is_object_dtype(ser)
+    ):
+        return {
+            'str_bool_frac': 0,
+            'regular_int_parse_frac': 0,
+            'strip_int_parse_frac': 0,
+            'us_dates_frac': 0,
+        }
+    return {
+        'str_bool_frac': _str_bool_frac(ser),
+        'regular_int_parse_frac': _regular_int_parse_frac(ser),
+        'strip_int_parse_frac': _strip_int_parse_frac(ser),
+        'us_dates_frac': _us_dates_frac(ser),
+    }
+
+
+# ============================================================
+# Cleaning Ops (replaces BaseHeuristicCleaningGenOps subclasses)
+# ============================================================
+
+try:
+    from buckaroo.jlisp.lisp_utils import s, sA
+    from buckaroo.auto_clean.heuristic_lang import get_top_score
+
+    def _make_cleaning_stat(rules, rules_op_names, class_name):
+        """Factory for heuristic cleaning ops StatFunc objects."""
+        def cleaning_func(
+            str_bool_frac=0.0, regular_int_parse_frac=0.0,
+            strip_int_parse_frac=0.0, us_dates_frac=0.0,
+            orig_col_name='',
+        ):
+            column_metadata = {
+                'str_bool_frac': str_bool_frac,
+                'regular_int_parse_frac': regular_int_parse_frac,
+                'strip_int_parse_frac': strip_int_parse_frac,
+                'us_dates_frac': us_dates_frac,
+                'orig_col_name': orig_col_name,
+            }
+            cleaning_op_name = get_top_score(rules, column_metadata)
+            if cleaning_op_name == "none":
+                return {
+                    "cleaning_ops": [],
+                    "cleaning_name": "None",
+                    "add_orig": False,
+                }
+            else:
+                cleaning_name = rules_op_names.get(
+                    cleaning_op_name, cleaning_op_name,
+                )
+                ops = [
+                    sA(
+                        cleaning_name,
+                        clean_strategy=class_name,
+                        clean_col=orig_col_name,
+                    ),
+                    {"symbol": "df"},
+                ]
+                return {
+                    "cleaning_ops": ops,
+                    "cleaning_name": cleaning_name,
+                    "add_orig": True,
+                }
+
+        cleaning_func.__name__ = class_name
+        cleaning_func.__qualname__ = class_name
+
+        return StatFunc(
+            name=class_name,
+            func=cleaning_func,
+            requires=[
+                StatKey('str_bool_frac', Any),
+                StatKey('regular_int_parse_frac', Any),
+                StatKey('strip_int_parse_frac', Any),
+                StatKey('us_dates_frac', Any),
+                StatKey('orig_col_name', Any),
+            ],
+            provides=[
+                StatKey('cleaning_ops', Any),
+                StatKey('cleaning_name', Any),
+                StatKey('add_orig', Any),
+            ],
+            needs_raw=False,
+        )
+
+    _frac_name_to_command = {
+        "str_bool_frac": "str_bool",
+        "regular_int_parse_frac": "regular_int_parse",
+        "strip_int_parse_frac": "strip_int_parse",
+        "us_dates_frac": "us_date",
+    }
+
+    conservative_cleaning = _make_cleaning_stat(
+        rules={
+            "str_bool_frac": [s("f>"), 0.9],
+            "regular_int_parse_frac": [s("f>"), 0.9],
+            "strip_int_parse_frac": [s("f>"), 0.9],
+            "none": [s("none-rule")],
+            "us_dates_frac": [s("primary"), [s("f>"), 0.8]],
+        },
+        rules_op_names=_frac_name_to_command,
+        class_name='ConservativeCleaningGenops',
+    )
+
+    aggressive_cleaning = _make_cleaning_stat(
+        rules={
+            "str_bool_frac": [s("f>"), 0.6],
+            "regular_int_parse_frac": [s("f>"), 0.7],
+            "strip_int_parse_frac": [s("f>"), 0.6],
+            "none": [s("none-rule")],
+            "us_dates_frac": [s("primary"), [s("f>"), 0.7]],
+        },
+        rules_op_names=_frac_name_to_command,
+        class_name='AggresiveCleaningGenOps',
+    )
+
+except ImportError:
+    conservative_cleaning = None
+    aggressive_cleaning = None
+
+
+# ============================================================
+# Convenience pipeline lists
+# ============================================================
+
+# Core analysis (equivalent to default analysis_klasses)
+PD_ANALYSIS_V2 = [
+    typing_stats, _type,
+    default_summary_stats,
+    computed_default_summary_stats,
+    histogram_series, histogram,
+]
+
+# With cleaning stats
+PD_ANALYSIS_V2_WITH_CLEANING = PD_ANALYSIS_V2 + [
+    pd_cleaning_stats,
+]
+
+# With heuristic fracs (for autocleaning)
+PD_ANALYSIS_V2_WITH_HEURISTICS = PD_ANALYSIS_V2 + [
+    heuristic_fracs,
+    orig_col_name,
+]

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -1,6 +1,6 @@
 import pandas as pd
 from buckaroo.jlisp.lisp_utils import s, sQ, merge_ops, format_ops, ops_eq
-from buckaroo.pluggable_analysis_framework.analysis_management import DfStats
+from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
 from ..customizations.all_transforms import configure_buckaroo, DefaultCommandKlsList
 
 def dumb_merge_ops(existing_ops, cleaning_ops):
@@ -81,7 +81,7 @@ class PandasAutocleaning:
     #     self.command_klasses = without_incoming
     #     self.setup_from_command_kls_list()
 
-    DFStatsKlass = DfStats
+    DFStatsKlass = DfStatsV2
     #until we plumb in swapping configs, just stick with default
     def __init__(self, ac_configs=tuple([AutocleaningConfig()]), conf_name=""):
 

--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -8,7 +8,7 @@ from traitlets import Unicode, Any, observe, Dict
 from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis, SDType
 from ..serialization_utils import pd_to_obj, sd_to_parquet_b64
 from buckaroo.pluggable_analysis_framework.utils import (filter_analysis)
-from buckaroo.pluggable_analysis_framework.analysis_management import DfStats
+from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
 from .autocleaning import SentinelAutocleaning
 from .dataflow_extras import (exception_protect, Sampling)
 from .styling_core import (
@@ -241,7 +241,7 @@ class CustomizableDataflow(DataFlow):
     #analysis_klasses = [StylingAnalysis]
     analysis_klasses: List[Type[ColAnalysis]] = [StylingAnalysis]
     command_config = Dict({}).tag(sync=True)
-    DFStatsClass = DfStats
+    DFStatsClass = DfStatsV2
     sampling_klass = Sampling
 
     df_display_klasses: TDict[str, Type[StylingAnalysis]]  = {}

--- a/buckaroo/pluggable_analysis_framework/column_filters.py
+++ b/buckaroo/pluggable_analysis_framework/column_filters.py
@@ -1,0 +1,119 @@
+"""Column type filter predicates for stat functions.
+
+These predicates determine which columns a stat function applies to,
+replacing ad-hoc isinstance/dtype checks inside function bodies.
+
+Each predicate works for both pandas and polars dtypes.
+
+Note: polars dtype equality (==) has surprising behavior with non-polars
+types (e.g., `np.dtype('O') == pl.Int8` returns True). We guard against
+this by checking isinstance(dtype, pl.DataType) before polars comparisons.
+"""
+from typing import Callable
+
+
+def _is_polars_dtype(dtype) -> bool:
+    """Check if dtype is a polars DataType instance or subclass."""
+    try:
+        import polars as pl
+        return isinstance(dtype, (pl.DataType, type)) and (
+            isinstance(dtype, pl.DataType) or
+            (isinstance(dtype, type) and issubclass(dtype, pl.DataType))
+        )
+    except (ImportError, TypeError):
+        return False
+
+
+def is_numeric(dtype) -> bool:
+    """Check if dtype is numeric (pandas or polars)."""
+    if _is_polars_dtype(dtype):
+        try:
+            import polars as pl
+            return dtype in (
+                pl.Int8, pl.Int16, pl.Int32, pl.Int64,
+                pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64,
+                pl.Float32, pl.Float64,
+            )
+        except ImportError:
+            return False
+
+    try:
+        import pandas as pd
+        return bool(pd.api.types.is_numeric_dtype(dtype))
+    except (ImportError, TypeError):
+        pass
+
+    return False
+
+
+def is_string(dtype) -> bool:
+    """Check if dtype is string/object (pandas or polars)."""
+    if _is_polars_dtype(dtype):
+        try:
+            import polars as pl
+            return dtype in (pl.Utf8, pl.String)
+        except (ImportError, AttributeError):
+            return False
+
+    try:
+        import pandas as pd
+        return bool(pd.api.types.is_string_dtype(dtype))
+    except (ImportError, TypeError):
+        pass
+
+    return False
+
+
+def is_temporal(dtype) -> bool:
+    """Check if dtype is datetime/date/time/timedelta (pandas or polars)."""
+    if _is_polars_dtype(dtype):
+        try:
+            import polars as pl
+            return dtype in (pl.Date, pl.Datetime, pl.Time, pl.Duration)
+        except (ImportError, AttributeError):
+            return False
+
+    try:
+        import pandas as pd
+        if pd.api.types.is_datetime64_any_dtype(dtype):
+            return True
+        if pd.api.types.is_timedelta64_dtype(dtype):
+            return True
+    except (ImportError, TypeError):
+        pass
+
+    return False
+
+
+def is_boolean(dtype) -> bool:
+    """Check if dtype is boolean (pandas or polars)."""
+    if _is_polars_dtype(dtype):
+        try:
+            import polars as pl
+            return dtype is pl.Boolean or dtype == pl.Boolean
+        except (ImportError, AttributeError):
+            return False
+
+    try:
+        import pandas as pd
+        return bool(pd.api.types.is_bool_dtype(dtype))
+    except (ImportError, TypeError):
+        pass
+
+    return False
+
+
+def any_of(*predicates: Callable) -> Callable:
+    """Combinator: returns True if any predicate matches."""
+    def combined(dtype) -> bool:
+        return any(p(dtype) for p in predicates)
+    combined.__name__ = f"any_of({', '.join(p.__name__ for p in predicates)})"
+    return combined
+
+
+def not_(predicate: Callable) -> Callable:
+    """Combinator: negates a predicate."""
+    def negated(dtype) -> bool:
+        return not predicate(dtype)
+    negated.__name__ = f"not_({predicate.__name__})"
+    return negated

--- a/buckaroo/pluggable_analysis_framework/df_stats_v2.py
+++ b/buckaroo/pluggable_analysis_framework/df_stats_v2.py
@@ -54,9 +54,7 @@ class DfStatsV2:
 
         # Process using v1-compatible output format
         self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, self.debug)
-
-        # Also keep v2 errors for richer diagnostics
-        _, self.stat_errors = self.ap.process_df(self.df, self.debug)
+        self.stat_errors = []
 
         if self.errs:
             output_full_reproduce(self.errs, self.sdf, operating_df_name)

--- a/buckaroo/pluggable_analysis_framework/df_stats_v2.py
+++ b/buckaroo/pluggable_analysis_framework/df_stats_v2.py
@@ -1,0 +1,89 @@
+"""DfStatsV2 — drop-in replacement for DfStats using StatPipeline.
+
+Wraps StatPipeline to match the DfStats interface used by DataFlow,
+PandasAutocleaning, and other consumers.
+
+Usage::
+
+    from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
+
+    # Same interface as DfStats
+    stats = DfStatsV2(my_df, [TypingStats, DefaultSummaryStats, Histogram])
+    stats.sdf  # -> SDType
+    stats.errs  # -> ErrDict (v1 compatible)
+"""
+from __future__ import annotations
+
+from typing import Type
+
+import numpy as np
+import pandas as pd
+
+from .col_analysis import AObjs, ColAnalysis, ErrDict, SDType
+from .stat_pipeline import StatPipeline
+from .stat_result import StatError
+from .utils import FAST_SUMMARY_WHEN_GREATER, PERVERSE_DF
+from .safe_summary_df import output_full_reproduce, output_reproduce_preamble
+
+
+class DfStatsV2:
+    """Drop-in replacement for DfStats. Uses StatPipeline internally.
+
+    Maintains the same interface as DfStats so that DataFlow,
+    autocleaning, and all other consumers work without changes.
+    """
+
+    ap_class = StatPipeline
+
+    @classmethod
+    def verify_analysis_objects(cls, col_analysis_objs: AObjs) -> None:
+        """Validate analysis objects without processing data."""
+        cls.ap_class(col_analysis_objs)
+
+    def __init__(
+        self,
+        df_stats_df: pd.DataFrame,
+        col_analysis_objs: AObjs,
+        operating_df_name: str = None,
+        debug: bool = False,
+    ) -> None:
+        self.df = self.get_operating_df(df_stats_df, force_full_eval=False)
+        self.col_order = self.df.columns
+        self.ap = self.ap_class(col_analysis_objs)
+        self.operating_df_name = operating_df_name
+        self.debug = debug
+
+        # Process using v1-compatible output format
+        self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, self.debug)
+
+        # Also keep v2 errors for richer diagnostics
+        _, self.stat_errors = self.ap.process_df(self.df, self.debug)
+
+        if self.errs:
+            output_full_reproduce(self.errs, self.sdf, operating_df_name)
+
+    def get_operating_df(self, df: pd.DataFrame, force_full_eval: bool) -> pd.DataFrame:
+        """Downsample large DataFrames for performance."""
+        rows = len(df)
+        cols = len(df.columns)
+        item_count = rows * cols
+
+        if item_count > FAST_SUMMARY_WHEN_GREATER:
+            return df.sample(np.min([50_000, len(df)]))
+        return df
+
+    def add_analysis(self, a_obj: Type[ColAnalysis]) -> None:
+        """Add a new analysis class interactively."""
+        passed, errors = self.ap.add_stat(a_obj)
+
+        # Re-process with updated pipeline
+        self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, debug=True)
+        _, self.stat_errors = self.ap.process_df(self.df, debug=True)
+
+        if not passed:
+            print("Unit tests failed")
+        if self.errs:
+            print("Errors on original dataframe")
+
+        if errors or self.stat_errors:
+            self.ap.print_errors(errors + self.stat_errors)

--- a/buckaroo/pluggable_analysis_framework/df_stats_v2.py
+++ b/buckaroo/pluggable_analysis_framework/df_stats_v2.py
@@ -19,11 +19,10 @@ from typing import Type
 import numpy as np
 import pandas as pd
 
-from .col_analysis import AObjs, ColAnalysis, ErrDict, SDType
+from .col_analysis import AObjs, ColAnalysis
 from .stat_pipeline import StatPipeline
-from .stat_result import StatError
-from .utils import FAST_SUMMARY_WHEN_GREATER, PERVERSE_DF
-from .safe_summary_df import output_full_reproduce, output_reproduce_preamble
+from .utils import FAST_SUMMARY_WHEN_GREATER
+from .safe_summary_df import output_full_reproduce
 
 
 class DfStatsV2:

--- a/buckaroo/pluggable_analysis_framework/ibis_analysis.py
+++ b/buckaroo/pluggable_analysis_framework/ibis_analysis.py
@@ -13,9 +13,9 @@ Optional dependency: install with `buckaroo[xorq]`.
 """
 from __future__ import annotations
 
-from typing import Any, List, Mapping, Tuple
+from typing import Any, List, Tuple
 
-from .col_analysis import ColAnalysis, ColMeta, SDType, ErrDict
+from .col_analysis import ColAnalysis, SDType, ErrDict
 
 
 # Guard optional imports
@@ -26,7 +26,7 @@ except ImportError:
     HAS_XORQ = False
 
 try:
-    import ibis
+    import ibis  # noqa: F401
     HAS_IBIS = True
 except ImportError:
     HAS_IBIS = False

--- a/buckaroo/pluggable_analysis_framework/ibis_analysis.py
+++ b/buckaroo/pluggable_analysis_framework/ibis_analysis.py
@@ -1,0 +1,170 @@
+"""Ibis/xorq analysis backend for the pluggable analysis framework.
+
+xorq as a COMPUTE backend (not caching):
+  - Execute analysis expressions against remote data sources
+    (DuckDB files, Postgres, Snowflake) without materializing data locally
+  - Ibis as the expression language — portable across backends
+
+What xorq does NOT replace:
+  - Column-level caching stays in SQLiteFileCache + PAFColumnExecutor
+  - DAG ordering and error model are framework concerns
+
+Optional dependency: install with `buckaroo[xorq]`.
+"""
+from __future__ import annotations
+
+from typing import Any, List, Mapping, Tuple
+
+from .col_analysis import ColAnalysis, ColMeta, SDType, ErrDict
+
+
+# Guard optional imports
+try:
+    import xorq  # noqa: F401
+    HAS_XORQ = True
+except ImportError:
+    HAS_XORQ = False
+
+try:
+    import ibis
+    HAS_IBIS = True
+except ImportError:
+    HAS_IBIS = False
+
+
+class IbisAnalysis(ColAnalysis):
+    """Base class for Ibis-expression-based analysis.
+
+    Analogous to PolarsAnalysis.select_clauses, but using Ibis expressions
+    that can be executed via xorq against any supported backend.
+
+    Subclass this and define ``ibis_expressions`` to register Ibis-based stats::
+
+        class BasicIbisStats(IbisAnalysis):
+            ibis_expressions = [
+                lambda t, col: t[col].count().name(f"{col}|length"),
+                lambda t, col: t[col].isnull().sum().name(f"{col}|null_count"),
+            ]
+            provides_defaults = {'length': 0, 'null_count': 0}
+
+    Each expression is a callable ``(table, column_name) -> ibis.Expr``
+    that produces a named scalar expression.
+    """
+    ibis_expressions: List[Any] = []
+
+
+class IbisAnalysisPipeline:
+    """Pipeline for executing Ibis-based analysis via xorq.
+
+    Collects all ``ibis_expressions`` from IbisAnalysis subclasses,
+    builds a single Ibis query, and executes it against the configured
+    backend.
+
+    The computed_summary stage is identical to the pandas path
+    (dict in, dict out).
+    """
+
+    def __init__(self, analysis_objects: list, backend=None):
+        """
+        Args:
+            analysis_objects: list of IbisAnalysis subclasses
+            backend: xorq/ibis backend connection (e.g., xorq.connect())
+        """
+        if not HAS_XORQ:
+            raise ImportError(
+                "xorq is required for IbisAnalysisPipeline. "
+                "Install with: pip install buckaroo[xorq]"
+            )
+
+        self.analysis_objects = analysis_objects
+        self.backend = backend
+
+        # Collect all ibis expressions
+        self._expressions = []
+        for obj in analysis_objects:
+            if hasattr(obj, 'ibis_expressions'):
+                self._expressions.extend(obj.ibis_expressions)
+
+    def build_query(self, table, columns: List[str]):
+        """Build a single Ibis aggregation query from all expressions.
+
+        Args:
+            table: ibis Table expression
+            columns: list of column names to analyze
+
+        Returns:
+            ibis expression that computes all stats
+        """
+        agg_exprs = []
+        for col in columns:
+            for expr_fn in self._expressions:
+                try:
+                    expr = expr_fn(table, col)
+                    agg_exprs.append(expr)
+                except Exception:
+                    continue
+
+        if not agg_exprs:
+            return None
+
+        return table.aggregate(agg_exprs)
+
+    def execute(self, table, columns: List[str]) -> SDType:
+        """Execute the analysis pipeline against an Ibis table.
+
+        Args:
+            table: ibis Table expression
+            columns: list of column names to analyze
+
+        Returns:
+            SDType dict mapping column names to their stats
+        """
+        query = self.build_query(table, columns)
+        if query is None:
+            return {}
+
+        # Execute via xorq backend
+        if self.backend is not None:
+            result_df = self.backend.execute(query)
+        else:
+            result_df = query.execute()
+
+        # Parse results into SDType format
+        # Expression names follow the "column|stat" convention
+        stats: SDType = {}
+        for col_stat_name in result_df.columns:
+            if '|' in col_stat_name:
+                col_name, stat_name = col_stat_name.split('|', 1)
+                if col_name not in stats:
+                    stats[col_name] = {}
+                stats[col_name][stat_name] = result_df[col_stat_name].iloc[0]
+
+        # Run computed_summary phase
+        for obj in self.analysis_objects:
+            for col_name in stats:
+                try:
+                    computed = obj.computed_summary(stats[col_name])
+                    stats[col_name].update(computed)
+                except Exception:
+                    continue
+
+        return stats
+
+    def process_df(self, table, columns: List[str] = None) -> Tuple[SDType, ErrDict]:
+        """Process a table (ibis Table or xorq-wrapped).
+
+        Args:
+            table: ibis Table expression
+            columns: optional list of columns (defaults to all)
+
+        Returns:
+            (SDType, ErrDict) matching the AnalysisPipeline interface
+        """
+        if columns is None:
+            columns = table.columns
+
+        try:
+            stats = self.execute(table, columns)
+            return stats, {}
+        except Exception as e:
+            return {}, {("__ibis__", "execute"): (e, IbisAnalysis)}

--- a/buckaroo/pluggable_analysis_framework/stat_func.py
+++ b/buckaroo/pluggable_analysis_framework/stat_func.py
@@ -1,0 +1,230 @@
+"""Core types for the pluggable analysis framework v2.
+
+StatKey, StatFunc, @stat decorator, and marker types.
+
+The function signature IS the contract:
+  - Parameter names/types become `requires`
+  - Return type becomes `provides`
+  - RawSeries/SampledSeries params indicate raw data needs
+"""
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional, get_type_hints
+
+
+# Sentinel for "no default provided"
+class _MissingSentinel:
+    """Sentinel object indicating no default was provided."""
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self):
+        return '<MISSING>'
+
+    def __bool__(self):
+        return False
+
+
+MISSING = _MissingSentinel()
+
+
+# ---------------------------------------------------------------------------
+# Marker types for raw data access
+# ---------------------------------------------------------------------------
+
+class RawSeries:
+    """Marker type: 'give me the raw column series'."""
+    pass
+
+
+class SampledSeries:
+    """Marker type: 'give me the downsampled series'."""
+    pass
+
+
+class RawDataFrame:
+    """Marker type: 'give me the full dataframe'."""
+    pass
+
+
+RAW_MARKER_TYPES = (RawSeries, SampledSeries, RawDataFrame)
+
+
+# ---------------------------------------------------------------------------
+# StatKey — a named, typed slot in the DAG
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class StatKey:
+    """A named, typed slot in the stat DAG."""
+    name: str
+    type: type  # Python type (int, float, Any, pd.Series, etc.)
+
+    def __repr__(self):
+        type_name = getattr(self.type, '__name__', str(self.type))
+        return f"StatKey({self.name!r}, {type_name})"
+
+
+# ---------------------------------------------------------------------------
+# StatFunc — a registered stat computation
+# ---------------------------------------------------------------------------
+
+@dataclass
+class StatFunc:
+    """A registered stat computation.
+
+    Attributes:
+        name: identifier for this stat function
+        func: the actual callable
+        requires: list of StatKeys this function needs as input
+        provides: list of StatKeys this function produces
+        needs_raw: True if any parameter is RawSeries/SampledSeries/RawDataFrame
+        column_filter: optional predicate on column dtype
+        quiet: suppress error reporting
+        default: fallback value on failure (MISSING = no fallback)
+    """
+    name: str
+    func: Callable
+    requires: List[StatKey]
+    provides: List[StatKey]
+    needs_raw: bool
+    column_filter: Optional[Callable] = None
+    quiet: bool = False
+    default: Any = field(default_factory=lambda: MISSING)
+
+
+# ---------------------------------------------------------------------------
+# Helpers for @stat decorator
+# ---------------------------------------------------------------------------
+
+def _is_typed_dict(tp) -> bool:
+    """Check if a type is a TypedDict subclass."""
+    if tp is None or not isinstance(tp, type):
+        return False
+    # TypedDict classes have __required_keys__ or __optional_keys__
+    return hasattr(tp, '__required_keys__') or hasattr(tp, '__optional_keys__')
+
+
+def _get_provides_from_return_type(func_name: str, return_type) -> List[StatKey]:
+    """Derive provided StatKeys from return annotation."""
+    if return_type is inspect.Parameter.empty or return_type is None:
+        return [StatKey(func_name, Any)]
+
+    if _is_typed_dict(return_type):
+        provides = []
+        for key, val_type in get_type_hints(return_type).items():
+            provides.append(StatKey(key, val_type))
+        return provides
+
+    return [StatKey(func_name, return_type)]
+
+
+def _get_requires_from_params(sig: inspect.Signature, hints: dict) -> tuple:
+    """Derive required StatKeys and needs_raw flag from parameter annotations."""
+    requires = []
+    needs_raw = False
+
+    for param_name, param in sig.parameters.items():
+        if param_name in ('self', 'cls'):
+            continue
+
+        param_type = hints.get(param_name, Any)
+
+        if param_type in RAW_MARKER_TYPES:
+            needs_raw = True
+
+        requires.append(StatKey(param_name, param_type))
+
+    return requires, needs_raw
+
+
+# ---------------------------------------------------------------------------
+# @stat decorator
+# ---------------------------------------------------------------------------
+
+def stat(column_filter=None, quiet=False, default=MISSING):
+    """Decorator that converts a function into a StatFunc.
+
+    The function signature IS the contract:
+      - Parameter names/types become `requires`
+      - Return type becomes `provides`
+      - RawSeries/SampledSeries params indicate raw data needs
+
+    Usage::
+
+        @stat()
+        def distinct_per(length: int, distinct_count: int) -> float:
+            return distinct_count / length
+
+        @stat(column_filter=is_numeric)
+        def mean(ser: RawSeries) -> float:
+            return ser.mean()
+
+        @stat(default=0)
+        def safe_ratio(a: int, b: int) -> float:
+            return a / b
+    """
+    def decorator(func):
+        sig = inspect.signature(func)
+        try:
+            hints = get_type_hints(func)
+        except Exception:
+            hints = {}
+
+        return_type = hints.get('return', inspect.Parameter.empty)
+
+        requires, needs_raw = _get_requires_from_params(sig, hints)
+        provides = _get_provides_from_return_type(func.__name__, return_type)
+
+        stat_func = StatFunc(
+            name=func.__name__,
+            func=func,
+            requires=requires,
+            provides=provides,
+            needs_raw=needs_raw,
+            column_filter=column_filter,
+            quiet=quiet,
+            default=default,
+        )
+
+        # Attach metadata to the function so pipeline can find it
+        func._stat_func = stat_func
+        return func
+
+    return decorator
+
+
+# ---------------------------------------------------------------------------
+# collect_stat_funcs — extract StatFunc objects from various sources
+# ---------------------------------------------------------------------------
+
+def collect_stat_funcs(obj) -> List[StatFunc]:
+    """Collect StatFunc objects from a class, function, or StatFunc instance.
+
+    - StatFunc instance: returned as-is in a list
+    - Function with @stat: returns its ._stat_func
+    - Class with @stat-decorated methods: collects all of them
+    - Anything else: returns empty list
+    """
+    if isinstance(obj, StatFunc):
+        return [obj]
+
+    if callable(obj) and hasattr(obj, '_stat_func'):
+        return [obj._stat_func]
+
+    if isinstance(obj, type):
+        # It's a class — collect all @stat-decorated methods
+        funcs = []
+        for name in sorted(dir(obj)):
+            attr = getattr(obj, name, None)
+            if callable(attr) and hasattr(attr, '_stat_func'):
+                funcs.append(attr._stat_func)
+        return funcs
+
+    return []

--- a/buckaroo/pluggable_analysis_framework/stat_func.py
+++ b/buckaroo/pluggable_analysis_framework/stat_func.py
@@ -97,6 +97,8 @@ class StatFunc:
     column_filter: Optional[Callable] = None
     quiet: bool = False
     default: Any = field(default_factory=lambda: MISSING)
+    spread_dict_result: bool = False  # v1 compat: spread all dict keys into accumulator
+    v1_computed: bool = False  # v1 compat: pass full accumulator as single dict arg
 
 
 # ---------------------------------------------------------------------------

--- a/buckaroo/pluggable_analysis_framework/stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/stat_pipeline.py
@@ -1,0 +1,409 @@
+"""StatPipeline — top-level orchestrator for the pluggable analysis framework v2.
+
+Replaces AnalysisPipeline with typed DAG execution and Ok/Err error propagation.
+Accepts a mix of v2 @stat functions and v1 ColAnalysis classes (via adapter).
+"""
+from __future__ import annotations
+
+import traceback
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
+
+import pandas as pd
+
+from buckaroo.df_util import old_col_new_col
+
+from .col_analysis import ColAnalysis, ColMeta, ErrDict, SDType
+from .stat_func import (
+    StatFunc, StatKey, RawSeries, SampledSeries, RawDataFrame,
+    RAW_MARKER_TYPES, MISSING, collect_stat_funcs,
+)
+from .stat_result import Ok, Err, UpstreamError, StatError, StatResult, resolve_accumulator
+from .typed_dag import build_typed_dag, build_column_dag, DAGConfigError
+from .v1_adapter import col_analysis_to_stat_funcs
+from .utils import PERVERSE_DF
+
+
+def _normalize_inputs(inputs: list) -> List[StatFunc]:
+    """Convert a mixed list of StatFunc, @stat functions, and ColAnalysis classes to StatFuncs."""
+    all_funcs: List[StatFunc] = []
+
+    for obj in inputs:
+        # Already a StatFunc
+        if isinstance(obj, StatFunc):
+            all_funcs.append(obj)
+            continue
+
+        # A @stat-decorated function
+        if callable(obj) and hasattr(obj, '_stat_func'):
+            all_funcs.append(obj._stat_func)
+            continue
+
+        # A class with @stat-decorated methods (stat group)
+        if isinstance(obj, type) and not issubclass(obj, ColAnalysis):
+            collected = collect_stat_funcs(obj)
+            if collected:
+                all_funcs.extend(collected)
+                continue
+
+        # A v1 ColAnalysis subclass
+        if isinstance(obj, type) and issubclass(obj, ColAnalysis):
+            adapted = col_analysis_to_stat_funcs(obj)
+            all_funcs.extend(adapted)
+            continue
+
+        raise TypeError(
+            f"Cannot convert {obj!r} to StatFunc. Expected StatFunc, "
+            f"@stat-decorated function, stat group class, or ColAnalysis subclass."
+        )
+
+    return all_funcs
+
+
+def _execute_stat_func(
+    sf: StatFunc,
+    accumulator: Dict[str, StatResult],
+    column_name: str,
+    raw_series=None,
+    sampled_series=None,
+    raw_dataframe=None,
+) -> None:
+    """Execute a single StatFunc, updating the accumulator in place.
+
+    Handles:
+    - Raw data injection (RawSeries, SampledSeries, RawDataFrame)
+    - Upstream error propagation
+    - Multi-value return unpacking (for TypedDict and v1 adapter dict returns)
+    - Default fallback on error
+    """
+    # Build kwargs from requires
+    kwargs = {}
+    has_upstream_err = False
+
+    for req in sf.requires:
+        if req.type is RawSeries:
+            kwargs[req.name] = raw_series
+            continue
+        if req.type is SampledSeries:
+            kwargs[req.name] = sampled_series if sampled_series is not None else raw_series
+            continue
+        if req.type is RawDataFrame:
+            kwargs[req.name] = raw_dataframe
+            continue
+
+        # Look up in accumulator
+        if req.name in accumulator:
+            result = accumulator[req.name]
+            if isinstance(result, Ok):
+                kwargs[req.name] = result.value
+            elif isinstance(result, Err):
+                # Upstream error — propagate to all outputs
+                upstream_err = UpstreamError(sf.name, req.name, result.error)
+                for sk in sf.provides:
+                    accumulator[sk.name] = Err(
+                        error=upstream_err,
+                        stat_func_name=sf.name,
+                        column_name=column_name,
+                        inputs={},
+                    )
+                has_upstream_err = True
+                break
+        else:
+            # Required key not in accumulator — should not happen after DAG validation
+            # but handle gracefully
+            err = DAGConfigError(
+                f"Required key '{req.name}' not found in accumulator for '{sf.name}'"
+            )
+            for sk in sf.provides:
+                accumulator[sk.name] = Err(
+                    error=err,
+                    stat_func_name=sf.name,
+                    column_name=column_name,
+                    inputs={},
+                )
+            has_upstream_err = True
+            break
+
+    if has_upstream_err:
+        return
+
+    # Execute the function
+    try:
+        result = sf.func(**kwargs)
+
+        # Unpack result — always try dict unpacking first
+        # This handles both TypedDict returns (v2) and v1 adapter dict returns
+        if isinstance(result, dict) and any(sk.name in result for sk in sf.provides):
+            for sk in sf.provides:
+                if sk.name in result:
+                    accumulator[sk.name] = Ok(result[sk.name])
+                else:
+                    accumulator[sk.name] = Ok(None)
+        elif len(sf.provides) == 1:
+            accumulator[sf.provides[0].name] = Ok(result)
+        else:
+            # Non-dict multi-value — assign result to all (unusual)
+            for sk in sf.provides:
+                accumulator[sk.name] = Ok(result)
+
+    except Exception as e:
+        # Check for default fallback
+        if sf.default is not MISSING:
+            for sk in sf.provides:
+                accumulator[sk.name] = Ok(sf.default)
+        else:
+            for sk in sf.provides:
+                accumulator[sk.name] = Err(
+                    error=e,
+                    stat_func_name=sf.name,
+                    column_name=column_name,
+                    inputs=kwargs.copy(),
+                )
+
+
+class StatPipeline:
+    """Top-level orchestrator for the pluggable analysis framework v2.
+
+    Accepts a mix of:
+    - StatFunc objects (v2)
+    - @stat-decorated functions (v2)
+    - Stat group classes with @stat methods (v2)
+    - ColAnalysis subclasses (v1 via adapter)
+
+    Builds a typed DAG, executes per-column with Ok/Err error propagation,
+    and supports column-type filtering.
+
+    Usage::
+
+        pipeline = StatPipeline([TypingStats, DefaultSummaryStats, distinct_per])
+        result, errors = pipeline.process_df(my_df)
+    """
+
+    def __init__(
+        self,
+        stat_funcs: list,
+        unit_test: bool = True,
+    ):
+        self.all_stat_funcs = _normalize_inputs(stat_funcs)
+        self._original_inputs = list(stat_funcs)
+
+        # Validate the full DAG (raises DAGConfigError if invalid)
+        self.ordered_stat_funcs = build_typed_dag(self.all_stat_funcs)
+
+        # Build key -> StatFunc mapping for error reporting
+        self._key_to_func: Dict[str, StatFunc] = {}
+        for sf in self.ordered_stat_funcs:
+            for sk in sf.provides:
+                self._key_to_func[sk.name] = sf
+
+        # Cache provided keys set (for compatibility)
+        self.provided_summary_facts_set = set(self._key_to_func.keys())
+
+        if unit_test:
+            self._unit_test_result = self.unit_test()
+
+    def process_column(
+        self,
+        column_name: str,
+        column_dtype,
+        raw_series=None,
+        sampled_series=None,
+        raw_dataframe=None,
+    ) -> Tuple[Dict[str, Any], List[StatError]]:
+        """Process a single column through the stat DAG.
+
+        1. Filters stat functions by column dtype
+        2. Executes in topological order with Ok/Err accumulator
+        3. Returns (plain_dict, errors)
+        """
+        # Build column-specific DAG (filters by dtype)
+        column_funcs = build_column_dag(self.all_stat_funcs, column_dtype)
+
+        # Execute in order
+        accumulator: Dict[str, StatResult] = {}
+        for sf in column_funcs:
+            _execute_stat_func(
+                sf, accumulator, column_name,
+                raw_series=raw_series,
+                sampled_series=sampled_series,
+                raw_dataframe=raw_dataframe,
+            )
+
+        # Build key_to_func for this column's funcs
+        col_key_to_func: Dict[str, StatFunc] = {}
+        for sf in column_funcs:
+            for sk in sf.provides:
+                col_key_to_func[sk.name] = sf
+
+        return resolve_accumulator(accumulator, column_name, col_key_to_func)
+
+    def process_df(
+        self,
+        df: pd.DataFrame,
+        debug: bool = False,
+    ) -> Tuple[SDType, List[StatError]]:
+        """Process all columns of a DataFrame.
+
+        Returns:
+            (summary_dict, all_errors) where summary_dict is SDType-compatible
+            (column_name -> {stat_name -> value}).
+        """
+        if len(df) == 0:
+            return {}, []
+
+        summary: SDType = {}
+        all_errors: List[StatError] = []
+
+        for orig_col_name, rewritten_col_name in old_col_new_col(df):
+            ser = df[orig_col_name]
+            col_dtype = ser.dtype
+
+            col_result, col_errors = self.process_column(
+                column_name=rewritten_col_name,
+                column_dtype=col_dtype,
+                raw_series=ser,
+                sampled_series=ser,
+                raw_dataframe=df,
+            )
+
+            # Add metadata (matches v1 behavior)
+            col_result['orig_col_name'] = orig_col_name
+            col_result['rewritten_col_name'] = rewritten_col_name
+
+            summary[rewritten_col_name] = col_result
+            all_errors.extend(col_errors)
+
+        return summary, all_errors
+
+    def process_df_v1_compat(
+        self,
+        df: pd.DataFrame,
+        debug: bool = False,
+    ) -> Tuple[SDType, ErrDict]:
+        """Process DataFrame with v1-compatible error format.
+
+        Returns (SDType, ErrDict) matching the v1 AnalysisPipeline interface.
+        """
+        summary, errors = self.process_df(df, debug=debug)
+
+        # Convert StatError list to v1 ErrDict format
+        errs: ErrDict = {}
+        for se in errors:
+            # Find the original ColAnalysis class if this came from v1 adapter
+            kls = _find_v1_class(se.stat_func, self._original_inputs) if se.stat_func else None
+            err_key = (se.column, se.stat_func.name if se.stat_func else "unknown")
+            errs[err_key] = (se.error, kls)
+
+        return summary, errs
+
+    def unit_test(self) -> Tuple[bool, List[StatError]]:
+        """Test the pipeline against PERVERSE_DF."""
+        try:
+            _, errors = self.process_df(PERVERSE_DF)
+            if not errors:
+                return True, []
+            return False, errors
+        except Exception:
+            return False, []
+
+    def add_stat(self, stat_func_or_class) -> Tuple[bool, List[StatError]]:
+        """Add a stat function or ColAnalysis class interactively.
+
+        Validates the DAG and runs unit test against PERVERSE_DF.
+        """
+        new_inputs = list(self._original_inputs)
+
+        # Remove existing with same name if re-adding
+        if isinstance(stat_func_or_class, type):
+            new_inputs = [
+                inp for inp in new_inputs
+                if not (isinstance(inp, type) and inp.__name__ == stat_func_or_class.__name__)
+            ]
+        new_inputs.append(stat_func_or_class)
+
+        try:
+            new_funcs = _normalize_inputs(new_inputs)
+            new_ordered = build_typed_dag(new_funcs)
+        except DAGConfigError as e:
+            return False, [StatError(
+                column="<dag>", stat_key="<config>",
+                error=e, stat_func=None,
+            )]
+
+        # Update internal state
+        self.all_stat_funcs = new_funcs
+        self.ordered_stat_funcs = new_ordered
+        self._original_inputs = new_inputs
+        self._key_to_func = {}
+        for sf in self.ordered_stat_funcs:
+            for sk in sf.provides:
+                self._key_to_func[sk.name] = sf
+        self.provided_summary_facts_set = set(self._key_to_func.keys())
+
+        # Unit test
+        passed, errors = self.unit_test()
+        return passed, errors
+
+    def test_stat(self, stat_name: str, inputs: Dict[str, Any]) -> Any:
+        """Test a single stat function with given inputs.
+
+        Returns Ok(value) or Err(exception).
+        """
+        # Find the stat func
+        sf = self._key_to_func.get(stat_name)
+        if sf is None:
+            raise KeyError(f"No stat function provides '{stat_name}'")
+
+        try:
+            result = sf.func(**inputs)
+            return Ok(result)
+        except Exception as e:
+            return Err(error=e, stat_func_name=sf.name, column_name="<test>")
+
+    def explain(self, stat_name: str) -> str:
+        """Return a human-readable description of a stat function."""
+        sf = self._key_to_func.get(stat_name)
+        if sf is None:
+            raise KeyError(f"No stat function provides '{stat_name}'")
+
+        lines = [f"StatFunc: {sf.name}"]
+        req_strs = [f"{sk.name} ({sk.type.__name__ if hasattr(sk.type, '__name__') else sk.type})"
+                     for sk in sf.requires]
+        lines.append(f"  requires: {', '.join(req_strs) if req_strs else 'none'}")
+
+        prov_strs = [f"{sk.name} ({sk.type.__name__ if hasattr(sk.type, '__name__') else sk.type})"
+                      for sk in sf.provides]
+        lines.append(f"  provides: {', '.join(prov_strs)}")
+
+        if sf.column_filter is not None:
+            filter_name = getattr(sf.column_filter, '__name__', repr(sf.column_filter))
+            lines.append(f"  column_filter: {filter_name}")
+        else:
+            lines.append("  column_filter: None (all columns)")
+
+        if sf.default is not MISSING:
+            lines.append(f"  default: {sf.default!r}")
+
+        return '\n'.join(lines)
+
+    def print_errors(self, errors: List[StatError]) -> None:
+        """Print reproduction code for all errors."""
+        for err in errors:
+            if err.stat_func is not None:
+                print(err.reproduce_code())
+                print()
+
+
+def _find_v1_class(stat_func: Optional[StatFunc], original_inputs: list) -> Any:
+    """Find the original v1 ColAnalysis class for a stat func name."""
+    if stat_func is None:
+        return None
+
+    # The v1 adapter names funcs as "ClassName__series" or "ClassName__computed"
+    name = stat_func.name
+    for suffix in ('__series', '__computed'):
+        if name.endswith(suffix):
+            class_name = name[:-len(suffix)]
+            for inp in original_inputs:
+                if isinstance(inp, type) and inp.__name__ == class_name:
+                    return inp
+    return None

--- a/buckaroo/pluggable_analysis_framework/stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/stat_pipeline.py
@@ -5,16 +5,15 @@ Accepts a mix of v2 @stat functions and v1 ColAnalysis classes (via adapter).
 """
 from __future__ import annotations
 
-import traceback
-from typing import Any, Dict, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import pandas as pd
 
 from buckaroo.df_util import old_col_new_col
 
-from .col_analysis import ColAnalysis, ColMeta, ErrDict, SDType
+from .col_analysis import ColAnalysis, ErrDict, SDType
 from .stat_func import (
-    StatFunc, StatKey, RawSeries, SampledSeries, RawDataFrame,
+    StatFunc, RawSeries, SampledSeries, RawDataFrame,
     RAW_MARKER_TYPES, MISSING, collect_stat_funcs,
 )
 from .stat_result import Ok, Err, UpstreamError, StatError, StatResult, resolve_accumulator

--- a/buckaroo/pluggable_analysis_framework/stat_result.py
+++ b/buckaroo/pluggable_analysis_framework/stat_result.py
@@ -1,0 +1,151 @@
+"""Result types for the pluggable analysis framework v2.
+
+Ok/Err result type with typed error propagation through the stat DAG.
+Two failure modes clearly distinguished:
+  - Config error (DAGConfigError) raised at pipeline construction
+  - Runtime error (Err) propagated downstream per-column
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Generic, List, Optional, Tuple, TypeVar, Union
+
+T = TypeVar('T')
+
+
+@dataclass(frozen=True)
+class Ok(Generic[T]):
+    """Successful stat computation result."""
+    value: T
+
+
+class UpstreamError(Exception):
+    """A required input failed, so this stat cannot be computed."""
+
+    def __init__(self, stat_func_name: str, failed_input: str, original_error: Exception):
+        self.stat_func_name = stat_func_name
+        self.failed_input = failed_input
+        self.original_error = original_error
+        super().__init__(
+            f"Cannot compute '{stat_func_name}': input '{failed_input}' failed"
+        )
+
+
+@dataclass(frozen=True)
+class Err:
+    """Failed stat computation result."""
+    error: Exception
+    stat_func_name: str
+    column_name: str
+    inputs: Dict[str, Any] = field(default_factory=dict)
+
+
+# Union type for stat results
+StatResult = Union[Ok, Err]
+
+
+@dataclass
+class StatError:
+    """Error report from stat pipeline execution, with reproduction support."""
+    column: str
+    stat_key: str
+    error: Exception
+    stat_func: Any  # StatFunc reference (Any to avoid circular import)
+    inputs: Dict[str, Any] = field(default_factory=dict)
+
+    def reproduce_code(self) -> str:
+        """Generate standalone Python code to reproduce this error."""
+        lines = []
+        lines.append(f"# Error in {self.stat_func.name} for column '{self.column}':")
+
+        # Determine if we need pandas import for series inputs
+        has_series = False
+        series_inputs = {}
+        scalar_inputs = {}
+
+        for k, v in self.inputs.items():
+            try:
+                import pandas as pd
+                if isinstance(v, pd.Series):
+                    has_series = True
+                    series_inputs[k] = v
+                    continue
+            except ImportError:
+                pass
+            scalar_inputs[k] = v
+
+        # Import the function's module
+        if self.stat_func.func is not None:
+            mod = getattr(self.stat_func.func, '__module__', None)
+            qualname = getattr(self.stat_func.func, '__qualname__', self.stat_func.name)
+            top_name = qualname.split('.')[0]
+            if mod:
+                lines.append(f"from {mod} import {top_name}")
+
+        if has_series:
+            lines.append("import pandas as pd")
+
+        # Serialize series inputs
+        for k, v in series_inputs.items():
+            try:
+                import pandas as pd
+                lines.append(f"{k} = pd.Series({v.tolist()!r}, dtype='{v.dtype}')")
+            except Exception:
+                lines.append(f"{k} = ...  # could not serialize")
+
+        # Build the function call
+        args = []
+        for k in self.inputs:
+            if k in series_inputs:
+                args.append(f"{k}={k}")
+            else:
+                args.append(f"{k}={scalar_inputs[k]!r}")
+
+        func_name = self.stat_func.name
+        err_type = type(self.error).__name__
+        err_msg = str(self.error)
+        lines.append(f"{func_name}({', '.join(args)})  # {err_type}: {err_msg}")
+
+        return '\n'.join(lines)
+
+
+def resolve_accumulator(
+    accumulator: Dict[str, StatResult],
+    column_name: str,
+    key_to_func: Optional[Dict[str, Any]] = None,
+) -> Tuple[Dict[str, Any], List[StatError]]:
+    """Convert Ok/Err accumulator to plain dict + error list.
+
+    Args:
+        accumulator: mapping of stat_name -> StatResult
+        column_name: the column being processed
+        key_to_func: mapping of stat_name -> StatFunc (for error reporting)
+
+    Returns:
+        (plain_dict, errors) where plain_dict has raw values for Ok results
+        and None for Err results.
+    """
+    if key_to_func is None:
+        key_to_func = {}
+
+    plain: Dict[str, Any] = {}
+    errors: List[StatError] = []
+
+    for key, result in accumulator.items():
+        if isinstance(result, Ok):
+            plain[key] = result.value
+        elif isinstance(result, Err):
+            plain[key] = None
+            stat_func = key_to_func.get(key)
+            errors.append(StatError(
+                column=column_name,
+                stat_key=key,
+                error=result.error,
+                stat_func=stat_func,
+                inputs=result.inputs,
+            ))
+        else:
+            # Should not happen, but be defensive
+            plain[key] = result
+
+    return plain, errors

--- a/buckaroo/pluggable_analysis_framework/typed_dag.py
+++ b/buckaroo/pluggable_analysis_framework/typed_dag.py
@@ -1,0 +1,150 @@
+"""Typed DAG construction for the pluggable analysis framework v2.
+
+Replaces v1's order_analysis() and check_solvable() with type-aware
+dependency resolution that supports column-type filtering.
+"""
+from __future__ import annotations
+
+import graphlib
+import warnings
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from .stat_func import StatFunc, StatKey, RAW_MARKER_TYPES
+
+
+class DAGConfigError(Exception):
+    """Raised when the stat DAG has unsatisfiable dependencies.
+
+    This is a configuration-time error, not a runtime error.
+    It means the set of stat functions cannot form a valid pipeline.
+    """
+    pass
+
+
+def build_typed_dag(stat_funcs: List[StatFunc]) -> List[StatFunc]:
+    """Build and topologically sort a typed stat DAG.
+
+    1. Builds provides map: stat_name -> (StatKey, StatFunc)
+    2. Validates all requirements have providers (raises DAGConfigError if not)
+    3. Warns on type mismatches between provider and consumer
+    4. Topologically sorts via graphlib
+    5. Detects cycles
+
+    Args:
+        stat_funcs: list of StatFunc objects to order
+
+    Returns:
+        Topologically sorted list of StatFunc objects
+
+    Raises:
+        DAGConfigError: if a required stat has no provider, or if a cycle exists
+    """
+    if not stat_funcs:
+        return []
+
+    # Build provides map: stat_name -> (StatKey, StatFunc)
+    provides_map: Dict[str, Tuple[StatKey, StatFunc]] = {}
+    for sf in stat_funcs:
+        for sk in sf.provides:
+            provides_map[sk.name] = (sk, sf)
+
+    # Validate all requirements are satisfiable
+    for sf in stat_funcs:
+        for req in sf.requires:
+            if req.type in RAW_MARKER_TYPES:
+                continue  # Raw types are provided by the executor, not the DAG
+
+            if req.name not in provides_map:
+                raise DAGConfigError(
+                    f"No function provides '{req.name}' (required by '{sf.name}')"
+                )
+
+            # Type compatibility check (warning, not error)
+            provided_key, provider_func = provides_map[req.name]
+            if (req.type is not Any and provided_key.type is not Any
+                    and req.type != provided_key.type):
+                if not (isinstance(req.type, type) and isinstance(provided_key.type, type)
+                        and issubclass(provided_key.type, req.type)):
+                    warnings.warn(
+                        f"Type mismatch: '{sf.name}' expects '{req.name}' as "
+                        f"{req.type.__name__}, but '{provider_func.name}' provides "
+                        f"{provided_key.type.__name__}. beartype will enforce at runtime.",
+                        stacklevel=2,
+                    )
+
+    # Build dependency graph for topological sort
+    # Each StatFunc is identified by its name
+    graph: Dict[str, Set[str]] = {}
+    func_map: Dict[str, StatFunc] = {}
+
+    for sf in stat_funcs:
+        func_map[sf.name] = sf
+        deps: Set[str] = set()
+        for req in sf.requires:
+            if req.type in RAW_MARKER_TYPES:
+                continue
+            if req.name in provides_map:
+                provider = provides_map[req.name][1]
+                if provider.name != sf.name:
+                    deps.add(provider.name)
+        graph[sf.name] = deps
+
+    # Topological sort
+    ts = graphlib.TopologicalSorter(graph)
+    try:
+        order = list(ts.static_order())
+    except graphlib.CycleError as e:
+        raise DAGConfigError(f"Cycle detected in stat DAG: {e}") from e
+
+    # Map back to StatFunc objects (only those in our input set)
+    return [func_map[name] for name in order if name in func_map]
+
+
+def build_column_dag(
+    all_stat_funcs: List[StatFunc],
+    column_dtype,
+) -> List[StatFunc]:
+    """Filter stat functions by column dtype and build DAG.
+
+    Functions whose column_filter rejects this dtype are excluded.
+    Functions whose requirements become unsatisfiable after filtering
+    are also excluded (cascade removal). This is NOT an error — it
+    means the stat doesn't apply to this column type.
+
+    Args:
+        all_stat_funcs: full set of stat functions
+        column_dtype: the dtype of the column being processed
+
+    Returns:
+        Topologically sorted list of applicable StatFunc objects
+    """
+    # Step 1: filter by column_filter predicate
+    candidates = [
+        sf for sf in all_stat_funcs
+        if sf.column_filter is None or sf.column_filter(column_dtype)
+    ]
+
+    # Step 2: iteratively remove funcs with unmet deps until stable
+    prev_count = -1
+    while len(candidates) != prev_count:
+        prev_count = len(candidates)
+
+        # Build current provides set
+        provides: Set[str] = set()
+        for sf in candidates:
+            for sk in sf.provides:
+                provides.add(sk.name)
+
+        # Keep only funcs whose requirements are all met
+        candidates = [
+            sf for sf in candidates
+            if all(
+                req.type in RAW_MARKER_TYPES or req.name in provides
+                for req in sf.requires
+            )
+        ]
+
+    if not candidates:
+        return []
+
+    return build_typed_dag(candidates)

--- a/buckaroo/pluggable_analysis_framework/typed_dag.py
+++ b/buckaroo/pluggable_analysis_framework/typed_dag.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import graphlib
 import warnings
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Set, Tuple
 
 from .stat_func import StatFunc, StatKey, RAW_MARKER_TYPES
 

--- a/buckaroo/pluggable_analysis_framework/v1_adapter.py
+++ b/buckaroo/pluggable_analysis_framework/v1_adapter.py
@@ -1,0 +1,166 @@
+"""V1 compatibility adapter.
+
+Converts existing ColAnalysis classes to StatFunc objects for use
+in StatPipeline. This allows mixing v1 ColAnalysis classes with
+v2 @stat functions in the same pipeline.
+
+Example::
+
+    pipeline = StatPipeline([
+        TypingStats,           # v1 ColAnalysis class
+        DefaultSummaryStats,   # v1 ColAnalysis class
+        distinct_per,          # v2 @stat function
+    ])
+"""
+from __future__ import annotations
+
+from typing import Any, List, Type
+
+from .col_analysis import ColAnalysis
+from .stat_func import StatFunc, StatKey, RawSeries, MISSING
+
+
+def _has_custom_series_summary(kls: Type[ColAnalysis]) -> bool:
+    """Check if a ColAnalysis class overrides series_summary."""
+    return (
+        kls.series_summary is not ColAnalysis.series_summary
+        or kls.requires_raw
+    )
+
+
+def _has_custom_computed_summary(kls: Type[ColAnalysis]) -> bool:
+    """Check if a ColAnalysis class overrides computed_summary."""
+    return kls.computed_summary is not ColAnalysis.computed_summary
+
+
+def col_analysis_to_stat_funcs(kls: Type[ColAnalysis]) -> List[StatFunc]:
+    """Convert a v1 ColAnalysis class into v2 StatFunc objects.
+
+    Creates one or two StatFunc objects per ColAnalysis:
+    - A "series" StatFunc if the class has a custom series_summary
+    - A "computed" StatFunc if the class has a custom computed_summary
+
+    If the class has both, the computed func depends on the series func's
+    outputs, preserving the v1 two-phase execution model.
+
+    Args:
+        kls: a ColAnalysis subclass
+
+    Returns:
+        list of StatFunc objects
+    """
+    funcs = []
+    has_series = _has_custom_series_summary(kls)
+    has_computed = _has_custom_computed_summary(kls)
+
+    # Determine which keys are provided by series vs computed phases
+    all_provided_names = set(kls.full_provides())
+    defaults = kls.provides_defaults.copy()
+
+    if has_series:
+        # Series phase provides keys from provides_series_stats + provides_defaults
+        # (v1 merges defaults first, then updates with series_summary result)
+        series_provide_names = set(kls.provides_series_stats) | set(defaults.keys())
+
+        # If there's also a computed phase, the computed phase may override some
+        # of these keys. But for DAG purposes, the series func provides them first.
+        if has_computed:
+            # Computed phase will provide its own keys. Remove keys that are
+            # ONLY set by computed (i.e., not in series_stats or defaults).
+            # In practice, v1 classes have series + computed provide different keys.
+            pass
+
+        series_provides = [StatKey(name, Any) for name in sorted(series_provide_names)]
+        series_requires = [StatKey('ser', RawSeries)]
+
+        # Capture kls and defaults in closure
+        _kls = kls
+        _defaults = defaults.copy()
+
+        def _make_series_func(kls_ref, defaults_ref):
+            def v1_series_wrapper(ser=None):
+                result = defaults_ref.copy()
+                if ser is not None:
+                    series_result = kls_ref.series_summary(ser, ser)
+                    result.update(series_result)
+                return result
+            v1_series_wrapper.__name__ = f"{kls_ref.__name__}__series"
+            v1_series_wrapper.__qualname__ = f"{kls_ref.__qualname__}__series"
+            v1_series_wrapper.__module__ = getattr(kls_ref, '__module__', __name__)
+            return v1_series_wrapper
+
+        series_func = _make_series_func(_kls, _defaults)
+
+        funcs.append(StatFunc(
+            name=f"{kls.__name__}__series",
+            func=series_func,
+            requires=series_requires,
+            provides=series_provides,
+            needs_raw=True,
+            quiet=kls.quiet,
+        ))
+
+    if has_computed and kls.requires_summary:
+        # Computed phase: takes stats from requires_summary, produces provides_defaults keys
+        computed_provide_names = set(defaults.keys())
+        # If series phase already provides some of these, the computed phase
+        # will update/override them (matching v1 behavior where computed_summary
+        # result is merged on top of series_summary result)
+        computed_provides = [StatKey(name, Any) for name in sorted(computed_provide_names)]
+
+        computed_requires = [StatKey(name, Any) for name in kls.requires_summary]
+
+        _kls = kls
+        _defaults = defaults.copy()
+        _req_names = list(kls.requires_summary)
+
+        def _make_computed_func(kls_ref, defaults_ref, req_names):
+            def v1_computed_wrapper(**kwargs):
+                # Build the summary dict that v1's computed_summary expects
+                # It should contain all stats computed so far
+                summary_dict = dict(kwargs)
+                result = defaults_ref.copy()
+                computed = kls_ref.computed_summary(summary_dict)
+                result.update(computed)
+                return result
+            v1_computed_wrapper.__name__ = f"{kls_ref.__name__}__computed"
+            v1_computed_wrapper.__qualname__ = f"{kls_ref.__qualname__}__computed"
+            v1_computed_wrapper.__module__ = getattr(kls_ref, '__module__', __name__)
+            return v1_computed_wrapper
+
+        computed_func = _make_computed_func(_kls, _defaults, _req_names)
+
+        funcs.append(StatFunc(
+            name=f"{kls.__name__}__computed",
+            func=computed_func,
+            requires=computed_requires,
+            provides=computed_provides,
+            needs_raw=False,
+            quiet=kls.quiet,
+        ))
+
+    elif not has_series and not has_computed:
+        # Class only has provides_defaults (pure defaults, no computation)
+        if defaults:
+            provide_keys = [StatKey(name, Any) for name in sorted(defaults.keys())]
+            _defaults = defaults.copy()
+            _kls_name = kls.__name__
+
+            def _make_defaults_func(defaults_ref, name):
+                def v1_defaults_wrapper():
+                    return defaults_ref.copy()
+                v1_defaults_wrapper.__name__ = name
+                return v1_defaults_wrapper
+
+            defaults_func = _make_defaults_func(_defaults, _kls_name)
+
+            funcs.append(StatFunc(
+                name=_kls_name,
+                func=defaults_func,
+                requires=[],
+                provides=provide_keys,
+                needs_raw=False,
+                quiet=kls.quiet,
+            ))
+
+    return funcs

--- a/buckaroo/pluggable_analysis_framework/v1_adapter.py
+++ b/buckaroo/pluggable_analysis_framework/v1_adapter.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from typing import Any, List, Type
 
 from .col_analysis import ColAnalysis
-from .stat_func import StatFunc, StatKey, RawSeries, MISSING
+from .stat_func import StatFunc, StatKey, RawSeries
 
 
 def _has_custom_series_summary(kls: Type[ColAnalysis]) -> bool:
@@ -53,8 +53,6 @@ def col_analysis_to_stat_funcs(kls: Type[ColAnalysis]) -> List[StatFunc]:
     has_series = _has_custom_series_summary(kls)
     has_computed = _has_custom_computed_summary(kls)
 
-    # Determine which keys are provided by series vs computed phases
-    all_provided_names = set(kls.full_provides())
     defaults = kls.provides_defaults.copy()
 
     if has_series:

--- a/buckaroo/server/data_loading.py
+++ b/buckaroo/server/data_loading.py
@@ -15,7 +15,7 @@ from buckaroo.customizations.analysis import (
 from buckaroo.customizations.histogram import Histogram
 from buckaroo.customizations.styling import DefaultSummaryStatsStyling, DefaultMainStyling
 from buckaroo.customizations.pd_autoclean_conf import CleaningConf, NoCleaningConf
-from buckaroo.pluggable_analysis_framework.analysis_management import DfStats
+from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
 
 
 class ServerSampling(Sampling):
@@ -40,7 +40,7 @@ class ServerDataflow(CustomizableDataflow):
     """Headless dataflow matching BuckarooInfiniteWidget's pipeline."""
     sampling_klass = ServerSampling
     autocleaning_klass = PandasAutocleaning
-    DFStatsClass = DfStats
+    DFStatsClass = DfStatsV2
     autoclean_conf = tuple([CleaningConf, NoCleaningConf])
     analysis_klasses = [
         TypingStats, DefaultSummaryStats,

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -1,0 +1,847 @@
+"""Comprehensive tests for the Pluggable Analysis Framework v2.
+
+Tests for: stat_func, stat_result, typed_dag, column_filters,
+stat_pipeline, v1_adapter, df_stats_v2.
+"""
+import warnings
+from typing import Any, TypedDict
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from buckaroo.pluggable_analysis_framework.stat_func import (
+    StatKey, StatFunc, RawSeries, SampledSeries, RawDataFrame,
+    RAW_MARKER_TYPES, MISSING, stat, collect_stat_funcs,
+)
+from buckaroo.pluggable_analysis_framework.stat_result import (
+    Ok, Err, UpstreamError, StatError, resolve_accumulator,
+)
+from buckaroo.pluggable_analysis_framework.typed_dag import (
+    build_typed_dag, build_column_dag, DAGConfigError,
+)
+from buckaroo.pluggable_analysis_framework.column_filters import (
+    is_numeric, is_string, is_temporal, is_boolean, any_of, not_,
+)
+from buckaroo.pluggable_analysis_framework.stat_pipeline import (
+    StatPipeline, _normalize_inputs,
+)
+from buckaroo.pluggable_analysis_framework.v1_adapter import (
+    col_analysis_to_stat_funcs,
+)
+from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis
+from buckaroo.pluggable_analysis_framework.utils import PERVERSE_DF
+
+
+# ============================================================================
+# Test fixtures — v2 stat functions
+# ============================================================================
+
+# Note: The function name becomes the stat key in the DAG.
+# So `length` provides 'length', `distinct_count` provides 'distinct_count', etc.
+
+@stat()
+def length(ser: RawSeries) -> int:
+    return len(ser)
+
+
+@stat()
+def null_count(ser: RawSeries) -> int:
+    return int(ser.isna().sum())
+
+
+@stat()
+def distinct_count(ser: RawSeries) -> int:
+    return len(ser.value_counts())
+
+
+@stat()
+def distinct_per(length: int, distinct_count: int) -> float:
+    return distinct_count / length
+
+
+@stat()
+def nan_per(length: int, null_count: int) -> float:
+    return null_count / length if length > 0 else 0.0
+
+
+@stat(column_filter=is_numeric)
+def mean_stat(ser: RawSeries) -> float:
+    return float(ser.mean())
+
+
+@stat(default=0.0)
+def safe_ratio(length: int, distinct_count: int) -> float:
+    return distinct_count / length
+
+
+class FreqStats(TypedDict):
+    most_freq: Any
+    freq_count: int
+
+
+@stat()
+def freq_stats(ser: RawSeries) -> FreqStats:
+    vc = ser.value_counts()
+    if len(vc) > 0:
+        return FreqStats(most_freq=vc.index[0], freq_count=int(vc.iloc[0]))
+    return FreqStats(most_freq=None, freq_count=0)
+
+
+# Stat group class
+class BasicStats:
+    @stat()
+    def grp_length(ser: RawSeries) -> int:
+        return len(ser)
+
+    @stat()
+    def grp_null_count(ser: RawSeries) -> int:
+        return int(ser.isna().sum())
+
+
+# V1 ColAnalysis fixtures
+class V1Len(ColAnalysis):
+    provides_defaults = {'length': 0}
+    provides_series_stats = ['length']
+
+    @staticmethod
+    def series_summary(sampled_ser, ser):
+        return {'length': len(ser)}
+
+
+class V1DistinctCount(ColAnalysis):
+    provides_defaults = {'distinct_count': 0}
+    provides_series_stats = ['distinct_count']
+
+    @staticmethod
+    def series_summary(sampled_ser, ser):
+        return {'distinct_count': len(ser.value_counts())}
+
+
+class V1DistinctPer(ColAnalysis):
+    provides_defaults = {'distinct_per': 0.0}
+    requires_summary = ['length', 'distinct_count']
+
+    @staticmethod
+    def computed_summary(summary_dict):
+        l = summary_dict['length']
+        dc = summary_dict['distinct_count']
+        return {'distinct_per': dc / l if l > 0 else 0.0}
+
+
+class V1Combined(ColAnalysis):
+    """V1 class with both series_summary and computed_summary."""
+    provides_defaults = {'raw_len': 0, 'doubled_len': 0}
+    provides_series_stats = ['raw_len']
+    requires_summary = ['raw_len']
+
+    @staticmethod
+    def series_summary(sampled_ser, ser):
+        return {'raw_len': len(ser)}
+
+    @staticmethod
+    def computed_summary(summary_dict):
+        return {'doubled_len': summary_dict.get('raw_len', 0) * 2}
+
+
+# ============================================================================
+# Tests: stat_func
+# ============================================================================
+
+class TestStatDecorator:
+    def test_basic_raw_series(self):
+        sf = length._stat_func
+        assert sf.name == 'length'
+        assert len(sf.requires) == 1
+        assert sf.requires[0].name == 'ser'
+        assert sf.requires[0].type is RawSeries
+        assert sf.needs_raw is True
+        assert len(sf.provides) == 1
+        assert sf.provides[0].name == 'length'
+        assert sf.provides[0].type is int
+
+    def test_computed_stat(self):
+        sf = distinct_per._stat_func
+        assert sf.name == 'distinct_per'
+        assert sf.needs_raw is False
+        assert len(sf.requires) == 2
+        req_names = {r.name for r in sf.requires}
+        assert req_names == {'length', 'distinct_count'}
+        assert sf.requires[0].type is int
+        assert sf.provides[0].name == 'distinct_per'
+        assert sf.provides[0].type is float
+
+    def test_typed_dict_return(self):
+        sf = freq_stats._stat_func
+        assert sf.name == 'freq_stats'
+        assert len(sf.provides) == 2
+        prov_names = {p.name for p in sf.provides}
+        assert prov_names == {'most_freq', 'freq_count'}
+
+    def test_column_filter(self):
+        sf = mean_stat._stat_func
+        assert sf.column_filter is is_numeric
+
+    def test_default(self):
+        sf = safe_ratio._stat_func
+        assert sf.default == 0.0
+
+    def test_no_default(self):
+        sf = distinct_per._stat_func
+        assert sf.default is MISSING
+
+
+class TestStatKey:
+    def test_frozen(self):
+        sk = StatKey('foo', int)
+        with pytest.raises(AttributeError):
+            sk.name = 'bar'
+
+    def test_equality(self):
+        assert StatKey('foo', int) == StatKey('foo', int)
+        assert StatKey('foo', int) != StatKey('foo', float)
+
+    def test_repr(self):
+        sk = StatKey('length', int)
+        assert 'length' in repr(sk)
+        assert 'int' in repr(sk)
+
+
+class TestCollectStatFuncs:
+    def test_from_stat_func(self):
+        sf = length._stat_func
+        assert collect_stat_funcs(sf) == [sf]
+
+    def test_from_decorated_function(self):
+        funcs = collect_stat_funcs(length)
+        assert len(funcs) == 1
+        assert funcs[0].name == 'length'
+
+    def test_from_class(self):
+        funcs = collect_stat_funcs(BasicStats)
+        assert len(funcs) == 2
+        names = {f.name for f in funcs}
+        assert names == {'grp_length', 'grp_null_count'}
+
+    def test_from_unknown(self):
+        assert collect_stat_funcs(42) == []
+        assert collect_stat_funcs("hello") == []
+
+
+class TestMissingSentinel:
+    def test_singleton(self):
+        assert MISSING is MISSING
+
+    def test_falsy(self):
+        assert not MISSING
+
+    def test_repr(self):
+        assert repr(MISSING) == '<MISSING>'
+
+
+# ============================================================================
+# Tests: stat_result
+# ============================================================================
+
+class TestOkErr:
+    def test_ok(self):
+        r = Ok(42)
+        assert r.value == 42
+
+    def test_ok_frozen(self):
+        r = Ok(42)
+        with pytest.raises(AttributeError):
+            r.value = 99
+
+    def test_err(self):
+        e = Err(
+            error=ValueError("bad"),
+            stat_func_name="test",
+            column_name="col1",
+            inputs={'a': 1},
+        )
+        assert isinstance(e.error, ValueError)
+        assert e.stat_func_name == 'test'
+        assert e.column_name == 'col1'
+        assert e.inputs == {'a': 1}
+
+    def test_upstream_error(self):
+        orig = ValueError("original")
+        ue = UpstreamError("downstream", "input_x", orig)
+        assert "downstream" in str(ue)
+        assert "input_x" in str(ue)
+        assert ue.original_error is orig
+
+
+class TestResolveAccumulator:
+    def test_all_ok(self):
+        acc = {'a': Ok(1), 'b': Ok('hello')}
+        plain, errors = resolve_accumulator(acc, 'col1')
+        assert plain == {'a': 1, 'b': 'hello'}
+        assert errors == []
+
+    def test_with_err(self):
+        acc = {
+            'a': Ok(1),
+            'b': Err(ValueError("bad"), "func", "col1"),
+        }
+        plain, errors = resolve_accumulator(acc, 'col1')
+        assert plain['a'] == 1
+        assert plain['b'] is None
+        assert len(errors) == 1
+        assert errors[0].stat_key == 'b'
+
+    def test_with_key_to_func(self):
+        sf = StatFunc(
+            name='test', func=lambda: None,
+            requires=[], provides=[StatKey('a', int)],
+            needs_raw=False,
+        )
+        acc = {'a': Err(ValueError("bad"), "test", "col1")}
+        _, errors = resolve_accumulator(acc, 'col1', {'a': sf})
+        assert errors[0].stat_func is sf
+
+
+class TestStatError:
+    def test_reproduce_code_scalar(self):
+        sf = StatFunc(
+            name='distinct_per', func=distinct_per,
+            requires=[StatKey('length', int), StatKey('distinct_count', int)],
+            provides=[StatKey('distinct_per', float)],
+            needs_raw=False,
+        )
+        se = StatError(
+            column='col1', stat_key='distinct_per',
+            error=ZeroDivisionError('division by zero'),
+            stat_func=sf,
+            inputs={'length': 0, 'distinct_count': 0},
+        )
+        code = se.reproduce_code()
+        assert 'distinct_per' in code
+        assert 'ZeroDivisionError' in code
+        assert 'length=0' in code
+
+    def test_reproduce_code_series(self):
+        sf = StatFunc(
+            name='length', func=length,
+            requires=[StatKey('ser', RawSeries)],
+            provides=[StatKey('length', int)],
+            needs_raw=True,
+        )
+        ser = pd.Series([1, 2, 3])
+        se = StatError(
+            column='col1', stat_key='length',
+            error=TypeError('test'),
+            stat_func=sf,
+            inputs={'ser': ser},
+        )
+        code = se.reproduce_code()
+        assert 'pd.Series' in code
+        assert 'TypeError' in code
+
+
+# ============================================================================
+# Tests: typed_dag
+# ============================================================================
+
+class TestBuildTypedDag:
+    def test_basic_ordering(self):
+        f1 = StatFunc('length', lambda: 10, [], [StatKey('length', int)], False)
+        f2 = StatFunc('dc', lambda: 5, [], [StatKey('distinct_count', int)], False)
+        f3 = StatFunc(
+            'dp', lambda l, d: d / l,
+            [StatKey('length', int), StatKey('distinct_count', int)],
+            [StatKey('distinct_per', float)],
+            False,
+        )
+        ordered = build_typed_dag([f3, f1, f2])
+        names = [f.name for f in ordered]
+        assert names.index('length') < names.index('dp')
+        assert names.index('dc') < names.index('dp')
+
+    def test_missing_provider(self):
+        f1 = StatFunc(
+            'dp', lambda: None,
+            [StatKey('nonexistent', int)],
+            [StatKey('result', float)],
+            False,
+        )
+        with pytest.raises(DAGConfigError, match='nonexistent'):
+            build_typed_dag([f1])
+
+    def test_raw_types_not_validated(self):
+        """RawSeries requirements should not raise DAGConfigError."""
+        f1 = StatFunc(
+            'length', lambda ser: len(ser),
+            [StatKey('ser', RawSeries)],
+            [StatKey('length', int)],
+            True,
+        )
+        ordered = build_typed_dag([f1])
+        assert len(ordered) == 1
+
+    def test_cycle_detection(self):
+        f1 = StatFunc(
+            'a', lambda: None,
+            [StatKey('b', int)], [StatKey('a', int)], False,
+        )
+        f2 = StatFunc(
+            'b', lambda: None,
+            [StatKey('a', int)], [StatKey('b', int)], False,
+        )
+        with pytest.raises(DAGConfigError, match='[Cc]ycle'):
+            build_typed_dag([f1, f2])
+
+    def test_type_mismatch_warning(self):
+        f1 = StatFunc('a', lambda: 1.5, [], [StatKey('x', float)], False)
+        f2 = StatFunc(
+            'b', lambda: None,
+            [StatKey('x', int)], [StatKey('y', int)], False,
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            build_typed_dag([f1, f2])
+            assert len(w) == 1
+            assert 'mismatch' in str(w[0].message).lower()
+
+    def test_empty_input(self):
+        assert build_typed_dag([]) == []
+
+
+class TestBuildColumnDag:
+    def test_filters_by_dtype(self):
+        f_numeric = StatFunc(
+            'mean', lambda: 0.0, [StatKey('ser', RawSeries)],
+            [StatKey('mean', float)], True,
+            column_filter=is_numeric,
+        )
+        f_all = StatFunc(
+            'length', lambda: 0, [StatKey('ser', RawSeries)],
+            [StatKey('length', int)], True,
+        )
+
+        # Numeric column — both should be included
+        result = build_column_dag([f_numeric, f_all], pd.Series([1]).dtype)
+        assert len(result) == 2
+
+        # String column — only f_all should be included
+        result = build_column_dag([f_numeric, f_all], pd.Series(['a']).dtype)
+        assert len(result) == 1
+        assert result[0].name == 'length'
+
+    def test_cascade_removal(self):
+        """If a filtered-out func provides a key needed by another, cascade remove."""
+        f1 = StatFunc(
+            'mean', lambda: 0.0, [StatKey('ser', RawSeries)],
+            [StatKey('mean', float)], True,
+            column_filter=is_numeric,
+        )
+        f2 = StatFunc(
+            'mean_ratio', lambda: 0.0,
+            [StatKey('mean', float)],
+            [StatKey('mean_ratio', float)], False,
+        )
+        f3 = StatFunc(
+            'length', lambda: 0, [StatKey('ser', RawSeries)],
+            [StatKey('length', int)], True,
+        )
+
+        # String column: mean is filtered out, mean_ratio cascades out
+        result = build_column_dag([f1, f2, f3], pd.Series(['a']).dtype)
+        assert len(result) == 1
+        assert result[0].name == 'length'
+
+
+# ============================================================================
+# Tests: column_filters
+# ============================================================================
+
+class TestColumnFilters:
+    def test_is_numeric_pandas(self):
+        assert is_numeric(pd.Series([1]).dtype) is True
+        assert is_numeric(pd.Series([1.0]).dtype) is True
+        assert is_numeric(pd.Series(['a']).dtype) is False
+        assert is_numeric(pd.Series([True]).dtype) is True
+
+    def test_is_numeric_nullable(self):
+        assert is_numeric(pd.Series([1], dtype='Int64').dtype) is True
+        assert is_numeric(pd.Series([None], dtype='UInt8').dtype) is True
+
+    def test_is_string_pandas(self):
+        assert is_string(pd.Series(['a']).dtype) is True
+        assert is_string(pd.Series([1]).dtype) is False
+
+    def test_is_temporal_pandas(self):
+        assert is_temporal(pd.Series(pd.to_datetime(['2021-01-01'])).dtype) is True
+        assert is_temporal(pd.Series([1]).dtype) is False
+
+    def test_is_boolean_pandas(self):
+        assert is_boolean(pd.Series([True, False]).dtype) is True
+        assert is_boolean(pd.Series([1]).dtype) is False
+
+    def test_any_of(self):
+        pred = any_of(is_numeric, is_string)
+        assert pred(pd.Series([1]).dtype) is True
+        assert pred(pd.Series(['a']).dtype) is True
+        assert pred(pd.Series(pd.to_datetime(['2021-01-01'])).dtype) is False
+
+    def test_not_(self):
+        pred = not_(is_numeric)
+        assert pred(pd.Series([1]).dtype) is False
+        assert pred(pd.Series(['a']).dtype) is True
+
+
+# ============================================================================
+# Tests: v1_adapter
+# ============================================================================
+
+class TestV1Adapter:
+    def test_series_only_class(self):
+        funcs = col_analysis_to_stat_funcs(V1Len)
+        assert len(funcs) == 1
+        sf = funcs[0]
+        assert sf.name == 'V1Len__series'
+        assert sf.needs_raw is True
+        prov_names = {sk.name for sk in sf.provides}
+        assert 'length' in prov_names
+
+    def test_computed_only_class(self):
+        funcs = col_analysis_to_stat_funcs(V1DistinctPer)
+        assert len(funcs) == 1
+        sf = funcs[0]
+        assert sf.name == 'V1DistinctPer__computed'
+        assert sf.needs_raw is False
+        req_names = {sk.name for sk in sf.requires}
+        assert req_names == {'length', 'distinct_count'}
+
+    def test_combined_class(self):
+        """Class with both series_summary and computed_summary."""
+        funcs = col_analysis_to_stat_funcs(V1Combined)
+        assert len(funcs) == 2
+        names = {f.name for f in funcs}
+        assert 'V1Combined__series' in names
+        assert 'V1Combined__computed' in names
+
+    def test_series_func_executes(self):
+        funcs = col_analysis_to_stat_funcs(V1Len)
+        sf = funcs[0]
+        result = sf.func(ser=pd.Series([1, 2, 3]))
+        assert isinstance(result, dict)
+        assert result['length'] == 3
+
+    def test_computed_func_executes(self):
+        funcs = col_analysis_to_stat_funcs(V1DistinctPer)
+        sf = funcs[0]
+        result = sf.func(length=10, distinct_count=5)
+        assert isinstance(result, dict)
+        assert result['distinct_per'] == 0.5
+
+
+# ============================================================================
+# Tests: stat_pipeline
+# ============================================================================
+
+class TestNormalizeInputs:
+    def test_stat_func_passthrough(self):
+        sf = length._stat_func
+        result = _normalize_inputs([sf])
+        assert result == [sf]
+
+    def test_decorated_function(self):
+        result = _normalize_inputs([length])
+        assert len(result) == 1
+        assert result[0].name == 'length'
+
+    def test_stat_group_class(self):
+        result = _normalize_inputs([BasicStats])
+        assert len(result) == 2
+
+    def test_v1_col_analysis(self):
+        result = _normalize_inputs([V1Len])
+        assert len(result) == 1
+        assert result[0].name == 'V1Len__series'
+
+    def test_invalid_input(self):
+        with pytest.raises(TypeError):
+            _normalize_inputs([42])
+
+    def test_mixed_inputs(self):
+        result = _normalize_inputs([V1Len, distinct_count, BasicStats])
+        assert len(result) >= 3
+
+
+class TestStatPipeline:
+    def test_basic_pipeline(self):
+        pipeline = StatPipeline(
+            [length, distinct_count, distinct_per],
+            unit_test=False,
+        )
+        assert 'distinct_per' in pipeline.provided_summary_facts_set
+        assert 'length' in pipeline.provided_summary_facts_set
+
+    def test_process_column(self):
+        pipeline = StatPipeline(
+            [length, distinct_count, distinct_per],
+            unit_test=False,
+        )
+        ser = pd.Series([1, 2, 3, 1, 2])
+        result, errors = pipeline.process_column(
+            column_name='test',
+            column_dtype=ser.dtype,
+            raw_series=ser,
+        )
+        assert result['length'] == 5
+        assert result['distinct_count'] == 3
+        assert result['distinct_per'] == 3 / 5
+        assert errors == []
+
+    def test_process_df(self):
+        pipeline = StatPipeline(
+            [length, null_count, nan_per],
+            unit_test=False,
+        )
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': [None, 2, None]})
+        result, errors = pipeline.process_df(df)
+        assert len(result) == 2
+
+        for col_key, col_stats in result.items():
+            assert 'length' in col_stats
+            assert 'null_count' in col_stats
+            assert 'nan_per' in col_stats
+
+    def test_error_propagation(self):
+        """Errors should propagate downstream via UpstreamError."""
+        @stat()
+        def always_fails(ser: RawSeries) -> int:
+            raise ValueError("intentional failure")
+
+        @stat()
+        def depends_on_fail(always_fails: int) -> float:
+            return always_fails * 2.0
+
+        pipeline = StatPipeline(
+            [always_fails, depends_on_fail],
+            unit_test=False,
+        )
+        ser = pd.Series([1, 2, 3])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+
+        assert result['always_fails'] is None
+        assert result['depends_on_fail'] is None
+        assert len(errors) >= 1
+
+    def test_default_fallback(self):
+        """@stat(default=...) should produce Ok(default) on error."""
+        @stat(default=-1)
+        def fails_with_default(ser: RawSeries) -> int:
+            raise ValueError("intentional")
+
+        pipeline = StatPipeline([fails_with_default], unit_test=False)
+        ser = pd.Series([1, 2, 3])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['fails_with_default'] == -1
+        assert errors == []
+
+    def test_column_filter(self):
+        """Numeric-only stat should not appear for string columns."""
+        pipeline = StatPipeline(
+            [length, mean_stat],
+            unit_test=False,
+        )
+        df = pd.DataFrame({'nums': [1, 2, 3], 'strs': ['a', 'b', 'c']})
+        result, errors = pipeline.process_df(df)
+
+        for col_key, col_stats in result.items():
+            if col_stats.get('orig_col_name') == 'strs':
+                assert 'mean_stat' not in col_stats
+            elif col_stats.get('orig_col_name') == 'nums':
+                assert 'mean_stat' in col_stats
+
+    def test_typed_dict_return(self):
+        pipeline = StatPipeline([freq_stats], unit_test=False)
+        ser = pd.Series([1, 1, 2, 3])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['most_freq'] == 1
+        assert result['freq_count'] == 2
+
+    def test_v1_compat_mixed(self):
+        """Mix v1 and v2 in the same pipeline."""
+        pipeline = StatPipeline(
+            [V1Len, V1DistinctCount, distinct_per],
+            unit_test=False,
+        )
+        ser = pd.Series([1, 2, 3, 1])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['length'] == 4
+        assert result['distinct_count'] == 3
+        assert result['distinct_per'] == 3 / 4
+
+    def test_explain(self):
+        pipeline = StatPipeline([length, distinct_per, distinct_count], unit_test=False)
+        explanation = pipeline.explain('distinct_per')
+        assert 'distinct_per' in explanation
+        assert 'length' in explanation
+        assert 'distinct_count' in explanation
+
+    def test_test_stat(self):
+        pipeline = StatPipeline([length, distinct_count, distinct_per], unit_test=False)
+        result = pipeline.test_stat('distinct_per', {'length': 10, 'distinct_count': 5})
+        assert isinstance(result, Ok)
+        assert result.value == 0.5
+
+    def test_test_stat_error(self):
+        pipeline = StatPipeline([length, distinct_count, distinct_per], unit_test=False)
+        result = pipeline.test_stat('distinct_per', {'length': 0, 'distinct_count': 0})
+        assert isinstance(result, Err)
+
+    def test_add_stat(self):
+        pipeline = StatPipeline([length, distinct_count], unit_test=False)
+        assert 'distinct_per' not in pipeline.provided_summary_facts_set
+        passed, errors = pipeline.add_stat(distinct_per)
+        assert 'distinct_per' in pipeline.provided_summary_facts_set
+
+    def test_dag_config_error(self):
+        """Pipeline should raise DAGConfigError for unsatisfiable deps."""
+        with pytest.raises(DAGConfigError):
+            StatPipeline([distinct_per], unit_test=False)
+
+    def test_process_perverse_df(self):
+        """Pipeline should handle PERVERSE_DF without crashing."""
+        pipeline = StatPipeline(
+            [length, null_count, distinct_count, nan_per, distinct_per],
+            unit_test=False,
+        )
+        result, errors = pipeline.process_df(PERVERSE_DF)
+        assert len(result) == len(PERVERSE_DF.columns)
+
+    def test_empty_df(self):
+        pipeline = StatPipeline([length], unit_test=False)
+        result, errors = pipeline.process_df(pd.DataFrame({}))
+        assert result == {}
+        assert errors == []
+
+    def test_unit_test_runs(self):
+        pipeline = StatPipeline(
+            [length, null_count, nan_per],
+            unit_test=True,
+        )
+        passed, errors = pipeline._unit_test_result
+        assert passed is True
+
+
+class TestStatPipelineV1Compat:
+    """Test backward compatibility with v1 ColAnalysis classes."""
+
+    def test_v1_only_pipeline(self):
+        pipeline = StatPipeline(
+            [V1Len, V1DistinctCount, V1DistinctPer],
+            unit_test=False,
+        )
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': [1, 1, 1]})
+        result, errors = pipeline.process_df(df)
+        assert len(result) == 2
+
+        for col_key, col_stats in result.items():
+            assert 'length' in col_stats
+            assert 'distinct_count' in col_stats
+            assert 'distinct_per' in col_stats
+
+    def test_v1_process_df_v1_compat(self):
+        """process_df_v1_compat should return ErrDict format."""
+        pipeline = StatPipeline([V1Len], unit_test=False)
+        df = pd.DataFrame({'a': [1, 2, 3]})
+        result, errs = pipeline.process_df_v1_compat(df)
+        assert isinstance(errs, dict)
+        assert len(errs) == 0
+
+
+# ============================================================================
+# Tests: df_stats_v2
+# ============================================================================
+
+class TestDfStatsV2:
+    def test_basic_usage(self):
+        from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': [4, 5, 6]})
+        stats = DfStatsV2(df, [V1Len, V1DistinctCount, V1DistinctPer])
+        assert isinstance(stats.sdf, dict)
+        assert len(stats.sdf) == 2
+
+    def test_interface_matches_dfstats(self):
+        from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
+        df = pd.DataFrame({'x': [1, 2, 3]})
+        stats = DfStatsV2(df, [V1Len])
+        assert hasattr(stats, 'sdf')
+        assert hasattr(stats, 'errs')
+        assert hasattr(stats, 'df')
+        assert hasattr(stats, 'col_order')
+        assert hasattr(stats, 'ap')
+
+
+# ============================================================================
+# Integration tests
+# ============================================================================
+
+class TestIntegration:
+    def test_mix_v1_v2_pipeline(self):
+        """The primary integration test from the plan: mix v1 and v2."""
+        pipeline = StatPipeline([
+            V1Len,             # v1 ColAnalysis (series only)
+            V1DistinctCount,   # v1 ColAnalysis (series only)
+            distinct_per,      # v2 @stat function
+        ], unit_test=False)
+
+        ser = pd.Series([1, 2, 3, 1, 2])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['length'] == 5
+        assert result['distinct_count'] == 3
+        assert result['distinct_per'] == 3 / 5
+        assert errors == []
+
+    def test_full_pipeline_on_perverse_df(self):
+        """Run a realistic pipeline on PERVERSE_DF."""
+        pipeline = StatPipeline([
+            length,
+            null_count,
+            distinct_count,
+            nan_per,
+            distinct_per,
+        ], unit_test=False)
+
+        result, errors = pipeline.process_df(PERVERSE_DF)
+        assert len(result) == len(PERVERSE_DF.columns)
+
+        for col_key, col_stats in result.items():
+            assert 'length' in col_stats
+            assert 'null_count' in col_stats
+            assert 'distinct_count' in col_stats
+            assert 'nan_per' in col_stats
+            assert 'distinct_per' in col_stats
+
+    def test_error_chain_reproduction(self):
+        """Verify error reproduction code is generated."""
+        @stat()
+        def bad_stat(ser: RawSeries) -> float:
+            raise RuntimeError("intentional test error")
+
+        pipeline = StatPipeline([bad_stat], unit_test=False)
+        ser = pd.Series([1, 2, 3])
+        _, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert len(errors) == 1
+        code = errors[0].reproduce_code()
+        assert 'RuntimeError' in code
+        assert 'bad_stat' in code
+
+    def test_backward_compat_output(self):
+        """V1 and V2 pipelines should produce matching stat values."""
+        v1_klasses = [V1Len, V1DistinctCount, V1DistinctPer]
+        v2_pipeline = StatPipeline(v1_klasses, unit_test=False)
+
+        df = pd.DataFrame({'a': [1, 2, 3, 1], 'b': ['x', 'y', 'x', 'x']})
+        v2_result, v2_errors = v2_pipeline.process_df(df)
+
+        # Verify expected stat values
+        for col_key, col_stats in v2_result.items():
+            assert col_stats['length'] == 4
+            assert isinstance(col_stats['distinct_per'], float)
+            assert col_stats['distinct_per'] > 0

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -6,13 +6,12 @@ stat_pipeline, v1_adapter, df_stats_v2.
 import warnings
 from typing import Any, TypedDict
 
-import numpy as np
 import pandas as pd
 import pytest
 
 from buckaroo.pluggable_analysis_framework.stat_func import (
-    StatKey, StatFunc, RawSeries, SampledSeries, RawDataFrame,
-    RAW_MARKER_TYPES, MISSING, stat, collect_stat_funcs,
+    StatKey, StatFunc, RawSeries,
+    MISSING, stat, collect_stat_funcs,
 )
 from buckaroo.pluggable_analysis_framework.stat_result import (
     Ok, Err, UpstreamError, StatError, resolve_accumulator,
@@ -124,9 +123,9 @@ class V1DistinctPer(ColAnalysis):
 
     @staticmethod
     def computed_summary(summary_dict):
-        l = summary_dict['length']
+        length = summary_dict['length']
         dc = summary_dict['distinct_count']
-        return {'distinct_per': dc / l if l > 0 else 0.0}
+        return {'distinct_per': dc / length if length > 0 else 0.0}
 
 
 class V1Combined(ColAnalysis):
@@ -349,7 +348,7 @@ class TestBuildTypedDag:
         f1 = StatFunc('length', lambda: 10, [], [StatKey('length', int)], False)
         f2 = StatFunc('dc', lambda: 5, [], [StatKey('distinct_count', int)], False)
         f3 = StatFunc(
-            'dp', lambda l, d: d / l,
+            'dp', lambda length, d: d / length,
             [StatKey('length', int), StatKey('distinct_count', int)],
             [StatKey('distinct_per', float)],
             False,

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -531,7 +531,7 @@ class TestV1Adapter:
     def test_computed_func_executes(self):
         funcs = col_analysis_to_stat_funcs(V1DistinctPer)
         sf = funcs[0]
-        result = sf.func(length=10, distinct_count=5)
+        result = sf.func({'length': 10, 'distinct_count': 5})
         assert isinstance(result, dict)
         assert result['distinct_per'] == 0.5
 

--- a/tests/unit/test_pd_stats_v2.py
+++ b/tests/unit/test_pd_stats_v2.py
@@ -1,0 +1,477 @@
+"""Tests for v2 @stat function equivalents of v1 ColAnalysis classes.
+
+Tests for: typing_stats, _type, default_summary_stats,
+computed_default_summary_stats, histogram, pd_cleaning_stats,
+heuristic_fracs, and full pipeline integration.
+"""
+import numpy as np
+import pandas as pd
+
+from buckaroo.pluggable_analysis_framework.stat_pipeline import StatPipeline
+from buckaroo.pluggable_analysis_framework.utils import PERVERSE_DF
+
+from buckaroo.customizations.pd_stats_v2 import (
+    typing_stats, _type,
+    default_summary_stats, computed_default_summary_stats,
+    histogram_series, histogram,
+    pd_cleaning_stats, heuristic_fracs,
+    orig_col_name,
+    PD_ANALYSIS_V2,
+)
+
+
+# ============================================================================
+# Tests: typing_stats
+# ============================================================================
+
+class TestTypingStats:
+    def test_numeric_int(self):
+        pipeline = StatPipeline([typing_stats], unit_test=False)
+        ser = pd.Series([1, 2, 3])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert errors == []
+        assert result['is_numeric'] is True
+        assert result['is_integer'] is True
+        assert result['is_float'] is False
+        assert result['is_bool'] is False
+        assert result['dtype'] == str(ser.dtype)
+
+    def test_numeric_float(self):
+        pipeline = StatPipeline([typing_stats], unit_test=False)
+        ser = pd.Series([1.0, 2.5, 3.0])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['is_float'] is True
+        assert result['is_numeric'] is True
+
+    def test_string(self):
+        pipeline = StatPipeline([typing_stats], unit_test=False)
+        ser = pd.Series(['a', 'b', 'c'])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['is_string'] is True
+        assert result['is_numeric'] is False
+
+    def test_bool(self):
+        pipeline = StatPipeline([typing_stats], unit_test=False)
+        ser = pd.Series([True, False, True])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['is_bool'] is True
+
+    def test_datetime(self):
+        pipeline = StatPipeline([typing_stats], unit_test=False)
+        ser = pd.Series(pd.to_datetime(['2021-01-01', '2021-01-02']))
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['is_datetime'] is True
+
+    def test_memory_usage(self):
+        pipeline = StatPipeline([typing_stats], unit_test=False)
+        ser = pd.Series([1, 2, 3])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['memory_usage'] > 0
+
+
+# ============================================================================
+# Tests: _type
+# ============================================================================
+
+class TestTypeComputed:
+    def _run(self, ser):
+        pipeline = StatPipeline([typing_stats, _type], unit_test=False)
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        return result['_type']
+
+    def test_integer(self):
+        assert self._run(pd.Series([1, 2, 3])) == 'integer'
+
+    def test_float(self):
+        assert self._run(pd.Series([1.0, 2.0, 3.0])) == 'float'
+
+    def test_string(self):
+        assert self._run(pd.Series(['a', 'b', 'c'])) == 'string'
+
+    def test_boolean(self):
+        assert self._run(pd.Series([True, False])) == 'boolean'
+
+    def test_datetime(self):
+        assert self._run(pd.Series(pd.to_datetime(['2021-01-01']))) == 'datetime'
+
+
+# ============================================================================
+# Tests: default_summary_stats
+# ============================================================================
+
+class TestDefaultSummaryStats:
+    def test_numeric_basics(self):
+        pipeline = StatPipeline([default_summary_stats], unit_test=False)
+        ser = pd.Series([1, 2, 3, 4, 5])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert errors == []
+        assert result['length'] == 5
+        assert result['null_count'] == 0
+        assert result['mean'] == 3.0
+        assert result['min'] == 1
+        assert result['max'] == 5
+
+    def test_with_nulls(self):
+        pipeline = StatPipeline([default_summary_stats], unit_test=False)
+        ser = pd.Series([1, None, 3, None, 5])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['null_count'] == 2
+        assert result['length'] == 5
+
+    def test_string_column(self):
+        pipeline = StatPipeline([default_summary_stats], unit_test=False)
+        ser = pd.Series(['a', 'b', 'c'])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['length'] == 3
+        assert result['mean'] == 0  # Default for non-numeric
+        assert result['std'] == 0
+
+    def test_bool_column(self):
+        """Bool columns should NOT get numeric stats."""
+        pipeline = StatPipeline([default_summary_stats], unit_test=False)
+        ser = pd.Series([True, False, True])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['length'] == 3
+        assert result['mean'] == 0  # Bools treated as non-numeric for stats
+
+    def test_value_counts_present(self):
+        pipeline = StatPipeline([default_summary_stats], unit_test=False)
+        ser = pd.Series([1, 1, 2, 3])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert isinstance(result['value_counts'], pd.Series)
+        assert result['value_counts'].iloc[0] == 2  # '1' is most frequent
+
+
+# ============================================================================
+# Tests: computed_default_summary_stats
+# ============================================================================
+
+class TestComputedDefaultSummaryStats:
+    def test_basic_computed(self):
+        pipeline = StatPipeline(
+            [default_summary_stats, computed_default_summary_stats],
+            unit_test=False,
+        )
+        ser = pd.Series([1, 2, 3, 1, 2])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert errors == []
+        assert result['distinct_count'] == 3
+        assert result['distinct_per'] == 3 / 5
+        assert result['nan_per'] == 0
+        assert result['non_null_count'] == 5
+        assert result['most_freq'] == 1  # most common value
+
+    def test_with_nulls(self):
+        pipeline = StatPipeline(
+            [default_summary_stats, computed_default_summary_stats],
+            unit_test=False,
+        )
+        ser = pd.Series([1, None, 2, None, 1])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['nan_per'] == 2 / 5
+        assert result['non_null_count'] == 3
+
+    def test_freq_values(self):
+        pipeline = StatPipeline(
+            [default_summary_stats, computed_default_summary_stats],
+            unit_test=False,
+        )
+        ser = pd.Series(['a', 'b', 'c', 'd', 'e', 'f'])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['most_freq'] is not None
+        assert result['5th_freq'] is not None
+        # 6th doesn't exist in provides, but all 5 freq slots filled
+        assert result['2nd_freq'] is not None
+
+
+# ============================================================================
+# Tests: histogram
+# ============================================================================
+
+class TestHistogram:
+    def _make_pipeline(self):
+        return StatPipeline(
+            [typing_stats, default_summary_stats,
+             computed_default_summary_stats,
+             histogram_series, histogram],
+            unit_test=False,
+        )
+
+    def test_numeric_histogram(self):
+        pipeline = self._make_pipeline()
+        ser = pd.Series(np.random.randn(100))
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert 'histogram' in result
+        assert isinstance(result['histogram'], list)
+        assert len(result['histogram']) > 0
+
+    def test_string_histogram(self):
+        pipeline = self._make_pipeline()
+        ser = pd.Series(['a', 'b', 'c', 'a', 'b'])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert 'histogram' in result
+        assert isinstance(result['histogram'], list)
+
+    def test_bool_histogram(self):
+        """Bool columns get categorical histogram."""
+        pipeline = self._make_pipeline()
+        ser = pd.Series([True, False, True, True])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert 'histogram' in result
+        assert isinstance(result['histogram'], list)
+
+    def test_all_null_numeric(self):
+        """All-null numeric column should still produce histogram."""
+        pipeline = self._make_pipeline()
+        ser = pd.Series([None, None, None], dtype='float64')
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert 'histogram' in result
+
+
+# ============================================================================
+# Tests: pd_cleaning_stats
+# ============================================================================
+
+class TestPdCleaningStats:
+    def test_numeric_column(self):
+        pipeline = StatPipeline(
+            [default_summary_stats, pd_cleaning_stats],
+            unit_test=False,
+        )
+        ser = pd.Series([1, 2, 3, 4, 5])
+        result, errors = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert 'int_parse' in result
+        assert 'int_parse_fail' in result
+        assert result['int_parse'] == 1.0  # All values are parseable
+
+    def test_string_column(self):
+        pipeline = StatPipeline(
+            [default_summary_stats, pd_cleaning_stats],
+            unit_test=False,
+        )
+        ser = pd.Series(['abc', 'def', '123', '456'])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['int_parse'] > 0
+        assert result['int_parse_fail'] > 0
+
+
+# ============================================================================
+# Tests: heuristic_fracs
+# ============================================================================
+
+class TestHeuristicFracs:
+    def test_string_column(self):
+        pipeline = StatPipeline([heuristic_fracs], unit_test=False)
+        ser = pd.Series(['true', 'false', 'yes', 'no'])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['str_bool_frac'] > 0
+
+    def test_numeric_column_returns_zeros(self):
+        pipeline = StatPipeline([heuristic_fracs], unit_test=False)
+        ser = pd.Series([1, 2, 3])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['str_bool_frac'] == 0
+        assert result['regular_int_parse_frac'] == 0
+
+    def test_integer_strings(self):
+        pipeline = StatPipeline([heuristic_fracs], unit_test=False)
+        ser = pd.Series(['1', '2', '3', '4'])
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['regular_int_parse_frac'] > 0
+
+
+# ============================================================================
+# Tests: orig_col_name
+# ============================================================================
+
+class TestOrigColName:
+    def test_provides_name(self):
+        pipeline = StatPipeline([orig_col_name], unit_test=False)
+        ser = pd.Series([1, 2, 3], name='my_col')
+        result, _ = pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert result['orig_col_name'] == 'my_col'
+
+
+# ============================================================================
+# Full pipeline integration tests
+# ============================================================================
+
+class TestFullPipeline:
+    def test_perverse_df(self):
+        """Full v2 pipeline should handle PERVERSE_DF without crashing."""
+        pipeline = StatPipeline(PD_ANALYSIS_V2, unit_test=False)
+        result, errors = pipeline.process_df(PERVERSE_DF)
+        assert len(result) == len(PERVERSE_DF.columns)
+
+        for col_key, col_stats in result.items():
+            assert 'length' in col_stats
+            assert 'dtype' in col_stats
+            assert '_type' in col_stats
+            assert 'distinct_count' in col_stats
+            assert 'nan_per' in col_stats
+            assert 'histogram' in col_stats
+
+    def test_mixed_df(self):
+        """Pipeline handles a DataFrame with mixed column types."""
+        df = pd.DataFrame({
+            'ints': [1, 2, 3, 4, 5],
+            'floats': [1.1, 2.2, 3.3, 4.4, 5.5],
+            'strs': ['a', 'b', 'c', 'd', 'e'],
+            'bools': [True, False, True, False, True],
+        })
+        pipeline = StatPipeline(PD_ANALYSIS_V2, unit_test=False)
+        result, errors = pipeline.process_df(df)
+        assert len(result) == 4
+
+        # Check type classification
+        type_map = {
+            col_stats['orig_col_name']: col_stats['_type']
+            for col_stats in result.values()
+        }
+        assert type_map['ints'] == 'integer'
+        assert type_map['floats'] == 'float'
+        assert type_map['strs'] == 'string'
+        assert type_map['bools'] == 'boolean'
+
+    def test_no_errors_on_simple_df(self):
+        """Simple DataFrame should produce zero errors."""
+        df = pd.DataFrame({'a': [1, 2, 3], 'b': ['x', 'y', 'z']})
+        pipeline = StatPipeline(PD_ANALYSIS_V2, unit_test=False)
+        result, errors = pipeline.process_df(df)
+        assert errors == []
+
+    def test_empty_df(self):
+        pipeline = StatPipeline(PD_ANALYSIS_V2, unit_test=False)
+        result, errors = pipeline.process_df(pd.DataFrame({}))
+        assert result == {}
+        assert errors == []
+
+    def test_unit_test_runs(self):
+        """StatPipeline.unit_test should not crash."""
+        pipeline = StatPipeline(PD_ANALYSIS_V2, unit_test=True)
+        passed, errors = pipeline._unit_test_result
+        # Some errors may occur on edge cases, but shouldn't crash
+
+
+# ============================================================================
+# Backward compatibility tests
+# ============================================================================
+
+class TestBackwardCompat:
+    """Verify v2 functions produce the same stat keys as v1 classes."""
+
+    def test_typing_stats_keys(self):
+        """v2 typing_stats + _type produce all keys from v1 TypingStats."""
+        from buckaroo.customizations.analysis import TypingStats
+
+        v1_keys = set(TypingStats.provides_defaults.keys())
+        v2_pipeline = StatPipeline([typing_stats, _type], unit_test=False)
+
+        ser = pd.Series([1, 2, 3])
+        v2_result, _ = v2_pipeline.process_column('test', ser.dtype, raw_series=ser)
+
+        # v2 should have all v1 keys
+        for key in v1_keys:
+            assert key in v2_result, f"Missing key: {key}"
+
+        # v2 also provides extras: is_string, memory_usage
+        assert 'is_string' in v2_result
+        assert 'memory_usage' in v2_result
+
+    def test_summary_stats_keys(self):
+        """v2 default_summary_stats produces all keys from v1 DefaultSummaryStats."""
+        from buckaroo.customizations.analysis import DefaultSummaryStats
+
+        v1_keys = set(DefaultSummaryStats.provides_defaults.keys())
+        v2_pipeline = StatPipeline([default_summary_stats], unit_test=False)
+
+        ser = pd.Series([1, 2, 3, 4, 5])
+        v2_result, _ = v2_pipeline.process_column('test', ser.dtype, raw_series=ser)
+
+        for key in v1_keys:
+            assert key in v2_result, f"Missing key: {key}"
+
+    def test_computed_summary_keys(self):
+        """v2 computed_default_summary_stats produces all keys from v1."""
+        from buckaroo.customizations.analysis import ComputedDefaultSummaryStats
+
+        v1_keys = set(ComputedDefaultSummaryStats.provides_defaults.keys())
+        v2_pipeline = StatPipeline(
+            [default_summary_stats, computed_default_summary_stats],
+            unit_test=False,
+        )
+
+        ser = pd.Series([1, 2, 3, 1, 2])
+        v2_result, _ = v2_pipeline.process_column('test', ser.dtype, raw_series=ser)
+
+        for key in v1_keys:
+            assert key in v2_result, f"Missing key: {key}"
+
+    def test_histogram_keys(self):
+        """v2 histogram functions produce the histogram key."""
+        v2_pipeline = StatPipeline(
+            [typing_stats, default_summary_stats,
+             computed_default_summary_stats,
+             histogram_series, histogram],
+            unit_test=False,
+        )
+
+        ser = pd.Series([1, 2, 3, 4, 5])
+        v2_result, _ = v2_pipeline.process_column('test', ser.dtype, raw_series=ser)
+        assert 'histogram' in v2_result
+        assert 'histogram_args' in v2_result
+
+    def test_typing_values_match_v1(self):
+        """v2 typing_stats produces same values as v1 TypingStats."""
+        from buckaroo.customizations.analysis import TypingStats
+
+        # Run v1 through adapter
+        v1_pipeline = StatPipeline([TypingStats], unit_test=False)
+        v2_pipeline = StatPipeline([typing_stats, _type], unit_test=False)
+
+        test_series = [
+            pd.Series([1, 2, 3], name='ints'),
+            pd.Series([1.0, 2.0], name='floats'),
+            pd.Series(['a', 'b'], name='strs'),
+            pd.Series([True, False], name='bools'),
+        ]
+
+        for ser in test_series:
+            v1_result, _ = v1_pipeline.process_column(
+                'test', ser.dtype, raw_series=ser)
+            v2_result, _ = v2_pipeline.process_column(
+                'test', ser.dtype, raw_series=ser)
+
+            for key in ['dtype', 'is_numeric', 'is_integer', 'is_bool',
+                        'is_float', 'is_datetime']:
+                assert v1_result.get(key) == v2_result.get(key), \
+                    f"Mismatch on {key} for {ser.name}: " \
+                    f"v1={v1_result.get(key)} v2={v2_result.get(key)}"
+
+    def test_summary_values_match_v1(self):
+        """v2 default_summary_stats produces same values as v1."""
+        from buckaroo.customizations.analysis import DefaultSummaryStats
+
+        v1_pipeline = StatPipeline([DefaultSummaryStats], unit_test=False)
+        v2_pipeline = StatPipeline([default_summary_stats], unit_test=False)
+
+        ser = pd.Series([1, 2, 3, 4, 5])
+        v1_result, _ = v1_pipeline.process_column('test', ser.dtype, raw_series=ser)
+        v2_result, _ = v2_pipeline.process_column('test', ser.dtype, raw_series=ser)
+
+        for key in ['length', 'null_count', 'min', 'max']:
+            assert v1_result[key] == v2_result[key], \
+                f"Mismatch on {key}: v1={v1_result[key]} v2={v2_result[key]}"
+
+    def test_heuristic_fracs_keys(self):
+        """v2 heuristic_fracs produces all keys from v1 HeuristicFracs."""
+        from buckaroo.customizations.pd_fracs import HeuristicFracs
+
+        v1_keys = set(HeuristicFracs.provides_defaults.keys())
+        v2_pipeline = StatPipeline([heuristic_fracs], unit_test=False)
+
+        ser = pd.Series(['true', 'false', '123'])
+        v2_result, _ = v2_pipeline.process_column('test', ser.dtype, raw_series=ser)
+
+        for key in v1_keys:
+            assert key in v2_result, f"Missing key: {key}"


### PR DESCRIPTION
## Summary
- Add Pluggable Analysis Framework v2 with `@stat` decorator, typed DAG, and error propagation
- Add `StatResult` type with success/error variants and dependency tracking
- Add runtime type enforcement at stat function boundaries
- Rewrite v1 `ColAnalysis` classes as v2 `@stat` functions (`pd_stats_v2.py`)
- Wire up all pandas widgets/dataflow to use `DfStatsV2` instead of `DfStats`
- Fix ruff lint issues across all new files

Replaces #506 — clean cherry-pick of the PAF v2 commits onto current main (no static asset / merge conflict issues).

## Test plan
- [ ] CI passes (unit tests for PAF v2 and pd_stats_v2)
- [ ] `test_paf_v2.py` — typed DAG resolution, error propagation, stat pipeline
- [ ] `test_pd_stats_v2.py` — rewritten stat functions produce same results as v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)