### PR TITLE
Add light/dark theme support with visual audit screenshots

### DIFF
--- a/packages/buckaroo-js-core/playwright.config.integration.ts
+++ b/packages/buckaroo-js-core/playwright.config.integration.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './pw-tests',
   // Match JupyterLab-based tests (integration, batch, and infinite scroll)
-  testMatch: ['integration.spec.ts', 'integration-batch.spec.ts', 'infinite-scroll-transcript.spec.ts', 'blank-rows-scroll.spec.ts'],
+  testMatch: ['integration.spec.ts', 'integration-batch.spec.ts', 'infinite-scroll-transcript.spec.ts', 'blank-rows-scroll.spec.ts', 'theme-screenshots-jupyter.spec.ts'],
   fullyParallel: false, // Integration tests should run serially
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots-jupyter.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots-jupyter.spec.ts
@@ -1,0 +1,123 @@
+import { test } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const JUPYTER_BASE_URL = 'http://localhost:8889';
+const JUPYTER_TOKEN = 'test-token-12345';
+
+const SCHEMES = ['light', 'dark'] as const;
+
+const screenshotsDir = path.resolve(__dirname, '..', 'screenshots');
+
+// Tall viewport to show code cells above and below the widget output
+test.use({ viewport: { width: 1280, height: 900 } });
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+/**
+ * Open a notebook in JupyterLab and run all cells.
+ * Returns when the first ag-grid widget is visible.
+ */
+async function openAndRunNotebook(page: import('@playwright/test').Page, notebookName: string) {
+  await page.goto(
+    `${JUPYTER_BASE_URL}/lab/tree/${notebookName}?token=${JUPYTER_TOKEN}`,
+    { timeout: 15_000 },
+  );
+  await page.waitForLoadState('domcontentloaded', { timeout: 10_000 });
+  await page.locator('.jp-Notebook').first().waitFor({ state: 'attached', timeout: 10_000 });
+
+  // Run all cells: Ctrl+Shift+Enter or the "Run All" menu
+  // Focus notebook first
+  await page.locator('.jp-Notebook').first().dispatchEvent('click');
+  await page.waitForTimeout(300);
+
+  // Use the menu: Run > Run All Cells
+  await page.locator('text=Run').first().click();
+  await page.waitForTimeout(300);
+  const runAll = page.locator('text=Run All Cells');
+  if (await runAll.isVisible()) {
+    await runAll.click();
+  } else {
+    // Fallback: Shift+Enter through cells
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('Shift+Enter');
+      await page.waitForTimeout(500);
+    }
+  }
+
+  // Wait for ag-grid to render
+  await page.locator('.ag-cell').first().waitFor({ state: 'visible', timeout: 15_000 });
+  await page.waitForTimeout(1000);
+}
+
+const notebookName = process.env.TEST_NOTEBOOK || 'test_buckaroo_widget.ipynb';
+
+for (const scheme of SCHEMES) {
+  test(`jupyter notebook in context [${scheme}]`, async ({ page }) => {
+    // JupyterLab has its own theme system; emulateMedia sets the browser
+    // preference which JupyterLab may or may not follow.  We also try to
+    // toggle JupyterLab's built-in theme via the settings menu.
+    await page.emulateMedia({ colorScheme: scheme });
+
+    await openAndRunNotebook(page, notebookName);
+
+    // Try to set JupyterLab theme via Settings menu
+    if (scheme === 'dark') {
+      const settingsMenu = page.locator('text=Settings');
+      if (await settingsMenu.isVisible()) {
+        await settingsMenu.click();
+        await page.waitForTimeout(200);
+        const darkTheme = page.locator('text=JupyterLab Dark');
+        if (await darkTheme.isVisible()) {
+          await darkTheme.click();
+          await page.waitForTimeout(1000);
+        } else {
+          // Close menu if dark theme not found
+          await page.keyboard.press('Escape');
+        }
+      }
+    }
+
+    // Scroll to the widget output so code cells above are visible
+    const widgetOutput = page.locator('.ag-root-wrapper').first();
+    await widgetOutput.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(500);
+
+    // Viewport screenshot captures surrounding code cells
+    await page.screenshot({
+      path: path.join(screenshotsDir, `jupyter-notebook-context--${scheme}.png`),
+    });
+  });
+
+  test(`jupyter full notebook [${scheme}]`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: scheme });
+
+    await openAndRunNotebook(page, notebookName);
+
+    if (scheme === 'dark') {
+      const settingsMenu = page.locator('text=Settings');
+      if (await settingsMenu.isVisible()) {
+        await settingsMenu.click();
+        await page.waitForTimeout(200);
+        const darkTheme = page.locator('text=JupyterLab Dark');
+        if (await darkTheme.isVisible()) {
+          await darkTheme.click();
+          await page.waitForTimeout(1000);
+        } else {
+          await page.keyboard.press('Escape');
+        }
+      }
+    }
+
+    // Full-page screenshot shows the entire notebook
+    await page.screenshot({
+      path: path.join(screenshotsDir, `jupyter-full-notebook--${scheme}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots-marimo.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots-marimo.spec.ts
@@ -9,6 +9,10 @@ const SCHEMES = ['light', 'dark'] as const;
 
 const screenshotsDir = path.resolve(__dirname, '..', 'screenshots');
 
+// Use a tall viewport so the full-page screenshot captures surrounding
+// marimo cells (markdown headings, descriptions) above and below widgets.
+test.use({ viewport: { width: 1280, height: 900 } });
+
 test.beforeAll(() => {
   fs.mkdirSync(screenshotsDir, { recursive: true });
 });
@@ -29,9 +33,33 @@ for (const scheme of SCHEMES) {
 
     await page.waitForTimeout(1000);
 
+    // fullPage: true captures the entire scrollable area — markdown cells
+    // above and below the widgets will be visible in the screenshot.
     await page.screenshot({
       path: path.join(screenshotsDir, `marimo-full-page--${scheme}.png`),
       fullPage: true,
+    });
+  });
+
+  test(`marimo small widget in context [${scheme}]`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: scheme });
+    await page.goto('/');
+
+    // Wait for the first BuckarooWidget to render
+    const firstWidget = page.locator('.buckaroo_anywidget').first();
+    await firstWidget.waitFor({ state: 'visible', timeout: 30_000 });
+    await firstWidget.locator('.ag-cell').first().waitFor({ state: 'visible', timeout: 30_000 });
+    await page.waitForTimeout(500);
+
+    // Scroll so the first widget is roughly centred, showing markdown
+    // cells above and the second widget heading below.
+    await firstWidget.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(300);
+
+    // Viewport screenshot (not fullPage) gives a natural "window" view
+    // with surrounding notebook cells visible.
+    await page.screenshot({
+      path: path.join(screenshotsDir, `marimo-small-widget-context--${scheme}.png`),
     });
   });
 
@@ -40,12 +68,11 @@ for (const scheme of SCHEMES) {
     await page.goto('/');
 
     // Wait for the first BuckarooWidget (which has the lowcode/operations UI)
-    await page.locator('.buckaroo_anywidget').first().waitFor({ state: 'visible', timeout: 30_000 });
-    await page.locator('.buckaroo_anywidget').first().locator('.ag-cell').first()
-      .waitFor({ state: 'visible', timeout: 30_000 });
+    const firstWidget = page.locator('.buckaroo_anywidget').first();
+    await firstWidget.waitFor({ state: 'visible', timeout: 30_000 });
+    await firstWidget.locator('.ag-cell').first().waitFor({ state: 'visible', timeout: 30_000 });
 
     // Click on Columns tab to open the lowcode UI if available
-    const firstWidget = page.locator('.buckaroo_anywidget').first();
     const columnsTab = firstWidget.locator('text=Columns');
     if (await columnsTab.isVisible()) {
       await columnsTab.click();
@@ -54,8 +81,12 @@ for (const scheme of SCHEMES) {
 
     await page.waitForTimeout(500);
 
-    // Screenshot just the first widget area
-    await firstWidget.screenshot({
+    // Scroll so surrounding cells are visible
+    await firstWidget.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(300);
+
+    // Viewport screenshot shows the lowcode UI with notebook context
+    await page.screenshot({
       path: path.join(screenshotsDir, `marimo-lowcode-widget--${scheme}.png`),
     });
   });

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/ChartCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/ChartCell.tsx
@@ -99,6 +99,15 @@ export const ChartColors = {
     cat_pop: "pink",
 }
 
+export function getChartColors(scheme: 'light' | 'dark') {
+    return scheme === 'light' ? {
+        unique: '#228B22',
+        longtail: '#006060',
+        NA: '#cc0000',
+        cat_pop: '#c06',
+    } : ChartColors;
+}
+
 
 export const getChartCell = (multiChartCellProps: ChartDisplayerA) => {
     const colorDefaults = {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -30,8 +30,8 @@ import {
     HeightStyleI,
     SetColumnFunc
 } from "./gridUtils";
-import { themeAlpine} from '@ag-grid-community/theming';
-import { colorSchemeDark } from '@ag-grid-community/theming';
+import { getThemeForScheme } from './gridUtils';
+import { useColorScheme } from '../useColorScheme';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
 ModuleRegistry.registerModules([InfiniteRowModelModule]);
@@ -156,7 +156,9 @@ export function DFViewerInfinite({
         )}, [hsCacheKey]
     );
   const defaultActiveCol:[string, string] = ["", ""];
-    const divClass = df_viewer_config?.component_config?.className || "ag-theme-alpine-dark";
+    const colorScheme = useColorScheme();
+    const defaultThemeClass = colorScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
+    const divClass = df_viewer_config?.component_config?.className || defaultThemeClass;
     return (
         <div className={`df-viewer  ${hs.classMode} ${hs.inIframe}`}>
             <pre>{error_info ? error_info : ""}</pre>
@@ -288,29 +290,15 @@ export function DFViewerInfiniteInner({
         [outside_df_params],
     );
 
-  // working from https://colorffy.com/dark-theme-generator?colors=b2317d-121212
-    const myTheme = useMemo(() => themeAlpine.withPart(colorSchemeDark).withParams({
-        spacing: 5,
-        browserColorScheme: "dark",
-        cellHorizontalPaddingScale: 0.3,
-        columnBorder: true,
+    const colorScheme = useColorScheme();
+    const myTheme = useMemo(() => getThemeForScheme(colorScheme).withParams({
         headerRowBorder: true,
         headerColumnBorder: true,
         headerColumnResizeHandleWidth: 0,
-
-        rowBorder: false,
-        rowVerticalPaddingScale: 0.5,
-        wrapperBorder: false,
-        fontSize: 12,
-        dataFontSize: "12px",
-        headerFontSize: 14,
-        iconSize: 10,
-        backgroundColor: "#121212",
-        oddRowBackgroundColor: '#3f3f3f',
-        headerVerticalPaddingScale: 0.6,
-        //    cellHorizontalPadding: 3,
-
-    }), []);
+        ...(colorScheme === 'dark'
+            ? { backgroundColor: "#121212", oddRowBackgroundColor: '#3f3f3f' }
+            : { backgroundColor: "#ffffff", oddRowBackgroundColor: '#f0f0f0' }),
+    }), [colorScheme]);
     const gridOptions: GridOptions = useMemo( () => {
         return {
         ...outerGridOptions(setActiveCol, df_viewer_config.extra_grid_config),

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -3,8 +3,9 @@ import React from "react";
 import { createPortal } from "react-dom";
 
 import { Bar, BarChart, Tooltip } from "recharts";
-import { ChartColors } from "./ChartCell";
+import { getChartColors } from "./ChartCell";
 import { ColDef, Column, Context, GridApi } from "@ag-grid-community/core";
+import { useColorScheme } from "../useColorScheme";
 
 export interface HistogramNode {
     name: string;
@@ -78,11 +79,12 @@ export interface HistogramBar {
 
 
 export const HistogramCell = (props:
-    {api:GridApi, colDef:ColDef, 
+    {api:GridApi, colDef:ColDef,
      column:Column, context:Context, value:any}
 ) => {
-    // relevant args here 
+    // relevant args here
     // https://www.ag-grid.com/react-data-grid/component-cell-renderer/
+    const colorScheme = useColorScheme();
     if (props === undefined ) {
         return <span></span>;
     }
@@ -94,20 +96,26 @@ export const HistogramCell = (props:
     }
   const histogramArr = potentialHistogramArr as HistogramBar[];
   //@ts-ignore
-  return TypedHistogramCell({histogramArr, context:props.context, className:props.colDef.cellClass|| ""});
+  return TypedHistogramCell({histogramArr, context:props.context, className:props.colDef.cellClass|| "", colorScheme});
 }
 
-export const TypedHistogramCell = ({histogramArr, context, className}:
-    {histogramArr:HistogramBar[], context:any, className?:string}) => {
+export const TypedHistogramCell = ({histogramArr, context, className, colorScheme = 'dark'}:
+    {histogramArr:HistogramBar[], context:any, className?:string, colorScheme?: 'light' | 'dark'}) => {
     const dumbClickHandler = (rechartsArgs: any, _unused_react: any) => {
         //we can access the rest of the data model through context
-    
+
         // I can't find the type for rechartsArgs
         // these are probably the keys we care about
         // activeTooltipIndex
         // activeLabel
         console.log("dumbClickHandler", rechartsArgs, context);
     };
+
+    const cc = getChartColors(colorScheme);
+    const isLight = colorScheme === 'light';
+    const barStroke = isLight ? '#888' : '#000';
+    const barFill = isLight ? '#999' : 'gray';
+    const boolFalseStroke = isLight ? '#666' : '#000';
 
     // used to prevent duplicate IDs which lead to a nasty bug where patterns aren't applied
     // https://github.com/paddymul/buckaroo/issues/292
@@ -140,7 +148,7 @@ export const TypedHistogramCell = ({histogramArr, context, className}:
             >
                 <defs>
                     <pattern id={starId} width="10" height="10" patternUnits="userSpaceOnUse">
-                        <polygon stroke="pink" points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2" />
+                        <polygon stroke={cc.cat_pop} points="0,0 2,5 0,10 5,8 10,10 8,5 10,0 5,2" />
                     </pattern>
                     <pattern
                         id={stripeId}
@@ -149,10 +157,10 @@ export const TypedHistogramCell = ({histogramArr, context, className}:
                         patternUnits="userSpaceOnUse"
                         patternTransform="rotate(45)"
                     >
-                        <rect width="2" height="4" fill={ChartColors.NA} />
+                        <rect width="2" height="4" fill={cc.NA} />
                     </pattern>
                     <pattern id={circleId} width="4" height="4" patternUnits="userSpaceOnUse">
-                        <circle data-color="outline" stroke="pink" cx=".5" cy=".5" r="1.5"></circle>
+                        <circle data-color="outline" stroke={cc.cat_pop} cx=".5" cy=".5" r="1.5"></circle>
                     </pattern>
 
                     <pattern
@@ -163,7 +171,7 @@ export const TypedHistogramCell = ({histogramArr, context, className}:
                         height="4"
                         patternUnits="userSpaceOnUse"
                     >
-                        <rect stroke="#0f0" x="0" width="2" height="2" y="0"></rect>
+                        <rect stroke={cc.unique} x="0" width="2" height="2" y="0"></rect>
                         <rect x="2" width="2" height="2" y="2"></rect>
                     </pattern>
 
@@ -177,7 +185,7 @@ export const TypedHistogramCell = ({histogramArr, context, className}:
                         patternTransform="translate(1, 1) rotate(0) skewX(0)"
                     >
                         <svg width="5" height="5" viewBox="0 0 100 100">
-                            <g fill="teal" opacity="1">
+                            <g fill={cc.longtail} opacity="1">
                                 <path d="M99.9557 99.9557C45.4895 98.3748 1.6248 54.5101 0.0439453 0.0439453C54.5101 1.6248 98.3748 45.4895 99.9557 99.9557Z"></path>
                             </g>
                         </svg>
@@ -185,15 +193,15 @@ export const TypedHistogramCell = ({histogramArr, context, className}:
                 </defs>
                 <Bar
                     dataKey="population"
-                    stroke="#000"
-                    fill="gray"
+                    stroke={barStroke}
+                    fill={barFill}
                     stackId="stack"
                     isAnimationActive={false}
                 />
                 <Bar
                     dataKey="tail"
-                    stroke="#000"
-                    fill="gray"
+                    stroke={barStroke}
+                    fill={barFill}
                     stackId="stack"
                     isAnimationActive={false}
                 />
@@ -206,41 +214,41 @@ export const TypedHistogramCell = ({histogramArr, context, className}:
                 />
                 <Bar
                     dataKey="false"
-                    stroke="#000"
+                    stroke={boolFalseStroke}
                     fill="#fff"
                     stackId="stack"
                     isAnimationActive={false}
                 />
                 <Bar
                     dataKey="cat_pop"
-                    stroke={ChartColors.cat_pop}
+                    stroke={cc.cat_pop}
                     fill={circleUrl}
                     stackId="stack"
                     isAnimationActive={false}
                 />
                 <Bar
                     dataKey="unique"
-                    stroke={ChartColors.unique}
+                    stroke={cc.unique}
                     fill={checkersUrl}
                     stackId="stack"
                     isAnimationActive={false}
                 />
                 <Bar
                     dataKey="longtail"
-                    stroke={ChartColors.longtail}
+                    stroke={cc.longtail}
                     fill={leafsUrl}
                     stackId="stack"
                     isAnimationActive={false}
                 />
                 <Bar
                     dataKey="user1"
-                    stroke="teal"
+                    stroke={cc.longtail}
                     fill={starUrl}
                     stackId="stack"
                     isAnimationActive={false}
                 />
-                <Bar dataKey="NA" fill={stripeUrl} 
-                     stackId="stack" 
+                <Bar dataKey="NA" fill={stripeUrl}
+                     stackId="stack"
                      isAnimationActive={false} />
                 <Tooltip
                     formatter={formatter}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -34,7 +34,7 @@ import { getFormatterFromArgs, getCellRenderer, objFormatter, getFormatter } fro
 import { CSSProperties, Dispatch, SetStateAction } from "react";
 import { CommandConfigT } from "../CommandUtils";
 import { KeyAwareSmartRowCache, PayloadArgs } from "./SmartRowCache";
-import { colorSchemeDark, themeAlpine, Theme } from "@ag-grid-community/theming";
+import { colorSchemeDark, colorSchemeLight, themeAlpine, Theme } from "@ag-grid-community/theming";
 
 
 // for now colDef stuff with less than 3 implementantions should stay in this file
@@ -527,21 +527,37 @@ export const getAutoSize = (
 
 
 
-export const myTheme: Theme = themeAlpine.withPart(colorSchemeDark).withParams({
-    spacing:5,
-    browserColorScheme: "dark",
+const sharedThemeParams = {
+    spacing: 5,
     cellHorizontalPaddingScale: 0.3,
     columnBorder: true,
     rowBorder: false,
     rowVerticalPaddingScale: 0.5,
     wrapperBorder: false,
     fontSize: 12,
-    dataFontSize: "12px",
+    dataFontSize: "12px" as const,
     headerFontSize: 14,
     iconSize: 10,
+    headerVerticalPaddingScale: 0.6,
+};
+
+export const myThemeDark: Theme = themeAlpine.withPart(colorSchemeDark).withParams({
+    ...sharedThemeParams,
+    browserColorScheme: "dark",
     backgroundColor: "#181D1F",
     oddRowBackgroundColor: '#222628',
-    headerVerticalPaddingScale: 0.6,
-//    cellHorizontalPadding: 3,
+});
 
-})
+export const myThemeLight: Theme = themeAlpine.withPart(colorSchemeLight).withParams({
+    ...sharedThemeParams,
+    browserColorScheme: "light",
+    backgroundColor: "#ffffff",
+    oddRowBackgroundColor: '#f5f5f5',
+});
+
+/** @deprecated Use getThemeForScheme() instead */
+export const myTheme: Theme = myThemeDark;
+
+export function getThemeForScheme(scheme: 'light' | 'dark'): Theme {
+    return scheme === 'light' ? myThemeLight : myThemeDark;
+}

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -143,11 +143,11 @@ export const fakeSearchCell = function (_params: any) {
         <div
             className={"FakeSearchEditor"}
             tabIndex={1} // important - without this the key presses wont be caught
-            style={{ display: "flex", "flexDirection": "row" }}
+            style={{ display: "flex", flexDirection: "row", width: "100%" }}
         >
             <input
                 type="text"
-                style={{ flex: "auto", width: 133 }}
+                style={{ flex: "1 1 auto", minWidth: 0 }}
                 value={searchVal}
                 onChange={({ target: { value }}) => setSearchVal(value)}
                 onSubmit={setVal}

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -9,8 +9,9 @@ import { BuckarooOptions } from "./WidgetTypes";
 import { BuckarooState, BKeys } from "./WidgetTypes";
 import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
 import { CustomCellEditorProps } from '@ag-grid-community/react';
-import { myTheme } from "./DFViewerParts/gridUtils";
+import { getThemeForScheme } from "./DFViewerParts/gridUtils";
 import { Theme } from "@ag-grid-community/theming";
+import { useColorScheme } from "./useColorScheme";
 
 export type setColumFunc = (newCol: string) => void;
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
@@ -363,14 +364,16 @@ export function StatusBar({
         cellStyle: { textAlign: "left" },
     };
 
-    const statusTheme: Theme = useMemo(()=> myTheme.withParams({
+    const colorScheme = useColorScheme();
+    const statusTheme: Theme = useMemo(()=> getThemeForScheme(colorScheme).withParams({
         headerFontSize: 14,
-        rowVerticalPaddingScale: 0.8,    
-    }), []);
+        rowVerticalPaddingScale: 0.8,
+    }), [colorScheme]);
+    const themeClass = colorScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
     return (
         <div className="status-bar">
-            <div 
-            className="theme-hanger ag-theme-alpine-dark">
+            <div
+            className={`theme-hanger ${themeClass}`}>
                 <AgGridReact
                     ref={gridRef}
                     theme={statusTheme}

--- a/packages/buckaroo-js-core/src/components/useColorScheme.ts
+++ b/packages/buckaroo-js-core/src/components/useColorScheme.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react';
+
+type ColorScheme = 'light' | 'dark';
+
+const mql =
+  typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+    ? window.matchMedia('(prefers-color-scheme: dark)')
+    : null;
+
+function subscribe(cb: () => void): () => void {
+  mql?.addEventListener('change', cb);
+  return () => mql?.removeEventListener('change', cb);
+}
+
+function getSnapshot(): ColorScheme {
+  return mql?.matches ? 'dark' : 'light';
+}
+
+function getServerSnapshot(): ColorScheme {
+  return 'dark'; // SSR fallback
+}
+
+/**
+ * React hook that reactively tracks the user's OS color scheme preference.
+ * Re-renders the component when the preference changes.
+ */
+export function useColorScheme(): ColorScheme {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -70,13 +70,18 @@
 .python-displayer, .command-displayer {
   width: 100%;
   height: 100%;
-  background: hsl(0, 0%, 13%);
+  background: var(--ag-background-color, hsl(0, 0%, 13%));
   overflow: hidden;
   padding: 2px;
   /*border:1px solid red; */
 }
 .python-displayer pre, .command-displayer pre {
   color: #41FF00;
+}
+@media (prefers-color-scheme: light) {
+  .python-displayer pre, .command-displayer pre {
+    color: #006400;
+  }
 }
 
 .command-displayer pre {
@@ -360,7 +365,7 @@
     margin-bottom:9px;
 }
 
-.ag-theme-alpine-dark  {
+.ag-theme-alpine-dark, .ag-theme-alpine  {
     --ag-grid-size:3px;
     --ag-list-item-height: 20px;
  }
@@ -576,8 +581,15 @@ When debugging CSS inside a weird environment I did the following
 	    <srt.BuckarooInfiniteWidget
 Then set the `style_block` property from ptyhon.  
 */
-div.cell-output-ipywidget-background {
+@media (prefers-color-scheme: dark) {
+  div.cell-output-ipywidget-background {
     background:#1f1f1f !important;
+  }
+}
+@media (prefers-color-scheme: light) {
+  div.cell-output-ipywidget-background {
+    background:#ffffff !important;
+  }
 }
 .cell-output-ipywidget-background .status-bar {
     margin-bottom:0;
@@ -594,12 +606,12 @@ div.cell-output-ipywidget-background {
 /* https://colorffy.com/dark-theme-generator?colors=b2317d-121212 */
 .ag-header-row .left_col_configs_header,
 .ag-row .left_col_configs_cell {
-    border-right:2px solid #717171 !important;
+    border-right:2px solid var(--ag-border-color, #717171) !important;
 }
 .ag-header-row .left_col_configs_header_last,
 .ag-row .left_col_configs_cell_last {
 
-    border-right:4px solid #717171 !important;
+    border-right:4px solid var(--ag-border-color, #717171) !important;
     border-bottom:none;
     border-top:none;
 
@@ -611,12 +623,12 @@ div.cell-output-ipywidget-background {
 
 /* we don't want these applying to the status bar too*/
 .df-viewer .ag-header {
-    border-bottom:4px solid #717171 !important;
+    border-bottom:4px solid var(--ag-border-color, #717171) !important;
 }
 
 .df-viewer .ag-center-cols-viewport .ag-row:first-child {
     /* first row at the top of regular rows */
-    border-top:2px solid #717171 !important;
+    border-top:2px solid var(--ag-border-color, #717171) !important;
 }
 
 /*

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -585,25 +585,23 @@ div div div .buckaroo_anywidget {
   outline:none;
 }
 
-/* Search input and button styling for theme adaptability */
+/* Search input and button styling — borderless, fill the AG-Grid cell */
 .FakeSearchEditor {
     width: 100%;
 }
 .FakeSearchEditor input {
-    border: 1px solid var(--ag-border-color, #68686e);
-    border-radius: 2px;
+    border: none;
     background: transparent;
     color: inherit;
+    outline: none;
 }
 .FakeSearchEditor button {
-    border: 1px solid var(--ag-border-color, #68686e);
-    border-radius: 2px;
+    border: none;
+    border-left: 1px solid var(--ag-border-color, #68686e);
     background: transparent;
     color: inherit;
     cursor: pointer;
-    padding: 0 3px;
-    min-width: 22px;
-    box-sizing: border-box;
+    padding: 0 4px;
 }
 
 

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -413,8 +413,25 @@ div.dependent-tabs ul.tabs li.active {
    */
    border-top-left-radius: 0;
    border-top-right-radius: 0;
+}
 
+/* Light mode: add visible border so the widget doesn't blend into white backgrounds */
+@media (prefers-color-scheme: light) {
+    .status-bar .ag-root-wrapper {
+        border: 1px solid #c0c0c0 !important;
+        border-bottom: none !important;
+    }
+    .df-viewer .ag-root-wrapper {
+        border: 1px solid #c0c0c0 !important;
+    }
+    .buckaroo-widget .df-viewer .ag-root-wrapper {
+        border-top: none !important;
+    }
+}
 
+/* Ensure empty grid area below rows has proper background */
+.theme-hanger {
+    background-color: var(--ag-background-color, #181D1F);
 }
 
 
@@ -559,8 +576,29 @@ div div div .buckaroo_anywidget {
   padding:0;
 }
 
-.statusBar .ag-column-first .FakeSearchEditor input{ 
+.statusBar .ag-column-first .FakeSearchEditor input{
   outline:none;
+}
+
+/* Search input and button styling for theme adaptability */
+.FakeSearchEditor {
+    width: 100%;
+}
+.FakeSearchEditor input {
+    border: 1px solid var(--ag-border-color, #68686e);
+    border-radius: 2px;
+    background: transparent;
+    color: inherit;
+}
+.FakeSearchEditor button {
+    border: 1px solid var(--ag-border-color, #68686e);
+    border-radius: 2px;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    padding: 0 3px;
+    min-width: 22px;
+    box-sizing: border-box;
 }
 
 

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -431,7 +431,12 @@ div.dependent-tabs ul.tabs li.active {
 
 /* Ensure empty grid area below rows has proper background */
 .theme-hanger {
-    background-color: var(--ag-background-color, #181D1F);
+    background-color: #181D1F;
+}
+@media (prefers-color-scheme: light) {
+    .theme-hanger {
+        background-color: #ffffff;
+    }
 }
 
 

--- a/tests/notebooks/marimo_pw_test.py
+++ b/tests/notebooks/marimo_pw_test.py
@@ -6,9 +6,22 @@ app = marimo.App(width="medium")
 
 @app.cell
 def _():
+    import marimo as mo
+    mo.md("# Buckaroo Widget Test\nThis notebook tests BuckarooWidget and BuckarooInfiniteWidget rendering.")
+    return (mo,)
+
+
+@app.cell
+def _():
     import pandas as pd
     from buckaroo.buckaroo_widget import BuckarooWidget, BuckarooInfiniteWidget
     return BuckarooInfiniteWidget, BuckarooWidget, pd
+
+
+@app.cell
+def _(mo):
+    mo.md("## Small DataFrame (5 rows)\nA simple `BuckarooWidget` with name, age, and score columns.")
+    return
 
 
 @app.cell
@@ -23,6 +36,12 @@ def _(BuckarooWidget, pd):
 
 
 @app.cell
+def _(mo):
+    mo.md("## Large DataFrame (200 rows)\nA `BuckarooInfiniteWidget` demonstrating infinite scroll with a larger dataset.")
+    return
+
+
+@app.cell
 def _(BuckarooInfiniteWidget, pd):
     rows = []
     for i in range(200):
@@ -30,6 +49,12 @@ def _(BuckarooInfiniteWidget, pd):
     large_df = pd.DataFrame(rows)
     widget = BuckarooInfiniteWidget(large_df)
     return large_df, rows, widget
+
+
+@app.cell
+def _(mo):
+    mo.md("---\n*End of test notebook.*")
+    return
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add automatic light/dark theme switching based on `prefers-color-scheme` OS preference
- Create `useColorScheme` React hook using `useSyncExternalStore` for reactive theme tracking
- Add AG-Grid theme variants (`myThemeLight`/`myThemeDark`) with shared params via `getThemeForScheme()`
- Update `DFViewerInfinite`, `StatusBar`, and CSS to dynamically adapt to color scheme
- Add Playwright screenshot specs for marimo/jupyter theme auditing
- Adapt histogram colors to light/dark scheme
- Fix widget border, search input styling, theme-hanger background for light mode

Replaces #505 — clean cherry-pick onto current main (no static asset / merge conflict issues).

## Test plan
- [ ] CI passes
- [ ] Theme screenshots captured in CI artifacts
- [ ] Light and dark modes render correctly in Storybook, server, and marimo

🤖 Generated with [Claude Code](https://claude.com/claude-code)