### PR TITLE
ci: skip unnecessary deps in lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           enable-cache: true
       - name: Install the project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked --dev --no-install-project
       - name: Run ruff
         run: uv run ruff check
 


### PR DESCRIPTION
## Summary
- LintPython job was installing all runtime dependencies (`--all-extras`) just to run ruff
- Ruff only needs source files on disk, not installed packages
- Switch to `--no-install-project` to skip project + extras installation

## Test plan
- [ ] LintPython job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)