### PR TITLE
Fix marimo Playwright tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,6 @@ jobs:
     name: Marimo Playwright Tests
     needs: [BuildWheel]
     runs-on: depot-ubuntu-latest
-    timeout-minutes: 4
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/tests/notebooks/marimo_pw_test.py
+++ b/tests/notebooks/marimo_pw_test.py
@@ -32,6 +32,7 @@ def _(BuckarooWidget, pd):
         'score': [88.5, 92.3, 76.1, 95.0, 81.7],
     })
     small_widget = BuckarooWidget(small_df)
+    small_widget
     return small_df, small_widget
 
 
@@ -48,6 +49,7 @@ def _(BuckarooInfiniteWidget, pd):
         rows.append({'id': i, 'value': i * 10, 'label': f'row_{i}'})
     large_df = pd.DataFrame(rows)
     large_widget = BuckarooInfiniteWidget(large_df)
+    large_widget
     return large_df, rows, large_widget
 
 


### PR DESCRIPTION
## Summary
- Widget cells in the test notebook used assignment statements as their last expression, but marimo only renders **bare expressions** as cell output. The widgets were instantiated in Python but never displayed in the browser.
- Added bare widget expressions (`small_widget` / `large_widget`) so marimo renders them, making `.buckaroo_anywidget` elements appear in the DOM.
- Removed `continue-on-error: true` and `timeout-minutes: 4` from the `TestMarimo` CI job so it properly gates the pipeline.

## Test plan
- [x] All 12 marimo Playwright tests pass locally (6 functional + 6 theme screenshots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)