### PR TITLE
ci: publish dev wheel to TestPyPI on every PR

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,6 +6,11 @@ on:
     branches: "*"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -76,6 +81,13 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Install the project
         run: uv sync --all-extras --dev
+      - name: Patch version for TestPyPI
+        if: github.event_name == 'pull_request'
+        run: |
+          BASE=$(grep -Po '^version = "\K[^"]+' pyproject.toml)
+          DEV="${BASE}.dev${{ github.run_id }}"
+          sed -i "s/^version = \".*\"/version = \"${DEV}\"/" pyproject.toml
+          echo "Published version: ${DEV}"
       - name: Build JS extension + Python wheel
         run: ./scripts/full_build.sh
       - name: Upload build artifacts
@@ -87,6 +99,74 @@ jobs:
             ./buckaroo/static/
             ./packages/buckaroo-js-core/dist/
             ./packages/buckaroo-widget/dist/
+
+  PublishTestPyPI:
+    name: Publish to TestPyPI
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    needs: [BuildWheel]
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 5
+    environment: testpypi
+    permissions:
+      id-token: write
+      pull-requests: write
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: buckaroo-build
+          path: artifacts
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: artifacts/dist/
+      - name: Comment on PR with install command
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const distFiles = fs.readdirSync('artifacts/dist');
+            const wheel = distFiles.find(f => f.endsWith('.whl'));
+            const version = wheel.match(/buckaroo-(.+?)-/)[1];
+            const body = [
+              '## :package: TestPyPI package published',
+              '',
+              '```bash',
+              `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ buckaroo==${version}`,
+              '```',
+              '',
+              'or with uv:',
+              '',
+              '```bash',
+              `uv pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ buckaroo==${version}`,
+              '```',
+            ].join('\n');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const marker = '## :package: TestPyPI package published';
+            const existing = comments.find(c => c.body.startsWith(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
 
   # ---------------------------------------------------------------------------
   # Source-level tests — operate on the codebase, no wheel needed


### PR DESCRIPTION
## Summary
- Adds `PublishTestPyPI` job to `checks.yml` that publishes a `.dev{run_id}` versioned wheel to TestPyPI on every PR push
- Uses trusted publishing (OIDC) via `environment: testpypi` — no API token secrets needed
- Posts a PR comment with `pip install` and `uv pip install` commands, updated in-place on subsequent pushes
- Skips fork PRs (OIDC tokens unavailable) and main pushes (keeps canonical version)
- No other jobs depend on it — if TestPyPI is down, all other checks still pass

## Test plan
- [x] Verified on PR #535 — `buckaroo==0.12.8.dev22283693233` published successfully to TestPyPI with PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)