### PR TITLE
ci: make marimo Playwright tests required

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -241,7 +241,6 @@ jobs:
     needs: [BuildWheel]
     runs-on: depot-ubuntu-latest
     timeout-minutes: 4
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -281,7 +280,6 @@ jobs:
     needs: [BuildWheel]
     runs-on: depot-ubuntu-latest
     timeout-minutes: 4
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install uv

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -353,7 +353,6 @@ jobs:
     needs: [BuildWheel]
     runs-on: depot-ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - name: Install uv


### PR DESCRIPTION
## Summary
- Remove `continue-on-error: true` from **TestMarimo** and **TestWASMMarimo** CI jobs
- These tests are now reliable and their failures should block the build

## Test plan
- [ ] Verify both marimo Playwright jobs pass on this PR (no longer soft-fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)