### PR TITLE
feat: named height strategies (fraction/fixed/fill)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -269,6 +269,18 @@ jobs:
           key: playwright-${{ hashFiles('packages/buckaroo-js-core/package.json') }}
       - name: Run Storybook Playwright Tests
         run: bash scripts/test_playwright_storybook.sh
+      - name: List screenshot files (debug)
+        if: always()
+        run: ls -laR packages/buckaroo-js-core/screenshots/ 2>/dev/null || echo "No screenshots dir"
+      - name: Upload Height Mode Screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: height-mode-screenshots
+          path: |
+            packages/buckaroo-js-core/screenshots/height-mode/
+            packages/buckaroo-js-core/pw-tests/screenshot-compare.html
+          if-no-files-found: warn
       - name: Capture Theme Screenshots
         run: bash scripts/test_playwright_screenshots.sh
       - name: Upload Theme Screenshots
@@ -276,7 +288,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: theme-screenshots
-          path: packages/buckaroo-js-core/screenshots/
+          path: |
+            packages/buckaroo-js-core/screenshots/
+            packages/buckaroo-js-core/pw-tests/screenshot-compare.html
           if-no-files-found: ignore
 
   TestServer:
@@ -315,6 +329,13 @@ jobs:
           key: playwright-${{ hashFiles('packages/buckaroo-js-core/package.json') }}
       - name: Run Server Playwright Tests
         run: bash scripts/test_playwright_server.sh
+      - name: Upload server test screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-screenshots
+          path: packages/buckaroo-js-core/screenshots/
+          if-no-files-found: ignore
 
   TestMarimo:
     name: Marimo Playwright Tests

--- a/HEIGHT_PLAN.md
+++ b/HEIGHT_PLAN.md
@@ -1,0 +1,387 @@
+# Buckaroo Height Handling: Analysis & Plan
+
+## Current State: How Height Works Today
+
+### The Height Calculation Engine (`gridUtils.ts:452-513`)
+
+The central function `heightStyle()` computes a `HeightStyleI` object that controls AG Grid's sizing:
+
+```
+window.innerHeight / height_fraction (default 2) = regularCompHeight
+
+if (numRows + pinnedRows) < maxRowsWithoutScrolling → "short mode"
+    domLayout: "autoHeight", style: { minHeight: 50, maxHeight: dfvHeight }
+
+else → "regular mode"
+    domLayout: "normal", style: { height: dfvHeight, overflow: "hidden" }
+```
+
+### Current Implicit Height Strategies (unnamed)
+
+Today `heightStyle()` has several behaviors baked into one function with if/else chains:
+
+| Environment | Behavior | Detection |
+|---|---|---|
+| **Jupyter / Marimo** | `window.innerHeight / 2` — takes half the screen. Works well with maximized notebooks. | Default path (no special detection) |
+| **Google Colab** | Fixed 500px. Colab's iframe environment is funky and this was the most expedient solution. | `location.host.indexOf("colab.googleusercontent.com")` |
+| **VSCode** | Fixed 500px. Same situation — VSCode's ipywidget rendering is its own thing. | `window.vscIPyWidgets !== undefined` |
+| **iframe generic** | CSS override: `.in-iframe .ag-center-cols-viewport { min-height: 450px }` | `window.parent !== window` |
+| **MCP standalone** | Gets the Jupyter behavior (half screen) by accident. Container is `100vh` but grid only uses `innerHeight / 2`. **Results in black space filling the bottom half.** | No detection — falls through to default |
+
+### Short Mode (orthogonal to the above)
+
+When the table has fewer rows than fit in the computed height, short mode kicks in:
+- `domLayout: "autoHeight"` — AG Grid sizes to fit content
+- No wasted vertical space for a 3-row table
+- This works correctly and doesn't need to change.
+
+### The Component Tree
+
+```
+standalone.tsx:  <div style={{ height: "100vh" }}>
+  BuckarooWidgetInfinite: <div style={{ height: "100%" }}>
+    <div class="orig-df" style={{ overflow: "hidden" }}>
+      <StatusBar />                                        ← autoHeight, always 1 header + 1 data row
+      <DFViewerInfinite>
+        <div class="df-viewer regular-mode">
+          <div class="theme-hanger" style={{ height: N px }}>  ← FIXED PIXELS (the problem)
+            <AgGridReact domLayout="normal" />
+          </div>
+        </div>
+      </DFViewerInfinite>
+    </div>
+  </div>
+</div>
+```
+
+The outer container says "fill the viewport" but the inner grid gets a fixed pixel height computed once at render. No resize listener, no flex-grow.
+
+---
+
+## Problem Statement
+
+1. **MCP standalone**: Table uses half the window. Should fill all available space.
+2. **No resize handling**: Height is computed once. Resizing the browser window doesn't reflow.
+3. **Environment detection lives in the frontend**: `heightStyle()` sniffs Colab, VSCode, iframes. This should be the Python side's job — it knows what environment it's running in.
+4. **Strategies are implicit**: The different height behaviors are tangled in one function. They should be named, explicit, and independently testable.
+
+---
+
+## Design: Named Height Strategies
+
+Replace the implicit if/else chains with an explicit `heightMode` on `ComponentConfig`. Each mode is a named, testable strategy. The Python side detects the environment and sets the mode. The frontend just executes it.
+
+### The Modes
+
+```typescript
+type HeightMode =
+    | "fraction"   // window.innerHeight / height_fraction. Default for Jupyter, Marimo.
+    | "fixed"      // Explicit pixel height (dfvHeight). Colab, VSCode.
+    | "fill"       // CSS flex: fill all available container space. MCP standalone.
+```
+
+| Mode | Used By | Behavior |
+|---|---|---|
+| `"fraction"` | Jupyter, Marimo | `window.innerHeight / (height_fraction \|\| 2)`. Half the screen. Existing behavior. |
+| `"fixed"` | Colab, VSCode | `dfvHeight` pixels (default 500). Existing behavior. |
+| `"fill"` | MCP standalone | CSS `flex: 1` — fills whatever parent container provides. Responsive to resize. |
+
+Short mode still applies on top of any of these: if the table has fewer rows than fit, it uses `domLayout: "autoHeight"` regardless of `heightMode`.
+
+### Updated Types
+
+**TypeScript (`DFWhole.ts`):**
+```typescript
+type HeightMode = "fraction" | "fixed" | "fill";
+
+type ComponentConfig = {
+    heightMode?: HeightMode;       // NEW — which height strategy to use
+    height_fraction?: number;      // for "fraction" mode (default: 2)
+    dfvHeight?: number;            // for "fixed" mode (default: 500)
+    layoutType?: "autoHeight" | "normal";
+    shortMode?: boolean;
+    selectionBackground?: string;
+    className?: string;
+};
+```
+
+**Python (`styling_core.py`):**
+```python
+ComponentConfig = TypedDict('ComponentConfig', {
+    'heightMode': NotRequired[Literal["fraction", "fixed", "fill"]],
+    'height_fraction': NotRequired[float],
+    'dfvHeight': NotRequired[int],
+    'layoutType': NotRequired[Literal["autoHeight", "normal"]],
+    'shortMode': NotRequired[bool],
+    'selectionBackground': NotRequired[str],
+    'className': NotRequired[str]
+})
+```
+
+### Backward Compatibility
+
+When `heightMode` is not set (existing code, old configs):
+- The frontend defaults to `"fraction"` — the current Jupyter behavior.
+- Colab/VSCode environment sniffing in `heightStyle()` stays as a fallback but only triggers when `heightMode` is unset. Once the Python side sets `heightMode` explicitly, the frontend trusts it.
+
+This means existing notebooks that don't set `heightMode` work exactly as before.
+
+---
+
+## How Each Mode Works
+
+### `"fraction"` mode (Jupyter, Marimo)
+
+Existing behavior, now explicitly named:
+```typescript
+const dfvHeight = window.innerHeight / (compC?.height_fraction || 2);
+// regular: { height: dfvHeight, overflow: "hidden" }
+// short:   { minHeight: 50, maxHeight: dfvHeight, overflow: "hidden" }
+```
+No CSS flex needed. This is "take half the screen" and it's the right call for notebooks where cells live above and below.
+
+### `"fixed"` mode (Colab, VSCode)
+
+Existing behavior, now explicitly named:
+```typescript
+const dfvHeight = compC?.dfvHeight || 500;
+// always: { height: dfvHeight, overflow: "hidden" }
+// domLayout: "normal"
+```
+These environments are funky. A fixed pixel height is the practical answer.
+
+### `"fill"` mode (MCP standalone)
+
+New behavior. The grid fills whatever space its parent container provides.
+
+**How resize works — pure CSS, no JS listeners:**
+
+AG Grid with `domLayout: "normal"` has internal resize detection. From the [AG Grid docs](https://www.ag-grid.com/react-data-grid/grid-size/):
+
+> "If the width and / or height change after the grid is initialised, the grid will automatically resize to fill the new area."
+
+So the mechanism is:
+
+1. `html, body, #root` are `height: 100vh` (set by `handlers.py`)
+2. The entire div chain down to `.theme-hanger` is an unbroken CSS flex column (`flex: 1; min-height: 0`)
+3. When the user resizes the browser window, `100vh` changes → CSS flex reflows the entire chain → `.theme-hanger` gets a new computed height
+4. AG Grid detects its container changed size (it watches internally) and re-renders its rows
+
+No `ResizeObserver`, no `window.addEventListener("resize")`, no JS resize code on our side. Pure CSS flexbox propagation + AG Grid's built-in container size monitoring.
+
+**The flex chain for "fill" mode:**
+
+```
+html, body, #root     → height: 100vh
+.buckaroo_anywidget   → height: 100%; display: flex; flex-direction: column
+.dcf-root             → flex: 1; min-height: 0; display: flex; flex-direction: column
+.orig-df              → flex: 1; min-height: 0; display: flex; flex-direction: column
+.status-bar           → flex-shrink: 0  (always 1 header row + 1 data row, takes its content height)
+.df-viewer            → flex: 1; min-height: 0; display: flex; flex-direction: column
+.theme-hanger         → flex: 1; min-height: 0  (AG Grid fills this)
+```
+
+**StatusBar in "fill" mode:** The StatusBar is always just a header row and one data row. It uses `domLayout: "autoHeight"` so its height is content-determined (~40-50px). In the flex column, it gets `flex-shrink: 0` — it takes exactly its natural content height and never gets compressed. The data grid (DFViewerInfinite) gets `flex: 1` and receives ALL remaining space. No fudge factors needed — flex handles the subtraction exactly.
+
+**`applicableStyle` for "fill" mode:**
+```typescript
+// regular (many rows):
+{ flex: 1, minHeight: 0, overflow: "hidden" }
+// domLayout: "normal" — AG Grid scrolls internally
+
+// short (few rows):
+{ minHeight: 50, maxHeight: containerHeight, overflow: "hidden" }
+// domLayout: "autoHeight" — AG Grid sizes to content
+// (short tables should NOT stretch to fill the screen)
+```
+
+**Short mode in "fill":** Still uses `domLayout: "autoHeight"`. A 3-row table should render at content height, not stretch. For short-mode detection, `maxRowsWithoutScrolling` uses `window.innerHeight / rowHeight` as a reasonable upper bound (the actual available space may be smaller, but we only need to detect "clearly short" tables).
+
+---
+
+## Where Environment Detection Happens
+
+### Current: Frontend sniffs the environment
+
+`heightStyle()` checks `location.host` for Colab, `window.vscIPyWidgets` for VSCode, `window.parent !== window` for iframes.
+
+### New: Python side sets `heightMode`
+
+The Python side already knows what environment it's in:
+
+**Jupyter / Marimo (default):** `heightMode` is unset → frontend defaults to `"fraction"`. Or explicitly: `component_config = {'heightMode': 'fraction'}`.
+
+**Colab:** Detected in Python (e.g., `"google.colab" in sys.modules`). Sets `component_config = {'heightMode': 'fixed', 'dfvHeight': 500}`.
+
+**VSCode:** Detected similarly. Sets `component_config = {'heightMode': 'fixed', 'dfvHeight': 500}`.
+
+**MCP standalone server:** The standalone server controls its own display state. Sets `component_config = {'heightMode': 'fill'}` when building the display args.
+
+This centralizes environment detection in Python. The frontend becomes a pure renderer of the chosen strategy.
+
+### Migration path for frontend environment detection
+
+The Colab/VSCode checks in `heightStyle()` become fallbacks:
+```typescript
+// Only sniff environment if heightMode is not explicitly set
+if (!compC?.heightMode) {
+    if (isGoogleColab || inVSCcode()) {
+        effectiveMode = "fixed";
+    } else {
+        effectiveMode = "fraction";
+    }
+} else {
+    effectiveMode = compC.heightMode;
+}
+```
+
+This preserves behavior for anyone using older Python-side code that doesn't set `heightMode` yet.
+
+---
+
+## Frontend Testability
+
+Each mode can be tested independently in Storybook by passing `component_config`. No environment sniffing in tests:
+
+```typescript
+// Story: "Fraction Mode (Jupyter)" — in a fixed-size container
+component_config: { heightMode: "fraction", height_fraction: 2 }
+
+// Story: "Fixed Mode (Colab/VSCode)"
+component_config: { heightMode: "fixed", dfvHeight: 500 }
+
+// Story: "Fill Mode (MCP Standalone)" — in a flex container
+component_config: { heightMode: "fill" }
+
+// Story: "Short Table" — short mode overrides any heightMode
+component_config: { heightMode: "fill" }  // with 3-row data
+```
+
+---
+
+## Implementation Plan
+
+### Step 1: Add `HeightMode` type and update `ComponentConfig`
+
+**Files:**
+- `packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts` — add `HeightMode` type, add `heightMode` to `ComponentConfig`
+- `buckaroo/dataflow/styling_core.py` — add `heightMode` to Python `ComponentConfig`
+
+### Step 2: Refactor `heightStyle()` to dispatch on `heightMode`
+
+**File:** `packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts`
+
+- When `heightMode` is set, use it directly
+- When unset, fall back to current environment-sniffing logic (backward compat)
+- `"fraction"`: existing `window.innerHeight / height_fraction` path
+- `"fixed"`: existing `dfvHeight || 500` path
+- `"fill"`: return `applicableStyle: { flex: 1, minHeight: 0, overflow: "hidden" }`
+- Short mode still applies on top regardless of mode
+
+### Step 3: Update component structure for "fill" mode
+
+**Files:**
+- `packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx` — when heightMode is "fill", `.df-viewer` and `.theme-hanger` use flex styles
+- `packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx` — `.orig-df` gets flex column layout
+- `packages/buckaroo-js-core/src/style/dcf-npm.css` — add CSS rules for fill mode flex chain
+
+### Step 4: MCP standalone sets `heightMode: "fill"`
+
+**Files:**
+- `packages/js/standalone.tsx` — inject `heightMode: "fill"` into component_config before passing to components
+- `buckaroo/server/handlers.py` — update page CSS for unbroken flex chain from `html` to `.theme-hanger`
+
+### Step 5: Python-side environment detection (future / optional)
+
+**Files:**
+- `buckaroo/buckaroo_widget.py` or environment detection module — detect Colab, VSCode, set `heightMode` in `component_config`
+- This can be done incrementally. The frontend fallback preserves existing behavior.
+
+### Step 6: Storybook stories for each mode
+
+**Files:**
+- `packages/buckaroo-js-core/src/stories/HeightMode.stories.tsx` — stories for each mode with different data sizes
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts` | Add `HeightMode` type, add `heightMode` to `ComponentConfig` |
+| `packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts` | Refactor `heightStyle()` to dispatch on `heightMode`, add `"fill"` path |
+| `packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx` | Support flex styles from `"fill"` mode |
+| `packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx` | Flex column layout on `.orig-df` for fill mode |
+| `packages/buckaroo-js-core/src/style/dcf-npm.css` | CSS rules for fill-mode flex chain |
+| `packages/js/standalone.tsx` | Inject `heightMode: "fill"` into component_config |
+| `buckaroo/server/handlers.py` | Page CSS: unbroken flex chain |
+| `buckaroo/dataflow/styling_core.py` | Add `heightMode` to Python `ComponentConfig` |
+
+---
+
+## Testing Strategy
+
+### Test-first approach
+
+Tests are written before implementation. They initially fail, then pass as each step is implemented.
+
+### 1. Unit Tests (`gridUtils.test.ts`)
+
+New test cases in the existing `getHeightStyle` describe block:
+
+| Test | Asserts |
+|---|---|
+| `heightMode: "fraction"` with 100 rows | `classMode: "regular-mode"`, `domLayout: "normal"`, `applicableStyle.height` is a pixel number |
+| `heightMode: "fraction"` with 3 rows | `classMode: "short-mode"`, `domLayout: "autoHeight"` |
+| `heightMode: "fixed"` with dfvHeight 500 | `applicableStyle.height === 500`, `domLayout: "normal"` |
+| `heightMode: "fixed"` with 3 rows | still `domLayout: "normal"` (fixed mode ignores short mode) |
+| `heightMode: "fill"` with 100 rows | `applicableStyle.flex === 1`, `applicableStyle.minHeight === 0`, `domLayout: "normal"` |
+| `heightMode: "fill"` with 3 rows | `classMode: "short-mode"`, `domLayout: "autoHeight"` (short overrides fill) |
+| No `heightMode` set, 100 rows | Same as `"fraction"` (backward compat) |
+| No `heightMode` set, 3 rows | Same as fraction short mode (backward compat) |
+
+### 2. Storybook Stories (`HeightMode.stories.tsx`)
+
+| Story | Setup | Expected Visual |
+|---|---|---|
+| `FractionMode` | 300 rows, `heightMode: "fraction"`, container 800x600 | Grid fills ~half of 600px container, scrolls |
+| `FractionModeShort` | 3 rows, `heightMode: "fraction"`, container 800x600 | Grid shrinks to fit 3 rows |
+| `FixedMode` | 300 rows, `heightMode: "fixed"`, `dfvHeight: 400` | Grid is exactly 400px |
+| `FixedModeShort` | 3 rows, `heightMode: "fixed"`, `dfvHeight: 400` | Grid is 400px (fixed ignores short) |
+| `FillMode` | 300 rows, `heightMode: "fill"`, flex container 800x600 | Grid fills full 600px container |
+| `FillModeShort` | 3 rows, `heightMode: "fill"`, flex container 800x600 | Grid shrinks to fit 3 rows |
+
+### 3. Playwright Integration Tests
+
+**Storybook-based (`pw-tests/height-mode.spec.ts`):**
+
+| Test | What it checks |
+|---|---|
+| Fill mode fills container | `.theme-hanger` height ≈ container height (within tolerance) |
+| Fraction mode uses half | `.theme-hanger` height ≈ container height / 2 |
+| Fixed mode uses explicit height | `.theme-hanger` height ≈ dfvHeight |
+| Short table in fill mode | `.theme-hanger` height < 200px (content-sized, not stretched) |
+
+**Server-based (`pw-tests/height-mode-server.spec.ts`):**
+
+| Test | What it checks |
+|---|---|
+| Server fill mode, 100 rows | Grid fills viewport, no black gap at bottom |
+| Server fill mode, 5 rows (short) | Grid content-sized, background visible only below content |
+| Server fill mode, resize | Set viewport to 800x600, screenshot, resize to 800x400, screenshot, verify grid height changed |
+
+**Screenshot capture for comparison viewer:**
+
+All Playwright tests capture before/after screenshots into `screenshots/height-mode/` directory for the comparison viewer.
+
+### 4. Screenshot Comparison Viewer (`screenshots/compare.html`)
+
+A self-contained HTML page that:
+- Scans the screenshots directory (via a generated manifest)
+- Shows before/after pairs side by side
+- Supports slider overlay (drag to reveal before vs after)
+- Supports toggle view (click to flip)
+- Groups screenshots by test scenario
+- Works by opening `file://` in a browser — no server needed
+
+The Playwright test script generates a `manifest.json` listing all screenshot pairs. The comparison viewer reads it.

--- a/buckaroo/customizations/analysis.py
+++ b/buckaroo/customizations/analysis.py
@@ -109,8 +109,8 @@ class TypingStats(ColAnalysis):
 
 class DefaultSummaryStats(ColAnalysis):
     provides_defaults = {
-        'length':0, 'min':0, 'max':0, 'mean':0, 'null_count':0,
-        'value_counts':0, 'mode':0, "std":0, "median":0}
+        'length':0, 'min':np.nan, 'max':np.nan, 'mean':np.nan, 'null_count':0,
+        'value_counts':0, 'mode':0, "std":np.nan, "median":np.nan}
     @staticmethod
     def series_summary(sampled_ser, ser):
         l = len(ser)

--- a/buckaroo/dataflow/styling_core.py
+++ b/buckaroo/dataflow/styling_core.py
@@ -156,6 +156,7 @@ PinnedRowConfig = TypedDict('PinnedRowConfig', {
 })
 
 ComponentConfig = TypedDict('ComponentConfig', {
+    'heightMode': NotRequired[Literal["fraction", "fixed", "fill"]],
     'height_fraction': NotRequired[float],
     'dfvHeight': NotRequired[int],  # temporary debugging prop
     'layoutType': NotRequired[Literal["autoHeight", "normal"]],

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -281,12 +281,18 @@ SESSION_HTML = """\
     <link rel="stylesheet" href="/static/compiled.css">
     <link rel="stylesheet" href="/static/standalone.css">
     <style>
-        html, body, #root { margin: 0; padding: 0; width: 100%; height: 100vh; background: #181D1F; }
+        html, body { margin: 0; padding: 0; width: 100%; height: 100%; background: #181D1F; }
+        #root { width: 100%; height: 100%; }
         /* Flex utility classes used by components */
         .flex { display: flex; }
         .flex-col { flex-direction: column; }
         /* orig-df uses "flex flex-row" but layout must be column (status bar on top, table below) */
         .orig-df.flex-row { flex-direction: column; }
+        /* Standalone fill-mode: unbroken flex chain from viewport to AG Grid */
+        .buckaroo_anywidget {
+            display: flex;
+            flex-direction: column;
+        }
         /* Match Jupyter's .cell-output-ipywidget-background gap removal */
         .status-bar { margin-bottom: 0; }
         .df-viewer { margin-top: 0; }

--- a/packages/buckaroo-js-core/playwright.config.server.ts
+++ b/packages/buckaroo-js-core/playwright.config.server.ts
@@ -8,7 +8,7 @@ const PYTHON = process.env.BUCKAROO_SERVER_PYTHON ?? 'uv run python';
 
 export default defineConfig({
   testDir: './pw-tests',
-  testMatch: ['server.spec.ts', 'server-buckaroo-search.spec.ts', 'server-buckaroo-summary.spec.ts', 'theme-screenshots-server.spec.ts'],
+  testMatch: ['server.spec.ts', 'server-buckaroo-search.spec.ts', 'server-buckaroo-summary.spec.ts', 'theme-screenshots-server.spec.ts', 'height-mode-server.spec.ts'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,

--- a/packages/buckaroo-js-core/pw-tests/height-mode-server.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/height-mode-server.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect } from '@playwright/test';
+import { waitForGrid } from './server-helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const PORT = 8701;
+const BASE = `http://localhost:${PORT}`;
+
+const screenshotsDir = path.resolve(__dirname, '..', 'screenshots', 'height-mode');
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+// --- Test data ---
+
+function writeTempCsv(rowCount: number): string {
+  const header = 'name,age,score';
+  const rows = [];
+  for (let i = 0; i < rowCount; i++) {
+    rows.push(`row${i},${20 + (i % 50)},${(i * 1.7).toFixed(1)}`);
+  }
+  const content = [header, ...rows].join('\n') + '\n';
+  const tmpPath = path.join(os.tmpdir(), `buckaroo_height_test_${Date.now()}_${rowCount}.csv`);
+  fs.writeFileSync(tmpPath, content);
+  return tmpPath;
+}
+
+function cleanupFile(p: string) {
+  if (p && fs.existsSync(p)) fs.unlinkSync(p);
+}
+
+async function loadViewer(request: any, session: string, filePath: string) {
+  const resp = await request.post(`${BASE}/load`, {
+    data: { session, path: filePath },
+  });
+  if (!resp.ok()) throw new Error(`/load failed (${resp.status()}): ${await resp.text()}`);
+  return resp.json();
+}
+
+// --- Tests ---
+
+test.describe('Height mode server integration', () => {
+  let csv5: string;
+  let csv100: string;
+
+  test.beforeAll(() => {
+    csv5 = writeTempCsv(5);
+    csv100 = writeTempCsv(100);
+  });
+
+  test.afterAll(() => {
+    cleanupFile(csv5);
+    cleanupFile(csv100);
+  });
+
+  test('fill mode: 100-row table fills viewport with no black gap', async ({ page, request }) => {
+    const session = `height-fill-100-${Date.now()}`;
+    await loadViewer(request, session, csv100);
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto(`${BASE}/s/${session}`);
+    await waitForGrid(page);
+    await page.waitForTimeout(1000);
+
+    // Measure the gap between the bottom of .theme-hanger and the viewport bottom
+    const gap = await page.evaluate(() => {
+      const el = document.querySelector('.theme-hanger');
+      if (!el) return 9999;
+      const rect = el.getBoundingClientRect();
+      return window.innerHeight - rect.bottom;
+    });
+
+    // In fill mode, the grid should extend close to the bottom of the viewport.
+    // Allow some tolerance for borders/margins.
+    // NOTE: This test will fail before implementation (gap will be ~half the screen).
+    expect(gap).toBeLessThan(50);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'server-fill-100rows.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fill mode: 5-row short table does not stretch', async ({ page, request }) => {
+    const session = `height-fill-5-${Date.now()}`;
+    await loadViewer(request, session, csv5);
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto(`${BASE}/s/${session}`);
+    await waitForGrid(page);
+    await page.waitForTimeout(1000);
+
+    // Short table: the grid should be small, not filling the viewport
+    const gridHeight = await page.evaluate(() => {
+      const el = document.querySelector('.theme-hanger');
+      if (!el) return 0;
+      return el.getBoundingClientRect().height;
+    });
+
+    // 5 rows + header + pinned ≈ under 250px
+    expect(gridHeight).toBeLessThan(250);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'server-fill-5rows-short.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fill mode: resize window causes grid to resize', async ({ page, request }) => {
+    const session = `height-fill-resize-${Date.now()}`;
+    await loadViewer(request, session, csv100);
+
+    // Start with a large viewport
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto(`${BASE}/s/${session}`);
+    await waitForGrid(page);
+    await page.waitForTimeout(1000);
+
+    const heightBefore = await page.evaluate(() => {
+      const el = document.querySelector('.theme-hanger');
+      return el ? el.getBoundingClientRect().height : 0;
+    });
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'server-fill-resize-before.png'),
+      fullPage: true,
+    });
+
+    // Resize to a smaller viewport
+    await page.setViewportSize({ width: 1024, height: 400 });
+    await page.waitForTimeout(1000);
+
+    const heightAfter = await page.evaluate(() => {
+      const el = document.querySelector('.theme-hanger');
+      return el ? el.getBoundingClientRect().height : 0;
+    });
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'server-fill-resize-after.png'),
+      fullPage: true,
+    });
+
+    // The grid should have gotten smaller after resize
+    // NOTE: This test will fail before implementation (height is fixed pixels).
+    expect(heightAfter).toBeLessThan(heightBefore);
+    // The difference should be significant (not just 1-2px jitter)
+    expect(heightBefore - heightAfter).toBeGreaterThan(100);
+  });
+
+  // Screenshots for comparison viewer (both viewport sizes)
+  for (const scheme of ['light', 'dark'] as const) {
+    test(`server screenshot 100 rows [${scheme}]`, async ({ page, request }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      const session = `height-ss-100-${scheme}-${Date.now()}`;
+      await loadViewer(request, session, csv100);
+      await page.setViewportSize({ width: 1024, height: 768 });
+      await page.goto(`${BASE}/s/${session}`);
+      await waitForGrid(page);
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `server-100rows--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+
+    test(`server screenshot 5 rows [${scheme}]`, async ({ page, request }) => {
+      await page.emulateMedia({ colorScheme: scheme });
+      const session = `height-ss-5-${scheme}-${Date.now()}`;
+      await loadViewer(request, session, csv5);
+      await page.setViewportSize({ width: 1024, height: 768 });
+      await page.goto(`${BASE}/s/${session}`);
+      await waitForGrid(page);
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `server-5rows--${scheme}.png`),
+        fullPage: true,
+      });
+    });
+  }
+});

--- a/packages/buckaroo-js-core/pw-tests/height-mode.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/height-mode.spec.ts
@@ -1,0 +1,324 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const STORYBOOK_BASE = 'http://localhost:6006/iframe.html?viewMode=story&id=';
+
+const screenshotsDir = path.resolve(__dirname, '..', 'screenshots', 'height-mode');
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+/**
+ * Wait for AG-Grid to render its first data cells.
+ */
+async function waitForAgGrid(page: any, timeout = 15000) {
+  await page.locator('.ag-root-wrapper').first().waitFor({ state: 'attached', timeout });
+  await page.locator('.ag-cell').first().waitFor({ state: 'visible', timeout });
+}
+
+/**
+ * querySelector that pierces open shadow DOMs.
+ * Stories use ShadowDomWrapper, so elements live inside a shadow root
+ * that native document.querySelector cannot reach.
+ */
+function deepQuerySelector(selector: string, root: ParentNode = document): Element | null {
+  const el = root.querySelector(selector);
+  if (el) return el;
+  // Walk all elements looking for shadow roots
+  const allEls = root.querySelectorAll('*');
+  for (const host of allEls) {
+    if (host.shadowRoot) {
+      const found = deepQuerySelector(selector, host.shadowRoot);
+      if (found) return found;
+    }
+  }
+  return null;
+}
+
+/**
+ * Get the bounding box height of the .theme-hanger element (the AG Grid container).
+ * Pierces shadow DOM since stories use ShadowDomWrapper.
+ */
+async function getThemeHangerHeight(page: any): Promise<number> {
+  return page.evaluate(() => {
+    const dqs = (sel: string, root: ParentNode = document): Element | null => {
+      const el = root.querySelector(sel);
+      if (el) return el;
+      for (const host of root.querySelectorAll('*')) {
+        if (host.shadowRoot) { const f = dqs(sel, host.shadowRoot); if (f) return f; }
+      }
+      return null;
+    };
+    const el = dqs('.theme-hanger');
+    if (!el) return 0;
+    return el.getBoundingClientRect().height;
+  });
+}
+
+/**
+ * Get the bounding box of the .df-viewer element.
+ * Pierces shadow DOM since stories use ShadowDomWrapper.
+ */
+async function getDfViewerBox(page: any): Promise<{ height: number; width: number } | null> {
+  return page.evaluate(() => {
+    const dqs = (sel: string, root: ParentNode = document): Element | null => {
+      const el = root.querySelector(sel);
+      if (el) return el;
+      for (const host of root.querySelectorAll('*')) {
+        if (host.shadowRoot) { const f = dqs(sel, host.shadowRoot); if (f) return f; }
+      }
+      return null;
+    };
+    const el = dqs('.df-viewer');
+    if (!el) return null;
+    const r = el.getBoundingClientRect();
+    return { height: r.height, width: r.width };
+  });
+}
+
+// --- Height Mode stories ---
+
+const HEIGHT_MODE_STORIES = {
+  fractionMode: 'buckaroo-dfviewer-heightmode--fraction-mode',
+  fractionModeShort: 'buckaroo-dfviewer-heightmode--fraction-mode-short',
+  fixedMode: 'buckaroo-dfviewer-heightmode--fixed-mode',
+  fixedModeShort: 'buckaroo-dfviewer-heightmode--fixed-mode-short',
+  fillMode: 'buckaroo-dfviewer-heightmode--fill-mode',
+  fillModeShort: 'buckaroo-dfviewer-heightmode--fill-mode-short',
+  noHeightMode: 'buckaroo-dfviewer-heightmode--no-height-mode',
+  noHeightModeShort: 'buckaroo-dfviewer-heightmode--no-height-mode-short',
+};
+
+test.describe('HeightMode Storybook integration tests', () => {
+
+  test('fill mode: grid fills container', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.fillMode}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    // Container is 600px. In fill mode, the grid should use most of it.
+    // Allow tolerance for status bar, headers, borders.
+    expect(height).toBeGreaterThan(400);
+
+    // Verify the CSS flex chain is unbroken (pierce shadow DOM)
+    const flexDisplay = await page.evaluate(() => {
+      const dqs = (sel: string, root: ParentNode = document): Element | null => {
+        const el = root.querySelector(sel);
+        if (el) return el;
+        for (const host of root.querySelectorAll('*')) {
+          if (host.shadowRoot) { const f = dqs(sel, host.shadowRoot); if (f) return f; }
+        }
+        return null;
+      };
+      const el = dqs('.df-viewer.fill-mode');
+      return el ? getComputedStyle(el).display : 'not-found';
+    });
+    expect(flexDisplay).toBe('flex');
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'fill-mode-300rows.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fill mode short: grid does NOT stretch to fill', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.fillModeShort}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    // 3 rows at ~21px each + header ≈ 100px. Should be well under 200.
+    expect(height).toBeLessThan(200);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'fill-mode-short.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fraction mode: grid uses approximately half of container', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.fractionMode}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    // window.innerHeight / 2 ≈ half the viewport. The story container is 600px
+    // but fraction mode uses window.innerHeight, not the container.
+    // Just verify it's a reasonable size (not 0, not the full viewport).
+    expect(height).toBeGreaterThan(100);
+    expect(height).toBeLessThan(800);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'fraction-mode-300rows.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fraction mode short: grid auto-sizes to content', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.fractionModeShort}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    expect(height).toBeLessThan(200);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'fraction-mode-short.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fixed mode: grid uses explicit pixel height', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.fixedMode}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    // dfvHeight is 400. Allow some tolerance for borders/padding.
+    expect(height).toBeGreaterThan(380);
+    expect(height).toBeLessThan(420);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'fixed-mode-300rows.png'),
+      fullPage: true,
+    });
+  });
+
+  test('fixed mode short: still uses fixed height (no short mode)', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.fixedModeShort}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    // Fixed mode ignores short — should still be ~400px
+    expect(height).toBeGreaterThan(380);
+    expect(height).toBeLessThan(420);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'fixed-mode-short.png'),
+      fullPage: true,
+    });
+  });
+
+  test('no heightMode: backward compat defaults to fraction', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.noHeightMode}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    expect(height).toBeGreaterThan(100);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'no-heightmode-300rows.png'),
+      fullPage: true,
+    });
+  });
+
+  test('no heightMode short: backward compat short mode', async ({ page }) => {
+    await page.goto(`${STORYBOOK_BASE}${HEIGHT_MODE_STORIES.noHeightModeShort}`);
+    await waitForAgGrid(page);
+    await page.waitForTimeout(500);
+
+    const height = await getThemeHangerHeight(page);
+    expect(height).toBeLessThan(200);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, 'no-heightmode-short.png'),
+      fullPage: true,
+    });
+  });
+
+  // Screenshot all stories in dark mode for the comparison viewer
+  for (const [name, storyId] of Object.entries(HEIGHT_MODE_STORIES)) {
+    test(`screenshot ${name} [dark]`, async ({ page }) => {
+      await page.emulateMedia({ colorScheme: 'dark' });
+      await page.goto(`${STORYBOOK_BASE}${storyId}`);
+      await waitForAgGrid(page);
+      await page.waitForTimeout(500);
+      await page.screenshot({
+        path: path.join(screenshotsDir, `${name}--dark.png`),
+        fullPage: true,
+      });
+    });
+  }
+});
+
+// After all tests, write a manifest for the comparison viewer.
+// Shows "before" (noHeightMode = legacy default) vs "after" (each named mode).
+test.afterAll(() => {
+  const manifest = {
+    generated: new Date().toISOString(),
+    pairs: [
+      // Before/after: default (legacy) vs fill mode
+      {
+        name: 'Fill Mode — 300 rows',
+        before: 'noHeightMode--dark.png',
+        after: 'fillMode--dark.png',
+        beforeLabel: 'Default (before)',
+        afterLabel: 'Fill (after)',
+      },
+      {
+        name: 'Fill Mode — short (3 rows)',
+        before: 'noHeightModeShort--dark.png',
+        after: 'fillModeShort--dark.png',
+        beforeLabel: 'Default (before)',
+        afterLabel: 'Fill (after)',
+      },
+      // Before/after: default (legacy) vs fraction mode
+      {
+        name: 'Fraction Mode — 300 rows',
+        before: 'noHeightMode--dark.png',
+        after: 'fractionMode--dark.png',
+        beforeLabel: 'Default (before)',
+        afterLabel: 'Fraction (after)',
+      },
+      {
+        name: 'Fraction Mode — short (3 rows)',
+        before: 'noHeightModeShort--dark.png',
+        after: 'fractionModeShort--dark.png',
+        beforeLabel: 'Default (before)',
+        afterLabel: 'Fraction (after)',
+      },
+      // Before/after: default (legacy) vs fixed mode
+      {
+        name: 'Fixed Mode — 300 rows',
+        before: 'noHeightMode--dark.png',
+        after: 'fixedMode--dark.png',
+        beforeLabel: 'Default (before)',
+        afterLabel: 'Fixed 400px (after)',
+      },
+      {
+        name: 'Fixed Mode — short (3 rows)',
+        before: 'noHeightModeShort--dark.png',
+        after: 'fixedModeShort--dark.png',
+        beforeLabel: 'Default (before)',
+        afterLabel: 'Fixed 400px (after)',
+      },
+      // Cross-comparison: fill vs fraction (the two non-fixed modes)
+      {
+        name: 'Fill vs Fraction — 300 rows',
+        before: 'fractionMode--dark.png',
+        after: 'fillMode--dark.png',
+        beforeLabel: 'Fraction',
+        afterLabel: 'Fill',
+      },
+      {
+        name: 'Fill vs Fraction — short (3 rows)',
+        before: 'fractionModeShort--dark.png',
+        after: 'fillModeShort--dark.png',
+        beforeLabel: 'Fraction',
+        afterLabel: 'Fill',
+      },
+    ],
+  };
+  fs.writeFileSync(
+    path.join(screenshotsDir, 'manifest.json'),
+    JSON.stringify(manifest, null, 2)
+  );
+});

--- a/packages/buckaroo-js-core/pw-tests/screenshot-compare.html
+++ b/packages/buckaroo-js-core/pw-tests/screenshot-compare.html
@@ -1,0 +1,337 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Buckaroo Screenshot Comparison</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #1a1a2e; color: #e0e0e0; }
+  h1 { padding: 16px 24px; font-size: 20px; background: #16213e; border-bottom: 1px solid #333; }
+  .controls { padding: 12px 24px; background: #16213e; border-bottom: 1px solid #333; display: flex; gap: 12px; align-items: center; flex-wrap: wrap; }
+  .controls label { font-size: 13px; }
+  .controls select, .controls input { background: #0f3460; color: #e0e0e0; border: 1px solid #555; padding: 4px 8px; border-radius: 4px; font-size: 13px; }
+  .controls button { background: #e94560; color: white; border: none; padding: 6px 14px; border-radius: 4px; cursor: pointer; font-size: 13px; }
+  .controls button:hover { background: #c73e54; }
+  .controls button.secondary { background: #0f3460; }
+  .controls button.secondary:hover { background: #1a5276; }
+
+  .pairs-container { padding: 16px 24px; }
+  .pair { margin-bottom: 32px; border: 1px solid #333; border-radius: 8px; overflow: hidden; background: #16213e; }
+  .pair-header { padding: 10px 16px; background: #0f3460; font-weight: 600; font-size: 14px; display: flex; justify-content: space-between; align-items: center; }
+  .pair-header .badge { font-size: 11px; padding: 2px 8px; border-radius: 10px; background: #e94560; }
+  .pair-body { display: flex; }
+  .pair-body.stacked { flex-direction: column; }
+  .pair-side { flex: 1; min-width: 0; position: relative; }
+  .pair-side img { width: 100%; display: block; }
+  .side-label { position: absolute; top: 8px; left: 8px; background: rgba(0,0,0,0.7); padding: 2px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; z-index: 2; }
+  .side-label.before { color: #ff6b6b; }
+  .side-label.after { color: #51cf66; }
+  .divider { width: 2px; background: #e94560; flex-shrink: 0; }
+
+  /* Slider overlay mode */
+  .slider-container { position: relative; overflow: hidden; }
+  .slider-container img { display: block; width: 100%; }
+  .slider-container .overlay { position: absolute; top: 0; left: 0; height: 100%; overflow: hidden; border-right: 2px solid #e94560; }
+  .slider-container .overlay img { display: block; height: 100%; width: auto; min-width: 100%; }
+  .slider-container input[type=range] { position: absolute; bottom: 8px; left: 10%; width: 80%; z-index: 3; }
+
+  /* Toggle mode */
+  .toggle-container { position: relative; cursor: pointer; }
+  .toggle-container img { display: block; width: 100%; }
+  .toggle-container .toggle-hint { position: absolute; bottom: 8px; right: 8px; background: rgba(0,0,0,0.7); padding: 2px 8px; border-radius: 4px; font-size: 11px; }
+
+  .no-pairs { padding: 40px; text-align: center; color: #888; }
+  .no-pairs code { background: #0f3460; padding: 2px 6px; border-radius: 3px; }
+
+  .drop-zone { border: 2px dashed #555; border-radius: 8px; padding: 40px; text-align: center; margin: 16px 24px; color: #888; }
+  .drop-zone.active { border-color: #e94560; color: #e94560; }
+
+  #file-input { display: none; }
+</style>
+</head>
+<body>
+
+<h1>Buckaroo Screenshot Comparison</h1>
+
+<div class="controls">
+  <label>View:
+    <select id="view-mode">
+      <option value="side-by-side">Side by Side</option>
+      <option value="stacked">Stacked</option>
+      <option value="slider">Slider Overlay</option>
+      <option value="toggle">Click to Toggle</option>
+    </select>
+  </label>
+  <label>Filter:
+    <input type="text" id="filter" placeholder="filter by name..." />
+  </label>
+  <button class="secondary" onclick="document.getElementById('file-input').click()">Load Screenshots Folder</button>
+  <input type="file" id="file-input" webkitdirectory multiple />
+  <button class="secondary" onclick="loadFromManifest()">Load from manifest.json</button>
+  <span id="status" style="font-size:12px; color:#888;"></span>
+</div>
+
+<div id="content">
+  <div class="drop-zone" id="drop-zone">
+    <p>Drop a screenshots folder here, or use the controls above.</p>
+    <p style="margin-top:8px; font-size:13px;">
+      Expected structure: pairs of files like <code>name--before.png</code> / <code>name--after.png</code>,<br>
+      or any two images to compare side by side.
+    </p>
+  </div>
+</div>
+
+<script>
+// State
+let pairs = [];
+let viewMode = 'side-by-side';
+
+const contentEl = document.getElementById('content');
+const statusEl = document.getElementById('status');
+const filterEl = document.getElementById('filter');
+const viewModeEl = document.getElementById('view-mode');
+
+viewModeEl.addEventListener('change', () => { viewMode = viewModeEl.value; render(); });
+filterEl.addEventListener('input', render);
+
+// --- File loading ---
+
+document.getElementById('file-input').addEventListener('change', (e) => {
+  const files = Array.from(e.target.files);
+  processFiles(files);
+});
+
+// Drag and drop
+const dropZone = document.getElementById('drop-zone');
+document.addEventListener('dragover', (e) => { e.preventDefault(); dropZone?.classList.add('active'); });
+document.addEventListener('dragleave', () => { dropZone?.classList.remove('active'); });
+document.addEventListener('drop', (e) => {
+  e.preventDefault();
+  dropZone?.classList.remove('active');
+  if (e.dataTransfer.items) {
+    const items = Array.from(e.dataTransfer.items);
+    const filePromises = items
+      .filter(item => item.kind === 'file')
+      .map(item => item.getAsFile());
+    processFiles(filePromises.filter(Boolean));
+  }
+});
+
+function processFiles(files) {
+  const imageFiles = files.filter(f => f && /\.(png|jpg|jpeg|gif|webp)$/i.test(f.name));
+  if (imageFiles.length === 0) {
+    statusEl.textContent = 'No image files found';
+    return;
+  }
+
+  // Group into pairs by name pattern
+  const byBase = {};
+  for (const f of imageFiles) {
+    // Try to match patterns: name--before.png / name--after.png
+    // or: before/name.png / after/name.png
+    // or just group alphabetically in pairs
+    const name = f.name;
+    const match = name.match(/^(.+?)--(before|after|light|dark)\.(png|jpg|jpeg|gif|webp)$/i);
+    if (match) {
+      const base = match[1];
+      const tag = match[2].toLowerCase();
+      if (!byBase[base]) byBase[base] = {};
+      byBase[base][tag] = f;
+    } else {
+      // Check for path-based grouping: .../before/name.png vs .../after/name.png
+      const pathMatch = f.webkitRelativePath?.match(/\/(before|after)\/(.+)$/i);
+      if (pathMatch) {
+        const tag = pathMatch[1].toLowerCase();
+        const base = pathMatch[2].replace(/\.[^.]+$/, '');
+        if (!byBase[base]) byBase[base] = {};
+        byBase[base][tag] = f;
+      }
+    }
+  }
+
+  // Build pairs
+  pairs = [];
+  for (const [base, group] of Object.entries(byBase)) {
+    const before = group.before || group.light;
+    const after = group.after || group.dark;
+    if (before && after) {
+      pairs.push({
+        name: base,
+        beforeUrl: URL.createObjectURL(before),
+        afterUrl: URL.createObjectURL(after),
+        beforeLabel: group.before ? 'Before' : 'Light',
+        afterLabel: group.after ? 'After' : 'Dark',
+      });
+    }
+  }
+
+  // If no pairs found by naming convention, just pair them up sequentially
+  if (pairs.length === 0 && imageFiles.length >= 2) {
+    const sorted = imageFiles.sort((a, b) => a.name.localeCompare(b.name));
+    for (let i = 0; i < sorted.length - 1; i += 2) {
+      pairs.push({
+        name: `${sorted[i].name} vs ${sorted[i+1].name}`,
+        beforeUrl: URL.createObjectURL(sorted[i]),
+        afterUrl: URL.createObjectURL(sorted[i+1]),
+        beforeLabel: sorted[i].name,
+        afterLabel: sorted[i+1].name,
+      });
+    }
+  }
+
+  statusEl.textContent = `${pairs.length} pair(s) from ${imageFiles.length} images`;
+  render();
+}
+
+// --- Manifest loading ---
+
+async function loadFromManifest() {
+  const manifestPaths = [
+    '../screenshots/height-mode/manifest.json',
+    './screenshots/height-mode/manifest.json',
+    'screenshots/height-mode/manifest.json',
+  ];
+
+  statusEl.textContent = 'Loading manifest...';
+
+  let manifest = null;
+  let basePath = null;
+
+  for (const mpath of manifestPaths) {
+    try {
+      const resp = await fetch(mpath);
+      if (resp.ok) {
+        manifest = await resp.json();
+        basePath = mpath.replace('/manifest.json', '');
+        break;
+      }
+    } catch (_) { /* try next path */ }
+  }
+
+  if (!manifest) {
+    statusEl.textContent = 'No manifest.json found — run Playwright tests first, or check file paths';
+    return;
+  }
+
+  pairs = manifest.pairs.map(p => ({
+    name: p.name,
+    beforeUrl: `${basePath}/${p.before}`,
+    afterUrl: `${basePath}/${p.after}`,
+    beforeLabel: p.beforeLabel || 'Before',
+    afterLabel: p.afterLabel || 'After',
+  }));
+  statusEl.textContent = `${pairs.length} pair(s) from manifest (${basePath})`;
+  render();
+}
+
+// --- Rendering ---
+
+function render() {
+  const filter = filterEl.value.toLowerCase();
+  const filtered = filter ? pairs.filter(p => p.name.toLowerCase().includes(filter)) : pairs;
+
+  if (filtered.length === 0) {
+    contentEl.innerHTML = `<div class="no-pairs">No screenshot pairs to show. Load some images or run the Playwright tests.</div>`;
+    return;
+  }
+
+  contentEl.innerHTML = filtered.map((pair, i) => {
+    switch (viewMode) {
+      case 'side-by-side': return renderSideBySide(pair, i);
+      case 'stacked': return renderStacked(pair, i);
+      case 'slider': return renderSlider(pair, i);
+      case 'toggle': return renderToggle(pair, i);
+      default: return renderSideBySide(pair, i);
+    }
+  }).join('');
+
+  // Attach slider event handlers
+  if (viewMode === 'slider') {
+    document.querySelectorAll('.slider-range').forEach(el => {
+      el.addEventListener('input', (e) => {
+        const idx = e.target.dataset.idx;
+        const pct = e.target.value;
+        const overlay = document.getElementById(`overlay-${idx}`);
+        if (overlay) overlay.style.width = pct + '%';
+      });
+    });
+  }
+
+  // Attach toggle handlers
+  if (viewMode === 'toggle') {
+    document.querySelectorAll('.toggle-container').forEach(el => {
+      let showAfter = true;
+      el.addEventListener('click', () => {
+        showAfter = !showAfter;
+        const imgs = el.querySelectorAll('img');
+        const hint = el.querySelector('.toggle-hint');
+        imgs[0].style.display = showAfter ? 'block' : 'none';
+        imgs[1].style.display = showAfter ? 'none' : 'block';
+        if (hint) hint.textContent = showAfter ? 'Showing: After (click to toggle)' : 'Showing: Before (click to toggle)';
+      });
+    });
+  }
+}
+
+function renderSideBySide(pair, i) {
+  return `<div class="pair">
+    <div class="pair-header"><span>${pair.name}</span></div>
+    <div class="pair-body">
+      <div class="pair-side">
+        <span class="side-label before">${pair.beforeLabel}</span>
+        <img src="${pair.beforeUrl}" alt="${pair.beforeLabel}" />
+      </div>
+      <div class="divider"></div>
+      <div class="pair-side">
+        <span class="side-label after">${pair.afterLabel}</span>
+        <img src="${pair.afterUrl}" alt="${pair.afterLabel}" />
+      </div>
+    </div>
+  </div>`;
+}
+
+function renderStacked(pair, i) {
+  return `<div class="pair">
+    <div class="pair-header"><span>${pair.name}</span></div>
+    <div class="pair-body stacked">
+      <div class="pair-side">
+        <span class="side-label before">${pair.beforeLabel}</span>
+        <img src="${pair.beforeUrl}" alt="${pair.beforeLabel}" />
+      </div>
+      <div class="pair-side">
+        <span class="side-label after">${pair.afterLabel}</span>
+        <img src="${pair.afterUrl}" alt="${pair.afterLabel}" />
+      </div>
+    </div>
+  </div>`;
+}
+
+function renderSlider(pair, i) {
+  return `<div class="pair">
+    <div class="pair-header"><span>${pair.name}</span> <span class="badge">Drag slider</span></div>
+    <div class="slider-container">
+      <img src="${pair.afterUrl}" alt="${pair.afterLabel}" />
+      <div class="overlay" id="overlay-${i}" style="width:50%;">
+        <img src="${pair.beforeUrl}" alt="${pair.beforeLabel}" />
+      </div>
+      <input type="range" class="slider-range" data-idx="${i}" min="0" max="100" value="50" />
+    </div>
+  </div>`;
+}
+
+function renderToggle(pair, i) {
+  return `<div class="pair">
+    <div class="pair-header"><span>${pair.name}</span> <span class="badge">Click to toggle</span></div>
+    <div class="toggle-container">
+      <img src="${pair.afterUrl}" alt="${pair.afterLabel}" style="display:block;" />
+      <img src="${pair.beforeUrl}" alt="${pair.beforeLabel}" style="display:none;" />
+      <span class="toggle-hint">Showing: After (click to toggle)</span>
+    </div>
+  </div>`;
+}
+
+// Try to auto-load manifest on page load
+loadFromManifest();
+</script>
+</body>
+</html>

--- a/packages/buckaroo-js-core/pw-tests/theme-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-screenshots.spec.ts
@@ -40,6 +40,11 @@ const STORIES = [
 
   // MessageBox
   { id: 'buckaroo-messagebox--mixed-messages', name: 'MessageBox-Mixed' },
+
+  // Height mode
+  { id: 'buckaroo-dfviewer-heightmode--fill-mode', name: 'HeightMode-Fill' },
+  { id: 'buckaroo-dfviewer-heightmode--fraction-mode', name: 'HeightMode-Fraction' },
+  { id: 'buckaroo-dfviewer-heightmode--fixed-mode', name: 'HeightMode-Fixed' },
 ];
 
 const SCHEMES = ['light', 'dark'] as const;

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -169,13 +169,14 @@ export function BuckarooInfiniteWidget({
         //evantually spliced back into the request args from scrolling/
         //the data source
         const outsideDFParams = [operations, buckaroo_state.post_processing, buckaroo_state.quick_command_args, buckaroo_state.df_display];
+        const isFillMode = cDisp.df_viewer_config?.component_config?.heightMode === "fill";
+        const fillClass = isFillMode ? "fill-mode" : "";
         return (
-            <div className="dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget"
+            <div className={`dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget ${fillClass}`}
              style={{ width: "100%", height: "100%" }}>
                 <div
-                    className="orig-df flex flex-row"
+                    className={`orig-df flex flex-row ${fillClass}`}
                     style={{
-                        // height: '450px',
                         overflow: "hidden",
                     }}
                 >
@@ -288,13 +289,14 @@ export function DFViewerInfiniteDS({
             });
         }, [messages, messagesEnabled, message_log]);
 
+        const isFillMode = cDisp.df_viewer_config?.component_config?.heightMode === "fill";
+        const fillClass = isFillMode ? "fill-mode" : "";
         return (
-            <div className="dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget"
+            <div className={`dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget ${fillClass}`}
              style={{ width: "100%", height: "100%" }}>
                 <div
-                    className="orig-df flex flex-row"
+                    className={`orig-df flex flex-row ${fillClass}`}
                     style={{
-                        // height: '450px',
                         overflow: "hidden",
                     }}
                 >

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -159,8 +159,10 @@ export function DFViewerInfinite({
     const colorScheme = useColorScheme();
     const defaultThemeClass = colorScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
     const divClass = df_viewer_config?.component_config?.className || defaultThemeClass;
+    const isFillMode = df_viewer_config?.component_config?.heightMode === "fill";
+    const fillClass = (isFillMode && hs.classMode !== "short-mode") ? "fill-mode" : "";
     return (
-        <div className={`df-viewer  ${hs.classMode} ${hs.inIframe}`}>
+        <div className={`df-viewer ${hs.classMode} ${hs.inIframe} ${fillClass}`}>
             <pre>{error_info ? error_info : ""}</pre>
             <div style={hs.applicableStyle}
                 className={`theme-hanger ${divClass}`}>

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -165,7 +165,10 @@ export type PinnedRowConfig = {
     default_renderer_columns?: string[];
 };
 
+export type HeightMode = "fraction" | "fixed" | "fill";
+
 export type ComponentConfig = {
+    heightMode?: HeightMode;
     height_fraction?: number;
     // temporary debugging props
     dfvHeight?: number;

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -162,6 +162,84 @@ describe("testing utility functions in gridUtils ", () => {
     });
   });
 
+  describe("getHeightStyle with heightMode", () => {
+    // --- "fraction" mode (Jupyter, Marimo) ---
+    it("heightMode 'fraction' with many rows → regular mode, pixel height", () => {
+      const result = getHeightStyle2(100, 0, { heightMode: "fraction", height_fraction: 2 });
+      expect(result.classMode).toBe("regular-mode");
+      expect(result.domLayout).toBe("normal");
+      // applicableStyle should have a numeric height (pixels)
+      expect(typeof result.applicableStyle.height).toBe("number");
+      expect((result.applicableStyle.height as number)).toBeGreaterThan(0);
+    });
+
+    it("heightMode 'fraction' with few rows → short mode", () => {
+      const result = getHeightStyle2(3, 0, { heightMode: "fraction", height_fraction: 2 });
+      expect(result.classMode).toBe("short-mode");
+      expect(result.domLayout).toBe("autoHeight");
+    });
+
+    // --- "fixed" mode (Colab, VSCode) ---
+    it("heightMode 'fixed' with dfvHeight → fixed pixel height", () => {
+      const result = getHeightStyle2(100, 0, { heightMode: "fixed", dfvHeight: 500 });
+      expect(result.classMode).toBe("regular-mode");
+      expect(result.domLayout).toBe("normal");
+      expect(result.applicableStyle.height).toBe(500);
+    });
+
+    it("heightMode 'fixed' defaults to 500px when dfvHeight not set", () => {
+      const result = getHeightStyle2(100, 0, { heightMode: "fixed" });
+      expect(result.domLayout).toBe("normal");
+      expect(result.applicableStyle.height).toBe(500);
+    });
+
+    it("heightMode 'fixed' with few rows still uses fixed height (no short mode override)", () => {
+      const result = getHeightStyle2(3, 0, { heightMode: "fixed", dfvHeight: 500 });
+      expect(result.classMode).toBe("regular-mode");
+      expect(result.domLayout).toBe("normal");
+      expect(result.applicableStyle.height).toBe(500);
+    });
+
+    // --- "fill" mode (MCP standalone) ---
+    it("heightMode 'fill' with many rows → flex style, normal domLayout", () => {
+      const result = getHeightStyle2(100, 0, { heightMode: "fill" });
+      expect(result.classMode).toBe("regular-mode");
+      expect(result.domLayout).toBe("normal");
+      // fill mode uses flex: 1 instead of a pixel height
+      expect(result.applicableStyle.flex).toBe(1);
+      expect(result.applicableStyle.minHeight).toBe(0);
+      expect(result.applicableStyle.overflow).toBe("hidden");
+      // should NOT have a pixel height
+      expect(result.applicableStyle.height).toBeUndefined();
+    });
+
+    it("heightMode 'fill' with few rows → short mode overrides fill", () => {
+      const result = getHeightStyle2(3, 0, { heightMode: "fill" });
+      expect(result.classMode).toBe("short-mode");
+      expect(result.domLayout).toBe("autoHeight");
+    });
+
+    // --- backward compat: no heightMode set ---
+    it("no heightMode with many rows → defaults to fraction behavior", () => {
+      const result = getHeightStyle2(100, 0, { height_fraction: 2 });
+      expect(result.classMode).toBe("regular-mode");
+      expect(result.domLayout).toBe("normal");
+      expect(typeof result.applicableStyle.height).toBe("number");
+    });
+
+    it("no heightMode with few rows → defaults to short mode", () => {
+      const result = getHeightStyle2(3, 0, {});
+      expect(result.classMode).toBe("short-mode");
+      expect(result.domLayout).toBe("autoHeight");
+    });
+
+    it("no heightMode, no component_config at all → defaults to fraction", () => {
+      const result = getHeightStyle2(100, 0);
+      expect(result.classMode).toBe("regular-mode");
+      expect(result.domLayout).toBe("normal");
+    });
+  });
+
   describe("getAutoSize", () => {
     it("should return fitProvidedWidth for 0 columns", () => {
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -265,14 +265,13 @@ export function dfToAgrid(
     pinned:'left'}
   }
   const lcc3 = lcc2.map(addPinned)
-  console.log("lcc3", lcc3);
 
   const columnConfigs: ColumnConfig[] =  dfviewer_config.column_config;
   const groupedColumnConfigs = getSubChildren(columnConfigs, 0);
   const flattenedColumnConfigs = groupedColumnConfigs.map(switchToColDef)
 
   const retMultiColumns:(ColDef|ColGroupDef)[] = [
-    ...lcc2,
+    ...lcc3,
     ...flattenedColumnConfigs]
   return retMultiColumns
 }

--- a/packages/buckaroo-js-core/src/stories/HeightMode.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/HeightMode.stories.tsx
@@ -1,0 +1,221 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
+import { DFViewerConfig, NormalColumnConfig, ComponentConfig } from "../components/DFViewerParts/DFWhole";
+import { ShadowDomWrapper } from "./StoryUtils";
+import { DatasourceWrapper, createDatasourceWrapper, dictOfArraystoDFData, arange, NRandom } from "../components/DFViewerParts/DFViewerDataHelper";
+import { useState, CSSProperties } from "react";
+
+/**
+ * Stories to test each HeightMode independently.
+ *
+ * Each story explicitly sets component_config.heightMode so the frontend
+ * dispatches to the named strategy — no environment sniffing involved.
+ */
+
+const INDEX_COL_CONFIG: NormalColumnConfig = {
+  col_name: "index",
+  header_name: "index",
+  displayer_args: { displayer: "string" },
+};
+
+const baseConfig: DFViewerConfig = {
+  column_config: [
+    { col_name: "a", header_name: "a", displayer_args: { displayer: "integer", min_digits: 1, max_digits: 5 } },
+    { col_name: "b", header_name: "b", displayer_args: { displayer: "obj" } },
+  ],
+  pinned_rows: [],
+  left_col_configs: [INDEX_COL_CONFIG],
+};
+
+const shortData = [
+  { index: 0, a: 10, b: "foo" },
+  { index: 1, a: 20, b: "bar" },
+  { index: 2, a: 30, b: "baz" },
+];
+
+const MEDIUM = 300;
+const mediumData = dictOfArraystoDFData({ a: NRandom(MEDIUM, 3, 50), b: arange(MEDIUM) });
+
+// --- Wrapper components ---
+
+/**
+ * Fixed-size container for fraction and fixed mode stories.
+ * Simulates a Jupyter/Colab output area with known dimensions.
+ */
+const FixedContainerViewer = ({
+  data,
+  component_config,
+  containerHeight,
+  containerWidth,
+}: {
+  data: any[];
+  component_config: ComponentConfig;
+  containerHeight: number;
+  containerWidth: number;
+}) => {
+  const [activeCol, setActiveCol] = useState<[string, string]>(["a", "a"]);
+  const data_wrapper: DatasourceWrapper = createDatasourceWrapper(data);
+  const config: DFViewerConfig = { ...baseConfig, component_config };
+
+  return (
+    <ShadowDomWrapper>
+      <div style={{ height: containerHeight, width: containerWidth }}>
+        <DFViewerInfinite
+          data_wrapper={data_wrapper}
+          df_viewer_config={config}
+          activeCol={activeCol}
+          setActiveCol={setActiveCol}
+        />
+      </div>
+    </ShadowDomWrapper>
+  );
+};
+
+/**
+ * Flex container for "fill" mode stories.
+ * Simulates the MCP standalone page where the grid should fill all available space.
+ * Uses display:flex + flex-direction:column so the grid's flex:1 style works.
+ */
+const FillContainerViewer = ({
+  data,
+  component_config,
+  containerHeight,
+  containerWidth,
+}: {
+  data: any[];
+  component_config: ComponentConfig;
+  containerHeight: number;
+  containerWidth: number;
+}) => {
+  const [activeCol, setActiveCol] = useState<[string, string]>(["a", "a"]);
+  const data_wrapper: DatasourceWrapper = createDatasourceWrapper(data);
+  const config: DFViewerConfig = { ...baseConfig, component_config };
+
+  const containerStyle: CSSProperties = {
+    height: containerHeight,
+    width: containerWidth,
+    display: "flex",
+    flexDirection: "column",
+  };
+
+  return (
+    <ShadowDomWrapper>
+      <div style={containerStyle}>
+        <DFViewerInfinite
+          data_wrapper={data_wrapper}
+          df_viewer_config={config}
+          activeCol={activeCol}
+          setActiveCol={setActiveCol}
+        />
+      </div>
+    </ShadowDomWrapper>
+  );
+};
+
+// --- Meta ---
+
+const meta = {
+  title: "Buckaroo/DFViewer/HeightMode",
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+} satisfies Meta;
+
+export default meta;
+
+// --- Stories ---
+
+/** Fraction mode (Jupyter/Marimo) — 300 rows, grid takes ~half of 600px container */
+export const FractionMode: StoryObj = {
+  render: () => (
+    <FixedContainerViewer
+      data={mediumData}
+      component_config={{ heightMode: "fraction", height_fraction: 2 }}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** Fraction mode with short table — 3 rows should auto-size, not take half screen */
+export const FractionModeShort: StoryObj = {
+  render: () => (
+    <FixedContainerViewer
+      data={shortData}
+      component_config={{ heightMode: "fraction", height_fraction: 2 }}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** Fixed mode (Colab/VSCode) — 300 rows, grid is exactly 400px */
+export const FixedMode: StoryObj = {
+  render: () => (
+    <FixedContainerViewer
+      data={mediumData}
+      component_config={{ heightMode: "fixed", dfvHeight: 400 }}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** Fixed mode with short table — still 400px (fixed mode ignores short) */
+export const FixedModeShort: StoryObj = {
+  render: () => (
+    <FixedContainerViewer
+      data={shortData}
+      component_config={{ heightMode: "fixed", dfvHeight: 400 }}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** Fill mode (MCP standalone) — 300 rows, grid fills the full 600px container */
+export const FillMode: StoryObj = {
+  render: () => (
+    <FillContainerViewer
+      data={mediumData}
+      component_config={{ heightMode: "fill" }}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** Fill mode with short table — 3 rows should auto-size, NOT stretch to 600px */
+export const FillModeShort: StoryObj = {
+  render: () => (
+    <FillContainerViewer
+      data={shortData}
+      component_config={{ heightMode: "fill" }}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** No heightMode set — backward compat, should behave like fraction */
+export const NoHeightMode: StoryObj = {
+  render: () => (
+    <FixedContainerViewer
+      data={mediumData}
+      component_config={{}}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};
+
+/** No heightMode, short table — backward compat short mode */
+export const NoHeightModeShort: StoryObj = {
+  render: () => (
+    <FixedContainerViewer
+      data={shortData}
+      component_config={{}}
+      containerHeight={600}
+      containerWidth={800}
+    />
+  ),
+};

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -495,6 +495,34 @@ div.dependent-tabs ul.tabs li.active {
 .df-viewer {
     width:100%;
 }
+
+/* fill-mode: unbroken flex column so AG Grid fills available space */
+.dcf-root.fill-mode {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+.orig-df.fill-mode {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0;
+}
+.orig-df.fill-mode .status-bar {
+    flex-shrink: 0;
+}
+.df-viewer.fill-mode {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+.df-viewer.fill-mode .theme-hanger {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
 .df-viewer.short-mode .ag-center-cols-viewport {
 /*  min-height: unset !important;  */
     min-height: 50px;

--- a/packages/js/standalone.tsx
+++ b/packages/js/standalone.tsx
@@ -15,6 +15,32 @@ import "../buckaroo-js-core/dist/style.css";
  * 5. Renders BuckarooInfiniteWidget (buckaroo mode) or DFViewerInfiniteDS (viewer mode)
  */
 
+/**
+ * Inject heightMode: "fill" into every display config's component_config.
+ * The standalone server page should fill the viewport, not use the Jupyter
+ * "half screen" heuristic.
+ */
+function injectFillMode(dfDisplayArgs: Record<string, any>): Record<string, any> {
+    const patched: Record<string, any> = {};
+    for (const [key, val] of Object.entries(dfDisplayArgs)) {
+        if (val && val.df_viewer_config) {
+            patched[key] = {
+                ...val,
+                df_viewer_config: {
+                    ...val.df_viewer_config,
+                    component_config: {
+                        ...val.df_viewer_config.component_config,
+                        heightMode: "fill",
+                    },
+                },
+            };
+        } else {
+            patched[key] = val;
+        }
+    }
+    return patched;
+}
+
 function getSessionId(): string {
     const match = window.location.pathname.match(/\/s\/([^/]+)/);
     if (!match) {
@@ -69,7 +95,7 @@ function ViewerApp({ model, src }: { model: WebSocketModel; src: any }) {
             <srt.DFViewerInfiniteDS
                 df_meta={dfMeta}
                 df_data_dict={dfDataDict}
-                df_display_args={dfDisplayArgs}
+                df_display_args={injectFillMode(dfDisplayArgs)}
                 src={src}
                 df_id={"standalone"}
             />
@@ -154,7 +180,7 @@ function BuckarooApp({ model, src }: { model: WebSocketModel; src: any }) {
             <srt.BuckarooInfiniteWidget
                 df_meta={dfMeta}
                 df_data_dict={dfDataDict}
-                df_display_args={dfDisplayArgs}
+                df_display_args={injectFillMode(dfDisplayArgs)}
                 operations={operations}
                 on_operations={onOperations}
                 operation_results={operationResults}

--- a/scripts/serve_height_comparison.sh
+++ b/scripts/serve_height_comparison.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Download height-mode CI screenshots and serve the comparison page locally.
+#
+# Usage:
+#   bash scripts/serve_height_comparison.sh [--port PORT] [--run-id RUN_ID] [--branch BRANCH]
+#
+# Requires: gh (GitHub CLI), python3
+
+set -euo pipefail
+
+PORT=8787
+RUN_ID=""
+BRANCH="worktree-height-fix"
+ARTIFACT_NAME="height-mode-screenshots"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --port)    PORT="$2"; shift 2 ;;
+    --run-id)  RUN_ID="$2"; shift 2 ;;
+    --branch)  BRANCH="$2"; shift 2 ;;
+    *)         echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+# Ensure gh is available
+if ! command -v gh &>/dev/null; then
+  echo "Error: GitHub CLI (gh) is required. Install it: https://cli.github.com/"
+  exit 1
+fi
+
+TMPDIR=$(mktemp -d)
+trap 'echo "Serving dir left at: $TMPDIR"' EXIT
+
+echo "==> Downloading artifact '${ARTIFACT_NAME}' from branch '${BRANCH}'..."
+
+if [[ -n "$RUN_ID" ]]; then
+  gh run download "$RUN_ID" --name "$ARTIFACT_NAME" --dir "$TMPDIR"
+else
+  # Find latest completed run on the branch
+  RUN_ID=$(gh run list --branch "$BRANCH" --workflow Checks --status completed --limit 1 --json databaseId --jq '.[0].databaseId')
+  if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+    echo "Error: No completed CI run found on branch '${BRANCH}'."
+    echo "Push to the branch first and wait for CI to finish."
+    exit 1
+  fi
+  echo "    Using run ID: ${RUN_ID}"
+  gh run download "$RUN_ID" --name "$ARTIFACT_NAME" --dir "$TMPDIR"
+fi
+
+echo "==> Downloaded to ${TMPDIR}"
+echo "    Contents:"
+ls -R "$TMPDIR"
+
+# Verify key files exist
+if [[ ! -f "$TMPDIR/pw-tests/screenshot-compare.html" ]]; then
+  # Try flat layout (artifact may strip prefix)
+  if [[ -f "$TMPDIR/screenshot-compare.html" ]]; then
+    mkdir -p "$TMPDIR/pw-tests"
+    mv "$TMPDIR/screenshot-compare.html" "$TMPDIR/pw-tests/"
+  else
+    echo "Warning: screenshot-compare.html not found in artifact"
+  fi
+fi
+
+if [[ ! -d "$TMPDIR/screenshots/height-mode" ]]; then
+  # Check if height-mode is at root level
+  if ls "$TMPDIR"/*.png &>/dev/null; then
+    mkdir -p "$TMPDIR/screenshots/height-mode"
+    mv "$TMPDIR"/*.png "$TMPDIR/screenshots/height-mode/"
+    [[ -f "$TMPDIR/manifest.json" ]] && mv "$TMPDIR/manifest.json" "$TMPDIR/screenshots/height-mode/"
+  fi
+fi
+
+URL="http://localhost:${PORT}/pw-tests/screenshot-compare.html"
+
+echo ""
+echo "==> Starting server on port ${PORT}"
+echo "    ${URL}"
+echo "    Press Ctrl+C to stop."
+echo ""
+
+# Auto-open in browser (macOS / Linux)
+(sleep 1 && {
+  if command -v open &>/dev/null; then
+    open "$URL"
+  elif command -v xdg-open &>/dev/null; then
+    xdg-open "$URL"
+  fi
+}) &
+
+cd "$TMPDIR"
+python3 -m http.server "$PORT"

--- a/scripts/test_playwright_storybook.sh
+++ b/scripts/test_playwright_storybook.sh
@@ -94,6 +94,7 @@ FAILED_TESTS=()
 STORYBOOK_TESTS=(
     "pw-tests/transcript-replayer.spec.ts"
     "pw-tests/outside-params.spec.ts"
+    "pw-tests/height-mode.spec.ts"
     # "pw-tests/example.spec.ts"  # Has pre-existing failures, excluded for now
 )
 


### PR DESCRIPTION
## Summary
- Introduces named `heightMode` strategies to replace implicit environment-sniffing in `heightStyle()`
- Three modes: `"fraction"` (Jupyter/Marimo), `"fixed"` (Colab/VSCode), `"fill"` (MCP standalone)
- **Test-first**: all tests and stories written before implementation — they will initially fail

## What's in this PR (test-first phase)
- `HEIGHT_PLAN.md` — full analysis of current height handling and implementation plan
- Unit tests for each `heightMode` in `gridUtils.test.ts`
- Storybook stories for each mode (`HeightMode.stories.tsx`)
- Playwright integration tests for Storybook stories and standalone server
- Screenshot comparison viewer (`screenshot-compare.html`) with slider/toggle/side-by-side views

## Key design decisions
- `heightMode` is set by the Python side (environment detection moves out of frontend)
- Backward compatible: no `heightMode` defaults to `"fraction"` (current behavior)
- `"fill"` mode uses CSS flexbox, no JS resize listeners — AG Grid detects container size changes natively
- Short tables (<5 rows) use `autoHeight` regardless of mode

## Test plan
- [ ] Unit tests pass after `heightStyle()` refactor
- [ ] Storybook stories render each mode correctly
- [ ] Playwright: fill mode fills viewport, fraction uses half, fixed uses explicit height
- [ ] Playwright: resize test verifies grid reflows in fill mode
- [ ] Screenshot comparison viewer shows before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)