### PR TITLE
perf: minify widget.js + lodash-es tree-shaking

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: "*"
+    branches: "**"
   merge_group:
   workflow_dispatch:
 

--- a/.github/workflows/deploy-ghpage.yml
+++ b/.github/workflows/deploy-ghpage.yml
@@ -6,22 +6,25 @@ on:
       - main
   pull_request:
     branches:
-#      - 'none-never'
-      - '*'
+      - '**'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
-          run_install: true
-          package_json_file: packages/package.json
+          version: 9.10.0
+      - uses: actions/setup-node@v6
+        with:
+          cache: 'pnpm'
+          cache-dependency-path: 'packages/pnpm-lock.yaml'
+      - name: Install pnpm dependencies
+        working-directory: packages
+        run: pnpm install --frozen-lockfile
       - uses: astral-sh/setup-uv@v7
-      - name: Run tests
+      - name: Build storybook
         working-directory: ./packages/buckaroo-js-core
         run: |
           pnpm build-storybook

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -7,14 +7,14 @@ on:
       - main
 
   pull_request:
-    branches: "*"
+    branches: "**"
 
 
 permissions:
   contents: read
   pages: write
   id-token: write
- 
+
 # List of jobs
 jobs:
   TestPython:
@@ -26,10 +26,15 @@ jobs:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
         with:
-          run_install: true
-          package_json_file: packages/package.json
-      - uses: astral-sh/setup-uv@v7
-      - name: Run tests
+          version: 9.10.0
+      - uses: actions/setup-node@v6
+        with:
+          cache: 'pnpm'
+          cache-dependency-path: 'packages/pnpm-lock.yaml'
+      - name: Install pnpm dependencies
+        working-directory: packages
+        run: pnpm install --frozen-lockfile
+      - name: Build storybook
         working-directory: ./packages/buckaroo-js-core
         run: |
           pnpm build-storybook

--- a/.gitignore
+++ b/.gitignore
@@ -159,6 +159,7 @@ ipydatagrid/nbextension/*
 buckaroo/nbextension/*
 buckaroo/labextension/*
 buckaroo/static/*.js
+buckaroo/static/*.js.map
 buckaroo/static/*.css
 docs/*.js
 docs/*.js.map

--- a/packages/buckaroo-js-core/jest.config.ts
+++ b/packages/buckaroo-js-core/jest.config.ts
@@ -8,6 +8,7 @@ export default {
     "\\.(css|less|sass|scss)$": "identity-obj-proxy",
     "^.+\\.svg$": "jest-transformer-svg",
     "^@/(.*)$": "<rootDir>/src/$1",
+    "^lodash-es$": "lodash",
   },
 
     testMatch: [

--- a/packages/buckaroo-js-core/package.json
+++ b/packages/buckaroo-js-core/package.json
@@ -30,12 +30,12 @@
     "/dist"
   ],
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^32.3.3",
-    "@ag-grid-community/core": "^32.3.3",
-    "@ag-grid-community/infinite-row-model": "^32.3.3",
-    "@ag-grid-community/react": "^32.3.3",
-    "@ag-grid-community/styles": "^32.3.3",
-    "@ag-grid-community/theming": "^32.3.3",
+    "@ag-grid-community/client-side-row-model": "^32.3.9",
+    "@ag-grid-community/core": "^32.3.9",
+    "@ag-grid-community/infinite-row-model": "^32.3.9",
+    "@ag-grid-community/react": "^32.3.9",
+    "@ag-grid-community/styles": "^32.3.9",
+    "@ag-grid-community/theming": "^32.3.9",
     "hyparquet": "^1.8.2",
     "lodash": "^4.17.21",
     "recharts": "^2.13.1"

--- a/packages/buckaroo-js-core/package.json
+++ b/packages/buckaroo-js-core/package.json
@@ -37,7 +37,7 @@
     "@ag-grid-community/styles": "^32.3.9",
     "@ag-grid-community/theming": "^32.3.9",
     "hyparquet": "^1.8.2",
-    "lodash": "^4.17.21",
+    "lodash-es": "^4.17.21",
     "recharts": "^2.13.1"
   },
   "devDependencies": {
@@ -55,7 +55,8 @@
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
     "@types/jest": "^29.5.14",
-    "@types/lodash": "^4.17.13",
+    "@types/lodash-es": "^4.17.12",
+    "lodash": "^4.17.21",
     "@types/node": "^22.15.3",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from "react";
-import * as _ from "lodash-es";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
 

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from "react";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
 

--- a/packages/buckaroo-js-core/src/components/DCFCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DCFCell.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
 

--- a/packages/buckaroo-js-core/src/components/DCFCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DCFCell.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from "react";
-import * as _ from "lodash-es";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/ChartCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/ChartCell.tsx
@@ -1,4 +1,4 @@
-import * as _ from "lodash-es";
+import { isArray } from "lodash-es";
 import React from "react";
 import { createPortal } from "react-dom";
 
@@ -125,7 +125,7 @@ export const getChartCell = (multiChartCellProps: ChartDisplayerA) => {
         const potentialHistogramArr = props.value;
         //for key "index", the value is "histogram"
         // this causes ReChart to blow up, so we check to see if it's an array
-        if (potentialHistogramArr === undefined || !_.isArray(potentialHistogramArr)) {
+        if (potentialHistogramArr === undefined || !isArray(potentialHistogramArr)) {
             return <span></span>;
         }
         const histogramArr = potentialHistogramArr as LineObservation[];

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/ChartCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/ChartCell.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import React from "react";
 import { createPortal } from "react-dom";
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
@@ -1,5 +1,5 @@
 import { IDatasource, IGetRowsParams } from "@ag-grid-community/core";
-import _ from "lodash";
+import * as _ from "lodash-es";
 
 export type RawDataWrapper = {
   data: any[];

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
@@ -1,5 +1,5 @@
 import { IDatasource, IGetRowsParams } from "@ag-grid-community/core";
-import * as _ from "lodash-es";
+import { keys, times, reduce } from "lodash-es";
 
 export type RawDataWrapper = {
   data: any[];
@@ -48,11 +48,11 @@ export const createDatasourceWrapper = (data: DFData, delay_in_milliseconds: num
 };
 
 export const dictOfArraystoDFData = (dict: Record<string, any[]>): DFData => {
-  const keys = _.keys(dict);
-  const length = dict[keys[0]].length;
+  const dictKeys = keys(dict);
+  const length = dict[dictKeys[0]].length;
 
-  return _.times(length, index => {
-    return _.reduce(keys, (result, key) => {
+  return times(length, index => {
+    return reduce(dictKeys, (result, key) => {
       result[key] = dict[key][index];
       return result;
     }, {} as Record<string, any>);

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -4,7 +4,7 @@ import {
     useEffect,
     useRef,
 } from "react";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { DFData, DFDataRow, DFViewerConfig, SDFT } from "./DFWhole";
 
 import { getCellRendererSelector, dfToAgrid, extractPinnedRows, extractSDFT } from "./gridUtils";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -4,7 +4,6 @@ import {
     useEffect,
     useRef,
 } from "react";
-import * as _ from "lodash-es";
 import { DFData, DFDataRow, DFViewerConfig, SDFT } from "./DFWhole";
 
 import { getCellRendererSelector, dfToAgrid, extractPinnedRows, extractSDFT } from "./gridUtils";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -1,7 +1,6 @@
 // I'm not sure about adding underlying types too
 
 import { ColDef, ColGroupDef, GridOptions } from "@ag-grid-community/core";
-import * as _ from "lodash-es";
 
 type AGGrid_ColDef = ColDef;
 export type ColDefOrGroup = ColDef|ColGroupDef

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -1,7 +1,7 @@
 // I'm not sure about adding underlying types too
 
 import { ColDef, ColGroupDef, GridOptions } from "@ag-grid-community/core";
-import _ from "lodash";
+import * as _ from "lodash-es";
 
 type AGGrid_ColDef = ColDef;
 export type ColDefOrGroup = ColDef|ColGroupDef

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
@@ -8,7 +8,7 @@ import {
     StringDisplayerA,
     ObjDisplayerA,
 } from "./DFWhole";
-import * as _ from "lodash-es";
+import { includes, isArray, isBoolean, isDate, isObject, map } from "lodash-es";
 
 import { HistogramCell } from "./HistogramCell";
 import { Base64PNGDisplayer, LinkCellRenderer, SVGDisplayer } from "./OtherRenderers";
@@ -43,12 +43,12 @@ export const getStringFormatter = (args: StringDisplayerA) => {
 };
 
 const dictDisplayer = (val: Record<string, any>): string => {
-    const objBody = _.map(val, (value, key) => `'${key}': ${objDisplayer(value)}`).join(",");
+    const objBody = map(val, (value, key) => `'${key}': ${objDisplayer(value)}`).join(",");
     return `{ ${objBody} }`;
 };
 
 export const isValidDate = (possibleDate: any): boolean => {
-    if (_.isDate(possibleDate) && isFinite(possibleDate.getTime())) {
+    if (isDate(possibleDate) && isFinite(possibleDate.getTime())) {
         return true;
     }
     return false;
@@ -72,11 +72,11 @@ export const dateDisplayerDefault = (d: Date): string => {
 const objDisplayer = (val: any | any[]): string => {
     if (val === undefined || val === null) {
         return "None";
-    } else if (_.isArray(val)) {
+    } else if (isArray(val)) {
         return `[ ${val.map(objDisplayer).join(", ")}]`;
-    } else if (_.isBoolean(val)) {
+    } else if (isBoolean(val)) {
         return boolDisplayer(val);
-    } else if (_.isObject(val)) {
+    } else if (isObject(val)) {
         return dictDisplayer(val);
     } else {
         return val.toString();
@@ -138,7 +138,7 @@ export const getFloatFormatter = (hint: FloatDisplayerA) => {
         }
 
         const res: string = floatFormatter.format(params.value);
-        if (!_.includes(res, ".")) {
+        if (!includes(res, ".")) {
             const padLength = res.length + hint.max_fraction_digits + 1;
             return res.padEnd(padLength);
         } else {
@@ -220,7 +220,7 @@ export function getCellRenderer(crArgs: CellRendererArgs) {
 }
 
 export function getFormatterFromArgs(dispArgs: DisplayerArgs) {
-    if (_.includes(cellRendererDisplayers, dispArgs.displayer)) {
+    if (includes(cellRendererDisplayers, dispArgs.displayer)) {
         return undefined;
     }
     const fArgs = dispArgs as FormatterArgs;

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
@@ -8,7 +8,7 @@ import {
     StringDisplayerA,
     ObjDisplayerA,
 } from "./DFWhole";
-import * as _ from "lodash";
+import * as _ from "lodash-es";
 
 import { HistogramCell } from "./HistogramCell";
 import { Base64PNGDisplayer, LinkCellRenderer, SVGDisplayer } from "./OtherRenderers";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -1,4 +1,4 @@
-import * as _ from "lodash-es";
+import { isArray } from "lodash-es";
 import React from "react";
 import { createPortal } from "react-dom";
 
@@ -91,7 +91,7 @@ export const HistogramCell = (props:
     const potentialHistogramArr = props.value;
     //for key "index", the value is "histogram"
     // this causes ReChart to blow up, so we check to see if it's an array
-    if (potentialHistogramArr === undefined || !_.isArray(potentialHistogramArr)) {
+    if (potentialHistogramArr === undefined || !isArray(potentialHistogramArr)) {
         return <span></span>;
     }
   const histogramArr = potentialHistogramArr as HistogramBar[];

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import React from "react";
 import { createPortal } from "react-dom";
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { ValueFormatterFunc } from "@ag-grid-community/core";
 
 export const getTextCellRenderer = (formatter: ValueFormatterFunc<any>) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
@@ -1,4 +1,3 @@
-import * as _ from "lodash-es";
 import { ValueFormatterFunc } from "@ag-grid-community/core";
 
 export const getTextCellRenderer = (formatter: ValueFormatterFunc<any>) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
@@ -1,4 +1,3 @@
-import * as _ from "lodash-es";
 //import { describe, expect } from 'jest';
 import {
     Segment,

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
@@ -1,4 +1,4 @@
-import * as _ from "lodash";
+import * as _ from "lodash-es";
 //import { describe, expect } from 'jest';
 import {
     Segment,

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
@@ -1,4 +1,4 @@
-import * as _ from "lodash-es";
+import { fromPairs, has, map, sum } from "lodash-es";
 import {
     DFData,
 } from "./DFWhole";
@@ -494,12 +494,12 @@ export class KeyAwareSmartRowCache {
 
 
     public usedSize(): number {
-        return _.sum(Array.from(this.srcAccesses.values()).map((x) => x.usedSize()))
+        return sum(Array.from(this.srcAccesses.values()).map((x) => x.usedSize()))
     }
 
     public debugCacheState():void {
-	_.map(
-	    _.fromPairs(
+	map(
+	    fromPairs(
 		Array.from(this.srcAccesses.entries())),
 	    (k, _c) => {console.log(k,  k.safeGetExtents())});
     }
@@ -640,7 +640,7 @@ export class KeyAwareSmartRowCache {
 	} else {
             src.addRows(seg, resp.data)
 	}
-        if (_.has(this.waitingCallbacks, cbKey)) {
+        if (has(this.waitingCallbacks, cbKey)) {
             const [success, fail] = this.waitingCallbacks[cbKey];
             if(verifyResp(resp)) {
                 success(this.getRows(resp.key), src.sentLength);
@@ -654,7 +654,7 @@ export class KeyAwareSmartRowCache {
     public addErrorResponse(resp: PayloadResponse) {
         const cbKey = getPayloadKey(resp.key)
 
-        if (_.has(this.waitingCallbacks, cbKey)) {
+        if (has(this.waitingCallbacks, cbKey)) {
             const [_success, fail] = this.waitingCallbacks[cbKey];
             fail()
             delete this.waitingCallbacks[cbKey]

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
@@ -1,4 +1,4 @@
-import * as _ from "lodash";
+import * as _ from "lodash-es";
 import {
     DFData,
 } from "./DFWhole";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/TableInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/TableInfinite.tsx
@@ -11,7 +11,7 @@ import {
 } from "./gridUtils";
 //import { InfiniteViewer } from "./InfiniteViewerImpl";
 import { Operation } from "../OperationUtils";
-import * as _ from "lodash-es";
+import { filter, map } from "lodash-es";
 import { PayloadResponse } from "./SmartRowCache";
 
 const data: [string, Operation[]][] = [
@@ -51,21 +51,21 @@ const MySelect = ({
 };
 
 function addSequentialIndex(list: Record<string, any>[]) {
-    return _.map(list, (item, index) => ({
+    return map(list, (item, index) => ({
         ...item,
         idx: index + 1, // Adding 1 to start the index from 1
     }));
 }
 
 function addUniqueIndex(list: Record<string, any>[]) {
-    return _.map(list, (item, _index) => ({
+    return map(list, (item, _index) => ({
         ...item,
         agIdx: `${item.idx}-${item.sport}`,
     }));
 }
 
 function filterBySport(list: any[], sport: string): any[] {
-    return _.filter(list, { sport: sport });
+    return filter(list, { sport: sport });
 }
 
 const getDataset = (sportName: string) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/TableInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/TableInfinite.tsx
@@ -11,7 +11,7 @@ import {
 } from "./gridUtils";
 //import { InfiniteViewer } from "./InfiniteViewerImpl";
 import { Operation } from "../OperationUtils";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { PayloadResponse } from "./SmartRowCache";
 
 const data: [string, Operation[]][] = [

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -11,7 +11,7 @@ import {
     multiIndexColToColDef,
 
 } from './gridUtils';
-import * as _ from "lodash-es";
+import { omit } from "lodash-es";
 import { DFData, DFViewerConfig, NormalColumnConfig, MultiIndexColumnConfig, PinnedRowConfig, ColumnConfig } from "./DFWhole";
 import { getFloatFormatter } from './Displayer';
 import { ColDef, ValueFormatterParams } from '@ag-grid-community/core';
@@ -309,14 +309,14 @@ describe("testing multi index organiztion  ", () => {
 
 
   it("childColDef should return proper subset", () => {
-    expect(_.omit(childColDef(SUPER__SUB_A, 1), "valueFormatter")).toStrictEqual({
+    expect(omit(childColDef(SUPER__SUB_A, 1), "valueFormatter")).toStrictEqual({
       "cellDataType": false,
       "cellStyle": undefined,
       "field": "a",
       "headerName": "sub_a",
     });
 
-    expect(_.omit(childColDef(SUPER__SUB_A2, 1), "valueFormatter")).toStrictEqual({
+    expect(omit(childColDef(SUPER__SUB_A2, 1), "valueFormatter")).toStrictEqual({
       "cellDataType": false,
       "cellStyle": undefined,
       "field": "a",

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -11,7 +11,7 @@ import {
     multiIndexColToColDef,
 
 } from './gridUtils';
-import * as _ from "lodash";
+import * as _ from "lodash-es";
 import { DFData, DFViewerConfig, NormalColumnConfig, MultiIndexColumnConfig, PinnedRowConfig, ColumnConfig } from "./DFWhole";
 import { getFloatFormatter } from './Displayer';
 import { ColDef, ValueFormatterParams } from '@ag-grid-community/core';

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -23,7 +23,7 @@ import {
     ColDefOrGroup,
 } from "./DFWhole";
 
-import * as _ from "lodash-es";
+import { cloneDeep, filter, find, get, has, includes, indexOf, isArray, keys, map, pick, union, without, zipObject } from "lodash-es";
 import { getTextCellRenderer } from "./OtherRenderers";
 import { getStyler } from "./Styler";
 import { DFData, SDFMeasure, SDFT } from "./DFWhole";
@@ -50,7 +50,7 @@ export function getCellRendererorFormatter(
         return colDefExtras;
     }
 
-    if (_.includes(cellRendererDisplayers, dispArgs.displayer)) {
+    if (includes(cellRendererDisplayers, dispArgs.displayer)) {
         const crArgs: CellRendererArgs = dispArgs as CellRendererArgs;
         return {
             cellRenderer: getCellRenderer(crArgs),
@@ -62,7 +62,7 @@ export function getCellRendererorFormatter(
 
 
 export function extractPinnedRows(sdf: DFData, prc: PinnedRowConfig[]) {
-    return _.map(_.map(prc, "primary_key_val"), (x) => _.find(sdf, { index: x }));
+    return map(map(prc, "primary_key_val"), (x) => find(sdf, { index: x }));
 }
 
 export function extractSingleSeriesSummary(
@@ -87,15 +87,15 @@ export function extractSingleSeriesSummary(
 	]
 	  
         },
-        data: _.filter(
-            _.map(full_summary_stats_df, (row) => _.pick(row, ["index", col_name])),
+        data: filter(
+            map(full_summary_stats_df, (row) => pick(row, ["index", col_name])),
             { index: "dtype" },
         ),
     };
 }
 
 export const getFieldVal = (f:ColumnConfig) : string => {
-  if(_.has(f, 'col_path')){
+  if(has(f, 'col_path')){
     return (f as MultiIndexColumnConfig).field;
   }
   return (f as NormalColumnConfig).col_name;
@@ -125,12 +125,12 @@ export function normalColToColDef (f:NormalColumnConfig) : ColDef {
 
 export const getSubChildren = (arr:ColumnConfig[], level:number): ColumnConfig[][] => {
   const keyFunc = (x:ColumnConfig) => {
-    if(_.has(x, 'col_path')) {
+    if(has(x, 'col_path')) {
       const xMICC: MultiIndexColumnConfig = x as MultiIndexColumnConfig
       return xMICC.col_path[level]
     }
     const xNCC: NormalColumnConfig = x as NormalColumnConfig;
-    return xNCC.col_name + "!&single" + _.indexOf(arr, x).toString(); // bad magic value
+    return xNCC.col_name + "!&single" + indexOf(arr, x).toString(); // bad magic value
   }
   return arr.reduce((acc: ColumnConfig[][], curr:ColumnConfig) => {
     
@@ -179,7 +179,7 @@ export function multiIndexColToColDef (f:MultiIndexColumnConfig[], level:number=
   if(rootDepth == 1) {
     const colDef: ColGroupDef = {
       //headerName: rootHeader,
-      children: _.map(f, (x) => childColDef(x, 0)),
+      children: map(f, (x) => childColDef(x, 0)),
       ...(f[0].ag_grid_specs)
     };
 
@@ -190,7 +190,7 @@ export function multiIndexColToColDef (f:MultiIndexColumnConfig[], level:number=
   if (childLevel == (rootDepth -1)) {
     const colDef: ColGroupDef = {
       headerName: rootHeader,
-      children: _.map(f, (x) => childColDef(x, childLevel)),
+      children: map(f, (x) => childColDef(x, childLevel)),
       ...(f[0].ag_grid_specs)
     };
     console.log(" colDef from multiIndexColToColDef", colDef)
@@ -199,7 +199,7 @@ export function multiIndexColToColDef (f:MultiIndexColumnConfig[], level:number=
     const groupedColumnConfigs = getSubChildren(f, childLevel);
     const colDef: ColGroupDef = {
       headerName: rootHeader,
-      children: _.map(groupedColumnConfigs, (x) => multiIndexColToColDef(x as MultiIndexColumnConfig[], childLevel)),
+      children: map(groupedColumnConfigs, (x) => multiIndexColToColDef(x as MultiIndexColumnConfig[], childLevel)),
       ...(f[0].ag_grid_specs)
     };
     console.log(" colDef from multiIndexColToColDef", colDef)
@@ -213,7 +213,7 @@ const switchToColDef = (x:ColumnConfig[]): ColDef|ColGroupDef => {
     //neverp
     throw new Error("x shouldn't be empty");
   }
-  if(_.has(x[0], 'col_path')) {
+  if(has(x[0], 'col_path')) {
     return multiIndexColToColDef(x as MultiIndexColumnConfig[])
   } else {
     if (x.length > 1) {
@@ -224,7 +224,7 @@ const switchToColDef = (x:ColumnConfig[]): ColDef|ColGroupDef => {
 }
 export function mergeCellClass(
   cOrig:ColDef|ColGroupDef, classSpec:"headerClass"|"cellClass", extraClass:string) : ColDef|ColGroupDef {
-    const c = _.cloneDeep(cOrig);
+    const c = cloneDeep(cOrig);
     //@ts-ignore
     if(c[classSpec] === undefined) { 
       //@ts-ignore
@@ -232,7 +232,7 @@ export function mergeCellClass(
     } else {
       console.log("c", c, classSpec)
       //@ts-ignore
-      if(_.isArray(c[classSpec])) {
+      if(isArray(c[classSpec])) {
 	//@ts-ignore
 	c[classSpec].push(extraClass)
       } else {
@@ -297,11 +297,11 @@ export function getCellRendererSelector(pinned_rows: PinnedRowConfig[], column_c
     return (params: ICellRendererParams<any, any, any>): CellRendererSelectorResult | undefined => {
         if (params.node.rowPinned) {
 
-            const pk = _.get(params.node.data, "index");
+            const pk = get(params.node.data, "index");
             if (pk === undefined) {
                 return anyRenderer; // default renderer
             }
-            const maybePrc: PinnedRowConfig | undefined = _.find(pinned_rows, {
+            const maybePrc: PinnedRowConfig | undefined = find(pinned_rows, {
                 primary_key_val: pk,
             });
             if (maybePrc === undefined) {
@@ -311,7 +311,7 @@ export function getCellRendererSelector(pinned_rows: PinnedRowConfig[], column_c
             const currentCol = params.column?.getColId();
             if (
                 (prc.default_renderer_columns === undefined && currentCol === "index") ||
-                _.includes(prc.default_renderer_columns, currentCol)
+                includes(prc.default_renderer_columns, currentCol)
             ) {
                 return anyRenderer;
             }
@@ -348,19 +348,19 @@ export function extractSDFT(summaryStatsDf: DFData): SDFT {
     /*  histogram_bins are special cased because of how they are passed to rendereres in pinned_rows
 	I think
      */
-    const maybeHistogramBins = _.find(summaryStatsDf, { index: "histogram_bins" }) || {};
-    const maybeHistogramLogBins = _.find(summaryStatsDf, { index: "histogram_log_bins" }) || {};
-    const allColumns: string[] = _.without(
-        _.union(_.keys(maybeHistogramBins), _.keys(maybeHistogramLogBins)),
+    const maybeHistogramBins = find(summaryStatsDf, { index: "histogram_bins" }) || {};
+    const maybeHistogramLogBins = find(summaryStatsDf, { index: "histogram_log_bins" }) || {};
+    const allColumns: string[] = without(
+        union(keys(maybeHistogramBins), keys(maybeHistogramLogBins)),
         "index",
     );
-    const vals: SDFMeasure[] = _.map(allColumns, (colName) => {
+    const vals: SDFMeasure[] = map(allColumns, (colName) => {
         return {
-            histogram_bins: _.get(maybeHistogramBins, colName, []) as number[],
-            histogram_log_bins: _.get(maybeHistogramLogBins, colName, []) as number[],
+            histogram_bins: get(maybeHistogramBins, colName, []) as number[],
+            histogram_log_bins: get(maybeHistogramLogBins, colName, []) as number[],
         };
     });
-    return _.zipObject(allColumns, vals) as SDFT;
+    return zipObject(allColumns, vals) as SDFT;
 }
 
 export const getPayloadKey = (payloadArgs: PayloadArgs): string => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -23,7 +23,7 @@ import {
     ColDefOrGroup,
 } from "./DFWhole";
 
-import * as _ from "lodash";
+import * as _ from "lodash-es";
 import { getTextCellRenderer } from "./OtherRenderers";
 import { getStyler } from "./Styler";
 import { DFData, SDFMeasure, SDFT } from "./DFWhole";

--- a/packages/buckaroo-js-core/src/components/DependentTabs.tsx
+++ b/packages/buckaroo-js-core/src/components/DependentTabs.tsx
@@ -1,6 +1,5 @@
 import React, { useState, CSSProperties, Dispatch, SetStateAction } from "react";
 import { DFWhole, EmptyDf } from "./DFViewerParts/DFWhole";
-import * as _ from "lodash-es";
 import { Operation } from "./OperationUtils";
 
 export function OperationDisplayer({

--- a/packages/buckaroo-js-core/src/components/DependentTabs.tsx
+++ b/packages/buckaroo-js-core/src/components/DependentTabs.tsx
@@ -1,6 +1,6 @@
 import React, { useState, CSSProperties, Dispatch, SetStateAction } from "react";
 import { DFWhole, EmptyDf } from "./DFViewerParts/DFWhole";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { Operation } from "./OperationUtils";
 
 export function OperationDisplayer({

--- a/packages/buckaroo-js-core/src/components/OperationDetail.tsx
+++ b/packages/buckaroo-js-core/src/components/OperationDetail.tsx
@@ -1,4 +1,4 @@
-import * as _ from "lodash-es";
+import { get, isArray, isEqual, isString } from "lodash-es";
 import { Operation, SettableArg, OperationEventFunc } from "./OperationUtils";
 import { ActualArg, CommandArgSpec } from "./CommandUtils";
 import { objWithoutNull, replaceAtIdx, replaceAtKey } from "./utils";
@@ -20,10 +20,10 @@ export const OperationDetail = ({
     const commandName = command[0]["symbol"];
     const pattern = commandPatterns[commandName];
 
-    if (!_.isArray(pattern)) {
+    if (!isArray(pattern)) {
         //we shouldn't get here
         return <h2>unknown command {commandName}</h2>;
-    } else if (_.isEqual(pattern, [null])) {
+    } else if (isEqual(pattern, [null])) {
         return <div className="operation-detail"></div>;
     } else {
         const fullPattern = pattern as ActualArg[];
@@ -92,7 +92,7 @@ const ArgGetter = ({
     const [_argPos, label, argType, lastArg] = argProps;
 
     const defaultShim = (event: { target: { value: SettableArg } }) => setter(event.target.value);
-    if (argType === "enum" && _.isArray(lastArg)) {
+    if (argType === "enum" && isArray(lastArg)) {
         return (
             <fieldset key={renderKey}>
                 <label> {label} </label>
@@ -155,7 +155,7 @@ const ArgGetter = ({
         const widgetRow = columns.map((colName: string) => {
             const colSetter = (event: { target: { value: any } }) => {
                 const newColVal = event.target.value;
-                if (_.isString(newColVal)) {
+                if (isString(newColVal)) {
                     const updatedColDict = replaceAtKey(
                         val as Record<string, string>,
                         colName,
@@ -164,8 +164,8 @@ const ArgGetter = ({
                     setter(objWithoutNull(updatedColDict, ["null"]));
                 }
             };
-            const colVal = _.get(val, colName, "null");
-            if (!_.isArray(lastArg)) {
+            const colVal = get(val, colName, "null");
+            if (!isArray(lastArg)) {
                 return <h3> arg error</h3>;
             }
             return (

--- a/packages/buckaroo-js-core/src/components/OperationDetail.tsx
+++ b/packages/buckaroo-js-core/src/components/OperationDetail.tsx
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { Operation, SettableArg, OperationEventFunc } from "./OperationUtils";
 import { ActualArg, CommandArgSpec } from "./CommandUtils";
 import { objWithoutNull, replaceAtIdx, replaceAtKey } from "./utils";

--- a/packages/buckaroo-js-core/src/components/OperationUtils.ts
+++ b/packages/buckaroo-js-core/src/components/OperationUtils.ts
@@ -1,7 +1,7 @@
 /*
   used for manipulating the JSON Flavored lisp of operations and commands
   */
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { SymbolT, ColEnumArgs, SymbolDf, symDf } from "./CommandUtils";
 
 export const sym = (symbolName: string) => {

--- a/packages/buckaroo-js-core/src/components/OperationUtils.ts
+++ b/packages/buckaroo-js-core/src/components/OperationUtils.ts
@@ -1,7 +1,6 @@
 /*
   used for manipulating the JSON Flavored lisp of operations and commands
   */
-import * as _ from "lodash-es";
 import { SymbolT, ColEnumArgs, SymbolDf, symDf } from "./CommandUtils";
 
 export const sym = (symbolName: string) => {

--- a/packages/buckaroo-js-core/src/components/Operations.tsx
+++ b/packages/buckaroo-js-core/src/components/Operations.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { Operation, SetOperationsFunc, OperationEventFunc } from "./OperationUtils";
 import { CommandConfigT } from "./CommandUtils";
 import { replaceInArr } from "./utils";

--- a/packages/buckaroo-js-core/src/components/Operations.tsx
+++ b/packages/buckaroo-js-core/src/components/Operations.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import * as _ from "lodash-es";
+import { keys, map, merge } from "lodash-es";
 import { Operation, SetOperationsFunc, OperationEventFunc } from "./OperationUtils";
 import { CommandConfigT } from "./CommandUtils";
 import { replaceInArr } from "./utils";
@@ -32,7 +32,7 @@ export const OperationAdder = ({
         <div className="operation-adder">
             <span className={"column-name"}> Column: {column}</span>
             <fieldset>
-                {_.keys(defaultArgs).map((optionVal) => (
+                {keys(defaultArgs).map((optionVal) => (
                     <button key={optionVal} onClick={addOperationByName(optionVal)}>
                         {" "}
                         {optionVal}{" "}
@@ -61,21 +61,21 @@ export const OperationViewer = ({
         return name + idx.toString();
     };
 
-    const operationObjs = _.map(Array.from(operations.entries()), ([index, element]) => {
+    const operationObjs = map(Array.from(operations.entries()), ([index, element]) => {
         const rowEl: Record<string, Operation> = {};
         rowEl[opToKey(index, element)] = element;
         return rowEl;
     });
     //why am I doing this? probably something so I gauruntee a clean dict
 
-    const operationDict = _.merge({}, ...operationObjs);
+    const operationDict = merge({}, ...operationObjs);
 
-    const idxObjs = _.map(Array.from(operations.entries()), ([index, element]) => {
+    const idxObjs = map(Array.from(operations.entries()), ([index, element]) => {
         const rowEl: Record<string, number> = {};
         rowEl[opToKey(index, element)] = index;
         return rowEl;
     });
-    const keyToIdx = _.merge({}, ...idxObjs);
+    const keyToIdx = merge({}, ...idxObjs);
 
     // previously was null
     const [activeKey, setActiveKey] = useState("");
@@ -95,7 +95,7 @@ export const OperationViewer = ({
         };
     }
     const getColumns = (passedOperations: Operation[]): string[] =>
-        _.map(Array.from(passedOperations.entries()), ([index, element]) => {
+        map(Array.from(passedOperations.entries()), ([index, element]) => {
             const name = element[0]["symbol"];
             const key = name + index.toString();
 	    return key;

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -1,6 +1,6 @@
 // https://plnkr.co/edit/QTNwBb2VEn81lf4t?open=index.tsx
 import React, { useRef, useCallback, useState, memo, useEffect, useMemo } from "react";
-import * as _ from "lodash-es";
+import { clone, fromPairs, includes, indexOf, keys, map } from "lodash-es";
 import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
 import { ColDef, GridApi, GridOptions, ModuleRegistry } from "@ag-grid-community/core";
 import { basicIntFormatter } from "./DFViewerParts/Displayer";
@@ -32,7 +32,7 @@ const dfDisplayCell = function (params: any) {
     const options = params.context.buckarooOptions.df_display;
     
     const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const newState = _.clone(params.context.buckarooState);
+        const newState = clone(params.context.buckarooState);
         newState.df_display = event.target.value;
         params.context.setBuckarooState(newState);
     };
@@ -57,7 +57,7 @@ const cleaningMethodCell = function (params: any) {
     const options = params.context.buckarooOptions.cleaning_method;
     
     const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const newState = _.clone(params.context.buckarooState);
+        const newState = clone(params.context.buckarooState);
         newState.cleaning_method = event.target.value;
         params.context.setBuckarooState(newState);
     };
@@ -82,7 +82,7 @@ const postProcessingCell = function (params: any) {
     const options = params.context.buckarooOptions.post_processing;
     
     const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-        const newState = _.clone(params.context.buckarooState);
+        const newState = clone(params.context.buckarooState);
         newState.post_processing = event.target.value;
         params.context.setBuckarooState(newState);
     };
@@ -106,7 +106,7 @@ const showCommandsCell = function (params: any) {
     const value = params.value === "1";
     
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const newState = _.clone(params.context.buckarooState);
+        const newState = clone(params.context.buckarooState);
         newState.show_commands = event.target.checked ? "1" : "0";
         params.context.setBuckarooState(newState);
     };
@@ -214,10 +214,10 @@ export function StatusBar({
 	console.log("heightOverride", heightOverride);
     }
     const optionCycles = buckarooOptions;
-    const idxs = _.fromPairs(
-        _.map(_.keys(optionCycles), (k) => [
+    const idxs = fromPairs(
+        map(keys(optionCycles), (k) => [
             k,
-            _.indexOf(optionCycles[k as BKeys], buckarooState[k as BKeys]),
+            indexOf(optionCycles[k as BKeys], buckarooState[k as BKeys]),
         ]),
     );
 
@@ -233,7 +233,7 @@ export function StatusBar({
         const curIdx = idxs[k];
         const nextIdx = nextIndex(curIdx, arr);
         const newVal = arr[nextIdx];
-        const newState = _.clone(buckarooState);
+        const newState = clone(buckarooState);
         newState[k] = newVal;
         return newState;
     };
@@ -242,10 +242,10 @@ export function StatusBar({
     const updateDict = (event: any) => {
         console.log("event.column", event.column, event.column.getColId());
         const colName = event.column.getColId();
-        if (_.includes(excludeKeys, colName)) {
+        if (includes(excludeKeys, colName)) {
             return;
         }
-        if (_.includes(_.keys(buckarooState), colName)) {
+        if (includes(keys(buckarooState), colName)) {
             const nbstate = newBuckarooState(colName as BKeys);
             setBuckarooState(nbstate);
         }

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -1,6 +1,6 @@
 // https://plnkr.co/edit/QTNwBb2VEn81lf4t?open=index.tsx
 import React, { useRef, useCallback, useState, memo, useEffect, useMemo } from "react";
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
 import { ColDef, GridApi, GridOptions, ModuleRegistry } from "@ag-grid-community/core";
 import { basicIntFormatter } from "./DFViewerParts/Displayer";

--- a/packages/buckaroo-js-core/src/components/utils.ts
+++ b/packages/buckaroo-js-core/src/components/utils.ts
@@ -1,4 +1,4 @@
-import * as _ from "lodash-es";
+import { clone, pickBy } from "lodash-es";
 import { DFWhole } from "./DFViewerParts/DFWhole";
 import { ColDef } from "@ag-grid-community/core";
 
@@ -25,13 +25,13 @@ export function replaceAtIdx<T>(arr: T[], idx: number, subst: T): T[] {
 }
 
 export function replaceAtKey<T>(obj: Record<string, T>, key: string, subst: T): Record<string, T> {
-    const objCopy = _.clone(obj);
+    const objCopy = clone(obj);
     objCopy[key] = subst;
     return objCopy;
 }
 
 export const objWithoutNull = (obj: Record<string, string>, extraStrips: string[] = []): Record<string, string> =>
-    _.pickBy(obj, (x) => ![null, undefined, ...extraStrips].includes(x)) as Record<string, string>;
+    pickBy(obj, (x) => ![null, undefined, ...extraStrips].includes(x)) as Record<string, string>;
 export const updateAtMatch = (
     cols: ColDef[],
     key: string,

--- a/packages/buckaroo-js-core/src/components/utils.ts
+++ b/packages/buckaroo-js-core/src/components/utils.ts
@@ -1,4 +1,4 @@
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { DFWhole } from "./DFViewerParts/DFWhole";
 import { ColDef } from "@ag-grid-community/core";
 
@@ -30,8 +30,8 @@ export function replaceAtKey<T>(obj: Record<string, T>, key: string, subst: T): 
     return objCopy;
 }
 
-export const objWithoutNull = (obj: Record<string, string>, extraStrips: string[] = []) =>
-    _.pickBy(obj, (x) => ![null, undefined, ...extraStrips].includes(x));
+export const objWithoutNull = (obj: Record<string, string>, extraStrips: string[] = []): Record<string, string> =>
+    _.pickBy(obj, (x) => ![null, undefined, ...extraStrips].includes(x)) as Record<string, string>;
 export const updateAtMatch = (
     cols: ColDef[],
     key: string,

--- a/packages/buckaroo-js-core/src/index.ts
+++ b/packages/buckaroo-js-core/src/index.ts
@@ -28,7 +28,7 @@ import { StatusBar } from "./components/StatusBar";
 
 import * as widgetUtils from "./widgetUtils";
 import { SampleButton, HeaderNoArgs, Counter } from "./SampleComponent";
-import _ from "lodash";
+import * as _ from "lodash-es";
 export default {
     
     ColumnsEditor,

--- a/packages/buckaroo-js-core/src/index.ts
+++ b/packages/buckaroo-js-core/src/index.ts
@@ -28,7 +28,6 @@ import { StatusBar } from "./components/StatusBar";
 
 import * as widgetUtils from "./widgetUtils";
 import { SampleButton, HeaderNoArgs, Counter } from "./SampleComponent";
-import * as _ from "lodash-es";
 export default {
     
     ColumnsEditor,

--- a/packages/buckaroo-js-core/src/stories/StatusBar.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StatusBar.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import "../style/dcf-npm.css"
-import * as _ from "lodash-es";
 import { StatusBar } from "../components/StatusBar";
 import { BuckarooOptions, BuckarooState, DFMeta } from "../components/WidgetTypes";
 import { useState } from "react";

--- a/packages/buckaroo-js-core/src/stories/StatusBar.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StatusBar.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import "../style/dcf-npm.css"
-import _ from "lodash";
+import * as _ from "lodash-es";
 import { StatusBar } from "../components/StatusBar";
 import { BuckarooOptions, BuckarooState, DFMeta } from "../components/WidgetTypes";
 import { useState } from "react";

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -4,8 +4,8 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
-		"build": "esbuild widget.tsx --format=esm --bundle --outdir=../../buckaroo/static/",
-		"build:standalone": "esbuild standalone.tsx --format=esm --bundle --minify --outdir=../../buckaroo/static/",
+		"build": "esbuild widget.tsx --format=esm --bundle --minify --sourcemap --outdir=../../buckaroo/static/",
+		"build:standalone": "esbuild standalone.tsx --format=esm --bundle --minify --sourcemap --outdir=../../buckaroo/static/",
 		"dev": "esbuild widget.tsx --format=esm --bundle --outdir=../../buckaroo/static/ --sourcemap=inline --watch",
 		"dev:standalone": "esbuild standalone.tsx --format=esm --bundle --outdir=../../buckaroo/static/ --sourcemap=inline --watch"
 	},

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -35,9 +35,9 @@ importers:
       hyparquet:
         specifier: ^1.8.2
         version: 1.23.3
-      lodash:
+      lodash-es:
         specifier: ^4.17.21
-        version: 4.17.21
+        version: 4.17.23
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -90,9 +90,9 @@ importers:
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
-      '@types/lodash':
-        specifier: ^4.17.13
-        version: 4.17.21
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       '@types/node':
         specifier: ^22.15.3
         version: 22.19.3
@@ -129,6 +129,9 @@ importers:
       jsdom:
         specifier: ^26.0.0
         version: 26.1.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       storybook:
         specifier: ^8.4.4
         version: 8.6.15
@@ -1495,6 +1498,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
+
   '@types/lodash@4.17.21':
     resolution: {integrity: sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==}
 
@@ -2844,6 +2850,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
@@ -5148,6 +5157,10 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.21
+
   '@types/lodash@4.17.21': {}
 
   '@types/mdx@2.0.13': {}
@@ -6817,6 +6830,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.23: {}
 
   lodash.memoize@4.1.2: {}
 

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -15,22 +15,22 @@ importers:
   buckaroo-js-core:
     dependencies:
       '@ag-grid-community/client-side-row-model':
-        specifier: ^32.3.3
-        version: 32.3.5
+        specifier: ^32.3.9
+        version: 32.3.9
       '@ag-grid-community/core':
-        specifier: ^32.3.3
-        version: 32.3.5
+        specifier: ^32.3.9
+        version: 32.3.9
       '@ag-grid-community/infinite-row-model':
-        specifier: ^32.3.3
-        version: 32.3.5
+        specifier: ^32.3.9
+        version: 32.3.9
       '@ag-grid-community/react':
-        specifier: ^32.3.3
-        version: 32.3.5(@ag-grid-community/core@32.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^32.3.9
+        version: 32.3.9(@ag-grid-community/core@32.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@ag-grid-community/styles':
-        specifier: ^32.3.3
-        version: 32.3.5
+        specifier: ^32.3.9
+        version: 32.3.9
       '@ag-grid-community/theming':
-        specifier: ^32.3.3
+        specifier: ^32.3.9
         version: 32.3.9
       hyparquet:
         specifier: ^1.8.2
@@ -190,27 +190,24 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ag-grid-community/client-side-row-model@32.3.5':
-    resolution: {integrity: sha512-dTAko9W0E914BMVfDBcresQfDZZPiVVmkbS2iRwDPX0erqYT2/nkuXXVh5If1LFnAqM1q5EQTZDZaLXDv2GO7Q==}
-
-  '@ag-grid-community/core@32.3.5':
-    resolution: {integrity: sha512-RGL3RyPCKC4R2fcG1gXdk7rs+CXig23wufTFJfbE46aQDxg941ww07G0cDS5Z5u/6btM9GJkxlwcR0JVEI003A==}
+  '@ag-grid-community/client-side-row-model@32.3.9':
+    resolution: {integrity: sha512-/x6gPhxn6c/QQSmDuNf81xrBNc3TKGymmokznvXPPf4tAXeLZn5kF0cW3sGa52XyqZcIsYFQvLkI+pCsX+I4ng==}
 
   '@ag-grid-community/core@32.3.9':
     resolution: {integrity: sha512-oZeAEPgaJVMzfKqbAPCyadcN5+iy+tjvhRLqEYJdBxtLgW/s2s0qXcXQvnrz7eUMD3Z7h3BQRVt2h/p0T6Ox/w==}
 
-  '@ag-grid-community/infinite-row-model@32.3.5':
-    resolution: {integrity: sha512-XdFwyeZfIOGc69H1OAJGiP2iTFIlUrC7ANIvxWtuAuy77lqjE1IYRxBv9Lfc+qM4pJRqYFVLmc9aOLJbmrr6DQ==}
+  '@ag-grid-community/infinite-row-model@32.3.9':
+    resolution: {integrity: sha512-jk/NCRTFeLUrqf9/meBnHufEjWGrq2EN+4NV6iwTs4o79hCbGhhldSh7h0hXzYpmTBqUyGsMHIb/Y77LmTU6Mg==}
 
-  '@ag-grid-community/react@32.3.5':
-    resolution: {integrity: sha512-GW2Alqo+U2eSXKZFVE+1F9THBSrHbbe4crAvjL4NOSaqimLtKyYJ8TCHgsn5PX/PPeOxfCVK5SMHD4oziSHidA==}
+  '@ag-grid-community/react@32.3.9':
+    resolution: {integrity: sha512-W21ELmhbniJQ2LMCytv5lwxz3FHpZp1iMp0Kvm9TXXxhldgDwMqVQa1uePeNBa068KIfXwnst0D2TGD8r0N/iA==}
     peerDependencies:
-      '@ag-grid-community/core': 32.3.5
+      '@ag-grid-community/core': 32.3.9
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@ag-grid-community/styles@32.3.5':
-    resolution: {integrity: sha512-gr4orZTYDqx3r+P+F8SSaL4BFzSTopjqaua5wXcOHfUm7OGENcgogMo2DiaMnxzcc33T/TbOIiL8RCDP7X0efw==}
+  '@ag-grid-community/styles@32.3.9':
+    resolution: {integrity: sha512-uPNR5EXeQqAIC0gohmY7CJ97cTIA/JtNSqAUzJ8AdVZcz4dbk9JJIl9DRFUYL+qWhMY+fUSTw2a+Yi6aOGSs8A==}
 
   '@ag-grid-community/theming@32.3.9':
     resolution: {integrity: sha512-NRqeoISBJncWDYDATc+cxG7D5CgVuOkJRpz3hWnEBY/CjEHCM/HBIDJnv1ALsNsro/6iwALrpHrPaScJbDF9vw==}
@@ -1676,9 +1673,6 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
-
-  ag-charts-types@10.3.5:
-    resolution: {integrity: sha512-DtvV+IS4RlocGV2IcaQOe/eM6eBGGCvkLnwxGkDxKa8ddxivv90fwlfPxK0O5XnVectiKtWFfOw35Cm0k+4vMw==}
 
   ag-charts-types@10.3.9:
     resolution: {integrity: sha512-drcRiJVencliC8LnRwk4MmeQDNNBg5GzmOoLFihO3/k0CUK0VF/N+2nc7iFozwaNG0btSB9vAhYuJLjqHMtRrQ==}
@@ -3806,14 +3800,9 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ag-grid-community/client-side-row-model@32.3.5':
+  '@ag-grid-community/client-side-row-model@32.3.9':
     dependencies:
-      '@ag-grid-community/core': 32.3.5
-      tslib: 2.8.1
-
-  '@ag-grid-community/core@32.3.5':
-    dependencies:
-      ag-charts-types: 10.3.5
+      '@ag-grid-community/core': 32.3.9
       tslib: 2.8.1
 
   '@ag-grid-community/core@32.3.9':
@@ -3821,19 +3810,19 @@ snapshots:
       ag-charts-types: 10.3.9
       tslib: 2.8.1
 
-  '@ag-grid-community/infinite-row-model@32.3.5':
+  '@ag-grid-community/infinite-row-model@32.3.9':
     dependencies:
-      '@ag-grid-community/core': 32.3.5
+      '@ag-grid-community/core': 32.3.9
       tslib: 2.8.1
 
-  '@ag-grid-community/react@32.3.5(@ag-grid-community/core@32.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@ag-grid-community/react@32.3.9(@ag-grid-community/core@32.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@ag-grid-community/core': 32.3.5
+      '@ag-grid-community/core': 32.3.9
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@ag-grid-community/styles@32.3.5': {}
+  '@ag-grid-community/styles@32.3.9': {}
 
   '@ag-grid-community/theming@32.3.9':
     dependencies:
@@ -5395,8 +5384,6 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
-
-  ag-charts-types@10.3.5: {}
 
   ag-charts-types@10.3.9: {}
 


### PR DESCRIPTION
## Summary
- Add `--minify --sourcemap` to widget.js esbuild (3.5 MB → 1.8 MB)
- Bump AG Grid v32.3.3 → v32.3.9 (latest patch)
- Migrate `lodash` → `lodash-es` for ESM tree-shaking
- Convert all lodash usage to named imports, remove 10 unused imports

## Test plan
- [x] `tsc -b` — 0 errors
- [x] `pnpm test` — 67/67 pass
- [x] `full_build.sh` — widget.js 1.8 MB (was 3.5 MB)
- [ ] CI checks pass
- [ ] Visual check in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)