### PR TITLE
perf: upgrade AG Grid v32 → v33

### DIFF
--- a/packages/buckaroo-js-core/package.json
+++ b/packages/buckaroo-js-core/package.json
@@ -30,12 +30,8 @@
     "/dist"
   ],
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^32.3.9",
-    "@ag-grid-community/core": "^32.3.9",
-    "@ag-grid-community/infinite-row-model": "^32.3.9",
-    "@ag-grid-community/react": "^32.3.9",
-    "@ag-grid-community/styles": "^32.3.9",
-    "@ag-grid-community/theming": "^32.3.9",
+    "ag-grid-community": "^33.3.2",
+    "ag-grid-react": "^33.3.2",
     "hyparquet": "^1.8.2",
     "lodash-es": "^4.17.21",
     "recharts": "^2.13.1"

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -15,7 +15,7 @@ import {
     IDisplayArgs
 } from "./DFViewerParts/gridUtils";
 import { DatasourceOrRaw, DFViewerInfinite } from "./DFViewerParts/DFViewerInfinite";
-import { IDatasource } from "@ag-grid-community/core";
+import { IDatasource } from "ag-grid-community";
 import { KeyAwareSmartRowCache, PayloadArgs, PayloadResponse, RequestFN } from "./DFViewerParts/SmartRowCache";
 import { parquetRead, parquetMetadata } from 'hyparquet'
 import { MessageBox } from "./MessageBox";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
@@ -1,4 +1,4 @@
-import { IDatasource, IGetRowsParams } from "@ag-grid-community/core";
+import { IDatasource, IGetRowsParams } from "ag-grid-community";
 import { keys, times, reduce } from "lodash-es";
 
 export type RawDataWrapper = {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -8,7 +8,7 @@ import { DFData, DFDataRow, DFViewerConfig, SDFT } from "./DFWhole";
 
 import { getCellRendererSelector, dfToAgrid, extractPinnedRows, extractSDFT } from "./gridUtils";
 
-import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
+import { AgGridReact } from "ag-grid-react"; // the AG Grid React Component
 import {
     GetRowIdParams,
     GridApi,
@@ -18,10 +18,10 @@ import {
     SortChangedEvent,
     CellClassParams,
     RefreshCellsParams,
-    //ColDef,
-} from "@ag-grid-community/core";
-import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
-import { InfiniteRowModelModule } from "@ag-grid-community/infinite-row-model";
+    ClientSideRowModelModule,
+    InfiniteRowModelModule,
+    PinnedRowModule,
+} from "ag-grid-community";
 
 import {
     getAutoSize,
@@ -34,6 +34,7 @@ import { useColorScheme } from '../useColorScheme';
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
 ModuleRegistry.registerModules([InfiniteRowModelModule]);
+ModuleRegistry.registerModules([PinnedRowModule]);
 
 
 const AccentColor = "#2196F3"

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -1,6 +1,6 @@
 // I'm not sure about adding underlying types too
 
-import { ColDef, ColGroupDef, GridOptions } from "@ag-grid-community/core";
+import { ColDef, ColGroupDef, GridOptions } from "ag-grid-community";
 
 type AGGrid_ColDef = ColDef;
 export type ColDefOrGroup = ColDef|ColGroupDef

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
@@ -1,4 +1,4 @@
-import { ValueFormatterFunc, ValueFormatterParams } from "@ag-grid-community/core";
+import { ValueFormatterFunc, ValueFormatterParams } from "ag-grid-community";
 import {
     DisplayerArgs,
     cellRendererDisplayers,

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -4,7 +4,7 @@ import { createPortal } from "react-dom";
 
 import { Bar, BarChart, Tooltip } from "recharts";
 import { getChartColors } from "./ChartCell";
-import { ColDef, Column, Context, GridApi } from "@ag-grid-community/core";
+import { ColDef, Column, Context, GridApi } from "ag-grid-community";
 import { useColorScheme } from "../useColorScheme";
 
 export interface HistogramNode {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
@@ -1,4 +1,4 @@
-import { ValueFormatterFunc } from "@ag-grid-community/core";
+import { ValueFormatterFunc } from "ag-grid-community";
 
 export const getTextCellRenderer = (formatter: ValueFormatterFunc<any>) => {
     const TextCellRenderer = (props: any) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SeriesSummaryTooltip.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SeriesSummaryTooltip.tsx
@@ -1,6 +1,6 @@
 import { DFViewer } from "./DFViewerInfinite";
 import { DFWhole, TooltipConfig } from "./DFWhole";
-import { ITooltipParams } from "@ag-grid-community/core";
+import { ITooltipParams } from "ag-grid-community";
 
 export function getBakedDFViewer(seriesDf: DFWhole) {
     const retFunc = (_props: ITooltipParams) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Styler.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Styler.tsx
@@ -1,6 +1,6 @@
 import {
     CellClassParams,
-} from "@ag-grid-community/core";
+} from "ag-grid-community";
 
 import { BLUE_TO_YELLOW, DIVERGING_RED_WHITE_BLUE } from "../../baked_data/colorMap";
 import {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -14,7 +14,7 @@ import {
 import { omit } from "lodash-es";
 import { DFData, DFViewerConfig, NormalColumnConfig, MultiIndexColumnConfig, PinnedRowConfig, ColumnConfig } from "./DFWhole";
 import { getFloatFormatter } from './Displayer';
-import { ColDef, ValueFormatterParams } from '@ag-grid-community/core';
+import { ColDef, ValueFormatterParams } from 'ag-grid-community';
 
 describe("testing utility functions in gridUtils ", () => {
   // mostly sanity checks to help develop gridUtils

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -8,7 +8,11 @@ import {
     IGetRowsParams,
     SizeColumnsToContentStrategy,
     SizeColumnsToFitProvidedWidthStrategy,
-} from "@ag-grid-community/core";
+    colorSchemeDark,
+    colorSchemeLight,
+    themeAlpine,
+    Theme,
+} from "ag-grid-community";
 
 import {
     DFWhole,
@@ -34,7 +38,7 @@ import { getFormatterFromArgs, getCellRenderer, objFormatter, getFormatter } fro
 import { CSSProperties, Dispatch, SetStateAction } from "react";
 import { CommandConfigT } from "../CommandUtils";
 import { KeyAwareSmartRowCache, PayloadArgs } from "./SmartRowCache";
-import { colorSchemeDark, colorSchemeLight, themeAlpine, Theme } from "@ag-grid-community/theming";
+
 
 
 // for now colDef stuff with less than 3 implementantions should stay in this file

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -1,16 +1,13 @@
 // https://plnkr.co/edit/QTNwBb2VEn81lf4t?open=index.tsx
 import React, { useRef, useCallback, useState, memo, useEffect, useMemo } from "react";
 import { clone, fromPairs, includes, indexOf, keys, map } from "lodash-es";
-import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
-import { ColDef, GridApi, GridOptions, ModuleRegistry } from "@ag-grid-community/core";
+import { AgGridReact, CustomCellEditorProps } from "ag-grid-react";
+import { ColDef, GridApi, GridOptions, ModuleRegistry, ClientSideRowModelModule, Theme } from "ag-grid-community";
 import { basicIntFormatter } from "./DFViewerParts/Displayer";
 import { DFMeta } from "./WidgetTypes";
 import { BuckarooOptions } from "./WidgetTypes";
 import { BuckarooState, BKeys } from "./WidgetTypes";
-import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
-import { CustomCellEditorProps } from '@ag-grid-community/react';
 import { getThemeForScheme } from "./DFViewerParts/gridUtils";
-import { Theme } from "@ag-grid-community/theming";
 import { useColorScheme } from "./useColorScheme";
 
 export type setColumFunc = (newCol: string) => void;

--- a/packages/buckaroo-js-core/src/components/utils.ts
+++ b/packages/buckaroo-js-core/src/components/utils.ts
@@ -1,6 +1,6 @@
 import { clone, pickBy } from "lodash-es";
 import { DFWhole } from "./DFViewerParts/DFWhole";
-import { ColDef } from "@ag-grid-community/core";
+import { ColDef } from "ag-grid-community";
 
 export type setDFFunc = (newDf: DFWhole) => void;
 

--- a/packages/buckaroo-js-core/src/stories/OutsideParamsInconsistency.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/OutsideParamsInconsistency.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React, { useMemo, useState } from "react";
 import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
 import { DFViewerConfig } from "../components/DFViewerParts/DFWhole";
-import { IDatasource, IGetRowsParams } from "@ag-grid-community/core";
+import { IDatasource, IGetRowsParams } from "ag-grid-community";
 
 const makeContextualDatasource = (dataA: any[], dataB: any[], delayMs = 0): IDatasource => {
   const total = Math.max(dataA.length, dataB.length);

--- a/packages/buckaroo-js-core/src/stories/RawAGGrid.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/RawAGGrid.stories.tsx
@@ -4,20 +4,17 @@ import { DFData } from "../components/DFViewerParts/DFWhole";
 import { createDatasourceWrapper, DatasourceWrapper } from "../components/DFViewerParts/DFViewerDataHelper";
 
 import {SelectBox } from './StoryUtils'
-import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
+import { AgGridReact } from "ag-grid-react";
 import {
     GridOptions,
-    //IDatasource,
     ModuleRegistry,
     ColDef,
-    CellClassParams
-} from "@ag-grid-community/core";
-
-import { themeAlpine} from '@ag-grid-community/theming';
-import { colorSchemeDark } from '@ag-grid-community/theming';
-
-import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
-import { InfiniteRowModelModule } from "@ag-grid-community/infinite-row-model";
+    CellClassParams,
+    themeAlpine,
+    colorSchemeDark,
+    ClientSideRowModelModule,
+    InfiniteRowModelModule,
+} from "ag-grid-community";
 
 ModuleRegistry.registerModules([ClientSideRowModelModule]);
 ModuleRegistry.registerModules([InfiniteRowModelModule]);

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -58,8 +58,8 @@
   font-size: 0.95em;
 }
 .dependent-tabs ul.tabs li.active {
-  background: var(--ag-range-selection-background-color-3);
-  color: var(--ag-alpine-active-color);
+  background: var(--ag-range-selection-background-color);
+  color: var(--ag-accent-color);
 }
 .dependent-tabs .output-area {
   clear: both;
@@ -366,7 +366,7 @@
 }
 
 .ag-theme-alpine-dark, .ag-theme-alpine  {
-    --ag-grid-size:3px;
+    --ag-spacing:3px;
     --ag-list-item-height: 20px;
  }
 

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -14,24 +14,12 @@ importers:
 
   buckaroo-js-core:
     dependencies:
-      '@ag-grid-community/client-side-row-model':
-        specifier: ^32.3.9
-        version: 32.3.9
-      '@ag-grid-community/core':
-        specifier: ^32.3.9
-        version: 32.3.9
-      '@ag-grid-community/infinite-row-model':
-        specifier: ^32.3.9
-        version: 32.3.9
-      '@ag-grid-community/react':
-        specifier: ^32.3.9
-        version: 32.3.9(@ag-grid-community/core@32.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ag-grid-community/styles':
-        specifier: ^32.3.9
-        version: 32.3.9
-      '@ag-grid-community/theming':
-        specifier: ^32.3.9
-        version: 32.3.9
+      ag-grid-community:
+        specifier: ^33.3.2
+        version: 33.3.2
+      ag-grid-react:
+        specifier: ^33.3.2
+        version: 33.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       hyparquet:
         specifier: ^1.8.2
         version: 1.23.3
@@ -192,28 +180,6 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
-
-  '@ag-grid-community/client-side-row-model@32.3.9':
-    resolution: {integrity: sha512-/x6gPhxn6c/QQSmDuNf81xrBNc3TKGymmokznvXPPf4tAXeLZn5kF0cW3sGa52XyqZcIsYFQvLkI+pCsX+I4ng==}
-
-  '@ag-grid-community/core@32.3.9':
-    resolution: {integrity: sha512-oZeAEPgaJVMzfKqbAPCyadcN5+iy+tjvhRLqEYJdBxtLgW/s2s0qXcXQvnrz7eUMD3Z7h3BQRVt2h/p0T6Ox/w==}
-
-  '@ag-grid-community/infinite-row-model@32.3.9':
-    resolution: {integrity: sha512-jk/NCRTFeLUrqf9/meBnHufEjWGrq2EN+4NV6iwTs4o79hCbGhhldSh7h0hXzYpmTBqUyGsMHIb/Y77LmTU6Mg==}
-
-  '@ag-grid-community/react@32.3.9':
-    resolution: {integrity: sha512-W21ELmhbniJQ2LMCytv5lwxz3FHpZp1iMp0Kvm9TXXxhldgDwMqVQa1uePeNBa068KIfXwnst0D2TGD8r0N/iA==}
-    peerDependencies:
-      '@ag-grid-community/core': 32.3.9
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ag-grid-community/styles@32.3.9':
-    resolution: {integrity: sha512-uPNR5EXeQqAIC0gohmY7CJ97cTIA/JtNSqAUzJ8AdVZcz4dbk9JJIl9DRFUYL+qWhMY+fUSTw2a+Yi6aOGSs8A==}
-
-  '@ag-grid-community/theming@32.3.9':
-    resolution: {integrity: sha512-NRqeoISBJncWDYDATc+cxG7D5CgVuOkJRpz3hWnEBY/CjEHCM/HBIDJnv1ALsNsro/6iwALrpHrPaScJbDF9vw==}
 
   '@anywidget/react@0.0.8':
     resolution: {integrity: sha512-obr4EasXgWra485u+G4V3Msn7A1EOnowarvR62FRjpv2Rz6AyOoLMz2B03Z9j3DrWdD0634fMGu5ZAeRyjuV4w==}
@@ -1680,8 +1646,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ag-charts-types@10.3.9:
-    resolution: {integrity: sha512-drcRiJVencliC8LnRwk4MmeQDNNBg5GzmOoLFihO3/k0CUK0VF/N+2nc7iFozwaNG0btSB9vAhYuJLjqHMtRrQ==}
+  ag-charts-types@11.3.2:
+    resolution: {integrity: sha512-trPGqgGYiTeLgtf9nLuztDYOPOFOLbqHn1g2D99phf7QowcwdX0TPx0wfWG8Hm90LjB8IH+G2s3AZe2vrdAtMQ==}
+
+  ag-grid-community@33.3.2:
+    resolution: {integrity: sha512-9bx0e/+ykOyLvUxHqmdy0cRVANH6JAtv0yZdnBZEXYYqBAwN+G5a4NY+2I1KvoOCYzbk8SnStG7y4hCdVAAWOQ==}
+
+  ag-grid-react@33.3.2:
+    resolution: {integrity: sha512-5bv4JIJvGov23sduIUIyQTqpa/qhoQrRkQm5pFOQb7RMwusfx6xBPrkLwIIlCJiQ8g0OOinxWzZ2kQ2Zml6tLw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -3809,35 +3784,6 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ag-grid-community/client-side-row-model@32.3.9':
-    dependencies:
-      '@ag-grid-community/core': 32.3.9
-      tslib: 2.8.1
-
-  '@ag-grid-community/core@32.3.9':
-    dependencies:
-      ag-charts-types: 10.3.9
-      tslib: 2.8.1
-
-  '@ag-grid-community/infinite-row-model@32.3.9':
-    dependencies:
-      '@ag-grid-community/core': 32.3.9
-      tslib: 2.8.1
-
-  '@ag-grid-community/react@32.3.9(@ag-grid-community/core@32.3.9)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ag-grid-community/core': 32.3.9
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@ag-grid-community/styles@32.3.9': {}
-
-  '@ag-grid-community/theming@32.3.9':
-    dependencies:
-      '@ag-grid-community/core': 32.3.9
-      tslib: 2.8.1
-
   '@anywidget/react@0.0.8(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@anywidget/types': 0.2.0
@@ -5398,7 +5344,18 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ag-charts-types@10.3.9: {}
+  ag-charts-types@11.3.2: {}
+
+  ag-grid-community@33.3.2:
+    dependencies:
+      ag-charts-types: 11.3.2
+
+  ag-grid-react@33.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      ag-grid-community: 33.3.2
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Consolidate 6 `@ag-grid-community/*` packages → 2 unified packages (`ag-grid-community` + `ag-grid-react`)
- Rewrite all imports across 16 source files
- Rename deprecated CSS variables for v33 compatibility
- ESM bundle: 2,277 KB → 1,722 KB (**-24.4%**)

## Test plan
- [x] `tsc -b` — 0 errors
- [x] `pnpm test` — 67/67 pass
- [x] `vite build` — success
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)