### PR TITLE
perf: upgrade AG Grid v34 → v35

### DIFF
--- a/packages/buckaroo-js-core/package.json
+++ b/packages/buckaroo-js-core/package.json
@@ -30,8 +30,8 @@
     "/dist"
   ],
   "dependencies": {
-    "ag-grid-community": "^34.3.1",
-    "ag-grid-react": "^34.3.1",
+    "ag-grid-community": "^35.1.0",
+    "ag-grid-react": "^35.1.0",
     "hyparquet": "^1.8.2",
     "lodash-es": "^4.17.21",
     "recharts": "^2.13.1"

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -422,6 +422,7 @@ const getDsGridOptions = (origGridOptions: GridOptions, maxRowsWithoutScrolling:
     const dsGridOptions: GridOptions = {
         ...origGridOptions,
         animateRows:false,
+        suppressNoRowsOverlay: true,
         onSortChanged: (event: SortChangedEvent) => {
             const api: GridApi = event.api;
 	    //@ts-ignore

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -15,11 +15,11 @@ importers:
   buckaroo-js-core:
     dependencies:
       ag-grid-community:
-        specifier: ^34.3.1
-        version: 34.3.1
+        specifier: ^35.1.0
+        version: 35.1.0
       ag-grid-react:
-        specifier: ^34.3.1
-        version: 34.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^35.1.0
+        version: 35.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       hyparquet:
         specifier: ^1.8.2
         version: 1.23.3
@@ -1646,14 +1646,14 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ag-charts-types@12.3.1:
-    resolution: {integrity: sha512-5216xYoawnvMXDFI6kTpPku+mH0Csiwu/FE7lsAm8Z22HEN6ciSG/V7g+IrpLWncELqksgENebCTP75PZ3CsHA==}
+  ag-charts-types@13.1.0:
+    resolution: {integrity: sha512-DytRM3CXli+Y013SC1Mr8lQBrhVTACK+11ilDHOhwUM0sRpmGuR51XFGcBKOliW1Vas1AycP31Cm3Pp0jx3hqw==}
 
-  ag-grid-community@34.3.1:
-    resolution: {integrity: sha512-PwlrPudsFOzGumphi2y9ihWeaUlIwKhOra/MXu2LjeV2U8DgLLcYS8CartE5Hszhn1poJHawwI9HWrxlKliwdw==}
+  ag-grid-community@35.1.0:
+    resolution: {integrity: sha512-yWFQfRNjv3KUBkHHzFdDOYGjPcDMU0B8Up4qG651diFlGRUGEGVs94SK73niWvk1FDZdpV9oWrwq3f30/qAoVg==}
 
-  ag-grid-react@34.3.1:
-    resolution: {integrity: sha512-1UTlBT+xJkjNZAuf7RxK61mgxKGTPB+6XR99oIHq7cYC89kJmLbWqhHt/1XqRWF5cAgSKk8u+HtOQaN8tAZStw==}
+  ag-grid-react@35.1.0:
+    resolution: {integrity: sha512-n8pJh4RTpos8stzz91nEhTCZZdLy9bjQYAGxIxJ8ocVagnEsAk9T5Vz/VEKUhOGz36il68n7TVbVWSuUA3a+mg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -5344,15 +5344,15 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ag-charts-types@12.3.1: {}
+  ag-charts-types@13.1.0: {}
 
-  ag-grid-community@34.3.1:
+  ag-grid-community@35.1.0:
     dependencies:
-      ag-charts-types: 12.3.1
+      ag-charts-types: 13.1.0
 
-  ag-grid-react@34.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  ag-grid-react@35.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      ag-grid-community: 34.3.1
+      ag-grid-community: 35.1.0
       prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)


### PR DESCRIPTION
## Summary
- Bump AG Grid v34 → v35
- Add `suppressNoRowsOverlay: true` to infinite row model grid options (v35 adds default overlays that flash during data loading)
- ESM bundle: 1,773 KB → 1,827 KB (+3% code growth)

## Test plan
- [x] `tsc -b` — 0 errors
- [x] `pnpm test` — 67/67 pass
- [x] `vite build` — success
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)