### PR TITLE
fix: add --index-strategy unsafe-best-match for TestPyPI installs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,7 +131,7 @@ jobs:
             const distFiles = fs.readdirSync('artifacts/dist');
             const wheel = distFiles.find(f => f.endsWith('.whl'));
             const version = wheel.match(/buckaroo-(.+?)-/)[1];
-            const idx = `--index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/`;
+            const idx = `--index-strategy unsafe-best-match --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/`;
             const body = [
               '## :package: TestPyPI package published',
               '',

--- a/tests/unit/server/test_mcp_uvx_install.py
+++ b/tests/unit/server/test_mcp_uvx_install.py
@@ -55,6 +55,7 @@ else:
     UVX_EXTRA_INDEX = os.environ.get("BUCKAROO_EXTRA_INDEX", "https://pypi.org/simple/")
     MCP_CMD = [
         "uvx",
+        "--index-strategy", "unsafe-best-match",
         "--index-url", UVX_INDEX_URL,
         "--extra-index-url", UVX_EXTRA_INDEX,
         "--from", UVX_PACKAGE,
@@ -190,6 +191,7 @@ class TestMcpInstall:
         """uvx can resolve and fetch buckaroo[mcp] without errors."""
         cmd = [
             "uvx",
+            "--index-strategy", "unsafe-best-match",
             "--index-url", os.environ.get("BUCKAROO_INDEX_URL", "https://test.pypi.org/simple/"),
             "--extra-index-url", os.environ.get("BUCKAROO_EXTRA_INDEX", "https://pypi.org/simple/"),
             "--from", os.environ.get("BUCKAROO_MCP_PACKAGE", "buckaroo[mcp]"),


### PR DESCRIPTION
## Summary
- Adds `--index-strategy unsafe-best-match` to all `uvx`/`uv` commands that use TestPyPI + PyPI indexes
- uv's default `first-match` strategy finds `buckaroo` on PyPI first and refuses to check TestPyPI for dev versions, causing resolution failures for users
- Applied to the PR comment install instructions and the CI integration tests that exercise the same uvx flow

Closes #561

## Test plan
- [ ] Verify the CI-generated PR comment includes `--index-strategy unsafe-best-match`
- [ ] Verify MCP integration tests still pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)