### PR TITLE
feat: per-request no_browser in /load POST body

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
   pull_request:
     branches: "*"
+  merge_group:
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Adds `no_browser` field to the `/load` POST body that suppresses browser window creation per-request
- When `"no_browser": true` is included in the request, the `LoadHandler` skips `_handle_browser_window()` regardless of the server's `open_browser` startup setting
- Backwards compatible: defaults to `false`, existing callers are unaffected

## Motivation
When buckaroo is embedded inside another tool (e.g. `xorq-mcp`), the embedding tool manages its own browser windows via the xorq web UI. The server-level `--no-browser` flag works when the embedding tool starts the server itself, but **not** when it reuses a pre-existing server that was started with browser opening enabled. This causes duplicate/unwanted raw buckaroo tabs.

## Test plan
- [x] All 13 existing server tests pass (`tests/unit/server/test_server.py`)
- [ ] Manual: POST to `/load` with `"no_browser": true` — verify no browser window opens
- [ ] Manual: POST to `/load` without `no_browser` — verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)