### PR TITLE
fix: pandas 3.0+ compatibility and marimo extras

### DIFF
--- a/buckaroo/customizations/analysis.py
+++ b/buckaroo/customizations/analysis.py
@@ -34,15 +34,15 @@ def get_mode(ser):
         
         # but in jupyterlite envs, we have a recent version of pandas
         # without this problem
-        if not pd.api.types.is_numeric():
+        if not pd.api.types.is_numeric_dtype(ser):
             return np.nan
         mode_raw = ser.mode()
         if len(mode_raw) == 0:
             return np.nan
         return mode_raw.values[0]
-        
+
     try:
-        if not pd.api.types.is_numeric():
+        if not pd.api.types.is_numeric_dtype(ser):
             return np.nan
         mode_raw = ser.mode()
         if len(mode_raw) == 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,11 @@ test = [
 ]
 
 mcp = ["mcp", "tornado>=6.0", "polars"]
-marimo = ["marimo>=0.19.7"]
+marimo = [
+    "marimo>=0.19.7",
+    "pandas; python_version >= '3.13'",
+    "pandas>=1.3.5; python_version < '3.13'",
+    ]
 jupyterlab = ["jupyterlab>=3.6.0"]
 notebook = ["notebook>=7.0.0"]
 packaging_tools = [

--- a/uv.lock
+++ b/uv.lock
@@ -233,6 +233,8 @@ jupyterlab = [
 ]
 marimo = [
     { name = "marimo" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
 ]
 mcp = [
     { name = "mcp" },
@@ -319,8 +321,10 @@ requires-dist = [
     { name = "numpy", marker = "python_full_version >= '3.13'", specifier = ">=2.2.5" },
     { name = "packaging", marker = "extra == 'test'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'dev'" },
+    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'marimo'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'test'" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=1.3.5" },
+    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'marimo'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'test'", specifier = ">=1.3.5" },
     { name = "pandera", marker = "extra == 'test'" },
     { name = "pl-series-hash", marker = "extra == 'dev'", specifier = "==0.2.1" },


### PR DESCRIPTION
## Summary
- Fix `pd.api.types.is_numeric()` → `is_numeric_dtype(ser)` in `get_mode()` — `is_numeric` was removed in pandas 3.0, breaking the entire analysis pipeline silently
- Add `pandas` to `[marimo]` extras — `marimo_utils.py` imports pandas at top level and `BuckarooDataFrame` inherits from `pd.DataFrame`

## Details

The `get_mode()` function in `customizations/analysis.py` called `pd.api.types.is_numeric()` which:
1. Used the wrong function name (should be `is_numeric_dtype`)
2. Passed no arguments (should pass `ser`)

With pandas 3.0+ this attribute doesn't exist at all, causing `DefaultSummaryStats.summary()` to fail for every column. The error is caught by `@exception_protect`, so `df_display_args["main"]` stays as the empty default (`data_key='empty'`), preventing buckaroo mode from rendering any data.

`is_numeric_dtype` has been in `pd.api.types` since at least pandas 0.22 and is not deprecated — safe across all supported versions.

## Test plan
- [ ] CI passes (all Python test matrix versions: 3.11–3.14, including max-versions with pandas 3.0+)
- [ ] Server Playwright tests pass (buckaroo mode renders data in clean venv)

🤖 Generated with [Claude Code](https://claude.com/claude-code)