### PR TITLE
Add DFViewerInfinite unit tests and enable TSX Jest discovery

### DIFF
--- a/JS_TEST_SUITE_REVIEW.md
+++ b/JS_TEST_SUITE_REVIEW.md
@@ -1,0 +1,91 @@
+# JS Test Suite and Coverage Review
+
+_Date: 2026-02-24_
+
+## Scope reviewed
+
+- Package: `packages/buckaroo-js-core`
+- Unit test runner/configuration: Jest (`package.json`, `jest.config.ts`)
+- Browser/integration test inventory: Playwright specs under `pw-tests/`
+- Coverage source: `pnpm test -- --coverage`
+
+## Current test suite snapshot
+
+- Jest is configured with `testMatch` as:
+  - `!**/*.spec.ts`
+  - `**/*.test.ts`
+- Existing test files in `src/`:
+  - `OperationsList.test.tsx`
+  - `Operations.test.tsx`
+  - `DFViewerParts/gridUtils.test.ts`
+  - `DFViewerParts/SmartRowCache.test.ts`
+- Result: only **2 of 4** unit test files currently match Jest config (the `.test.ts` files), while the two `.test.tsx` files are silently excluded.
+- Playwright has 23 `*.spec.ts` files under `pw-tests/`, giving broad E2E/integration surface coverage.
+
+## Coverage results (from Jest run)
+
+Overall (Jest unit tests):
+
+- Statements: **54.85%**
+- Branches: **29.83%**
+- Functions: **37.01%**
+- Lines: **53.89%**
+
+Notable by-module highlights:
+
+- Strong:
+  - `SmartRowCache.ts`: ~91.5% statements / ~81.25% branches
+  - `DFWhole.ts` and `baked_data/colorMap.ts`: 100%
+- Weak / high-risk:
+  - `DFViewerInfinite.tsx`: ~12.66% statements
+  - `ChartCell.tsx`: ~21.81% statements
+  - `HistogramCell.tsx`: ~17.94% statements
+  - `Styler.tsx`: ~11.26% statements
+  - `Displayer.ts`: ~37.31% statements
+  - `useColorScheme.ts`: ~33.33% statements
+
+## Key findings
+
+1. **Jest glob likely excludes intended React tests (`.test.tsx`).**
+   - This is the highest-value immediate fix because coverage and confidence are currently understated for component behavior already having test files.
+
+2. **Coverage is concentrated in utility/cache logic, not rendering-heavy components.**
+   - `SmartRowCache` and `gridUtils` are tested reasonably well; UI-heavy modules that drive user behavior are mostly untested at unit level.
+
+3. **Branch coverage is the main gap (29.83%).**
+   - Suggests limited exercise of error paths, conditional rendering, and edge-case prop/state combinations.
+
+4. **E2E inventory is large, but unit coverage is narrow.**
+   - Many Playwright specs exist; however, they do not replace fast deterministic unit-level tests for view/model boundary logic.
+
+## Suggested improvement plan (for follow-up implementation)
+
+### Priority 0 (quick wins)
+
+1. Update Jest `testMatch` to include `.test.tsx` (and optionally `.test.jsx/.test.js` if desired).
+2. Add/enable coverage thresholds in Jest (start pragmatic, raise gradually), e.g.:
+   - global lines/stmts ≥ 60
+   - branch ≥ 40
+3. Add `test:coverage` script for CI consistency.
+
+### Priority 1 (high-impact module tests)
+
+1. Add focused RTL tests for:
+   - `DFViewerInfinite.tsx` (loading transitions, pagination/infinite callbacks, empty/error states)
+   - `HistogramCell.tsx` and `ChartCell.tsx` (data-shape handling, fallback rendering)
+   - `Styler.tsx` (style mapping edge cases)
+2. Add branch-focused tests to `Displayer.ts` for display-mode switching and malformed payload handling.
+
+### Priority 2 (suite structure + maintainability)
+
+1. Split Jest projects/config by test type (pure unit vs component DOM tests) to keep feedback fast.
+2. Reduce console noise in tests (`console.log` in core classes) with explicit debug flags/mocks to improve signal.
+3. Map Playwright specs to explicit risk areas (smoke/regression/visual/theme) and run tiers in CI (smoke on PR, full nightly).
+
+## Suggested PR checklist for implementation agent
+
+- [ ] Fix Jest `testMatch` glob(s) and verify `.test.tsx` suites execute.
+- [ ] Add `test:coverage` script + initial thresholds.
+- [ ] Add at least one new test file targeting one low-coverage module (`DFViewerInfinite.tsx` preferred).
+- [ ] Re-run coverage and compare deltas.
+- [ ] Document CI strategy for Jest vs Playwright lanes.

--- a/packages/buckaroo-js-core/jest.config.ts
+++ b/packages/buckaroo-js-core/jest.config.ts
@@ -10,9 +10,6 @@ export default {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
 
-    testMatch: [
-	"!**/*.spec.ts",
-	"**/*.test.ts"
-    ],
+  testMatch: ["!**/*.spec.ts", "**/*.test.ts", "**/*.test.tsx"],
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
 };

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { render } from "@testing-library/react";
+import { DFViewerInfinite } from "./DFViewerInfinite";
+import { DFViewerConfig } from "./DFWhole";
+
+const setGridOptionMock = jest.fn();
+let latestAgGridProps: any = null;
+
+jest.mock("@ag-grid-community/react", () => {
+  const React = require("react");
+  return {
+    AgGridReact: React.forwardRef((props: any, ref: any) => {
+      latestAgGridProps = props;
+      React.useImperativeHandle(ref, () => ({
+        api: {
+          setGridOption: setGridOptionMock,
+        },
+      }));
+
+      React.useEffect(() => {
+        props.onGridReady?.({
+          api: {
+            setGridOption: setGridOptionMock,
+          },
+        });
+      }, [props]);
+
+      return <div data-testid="ag-grid-react-mock" />;
+    }),
+  };
+});
+
+jest.mock("../useColorScheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+const baseConfig: DFViewerConfig = {
+  pinned_rows: [{ primary_key_val: "mean", displayer_args: { displayer: "obj" } }],
+  left_col_configs: [],
+  column_config: [
+    { col_name: "index", header_name: "index", displayer_args: { displayer: "obj" } },
+    { col_name: "a", header_name: "a", displayer_args: { displayer: "obj" } },
+  ],
+  component_config: { className: "my-custom-theme" },
+};
+
+describe("DFViewerInfinite", () => {
+  beforeEach(() => {
+    setGridOptionMock.mockClear();
+    latestAgGridProps = null;
+  });
+
+  it("renders error_info and custom class name", () => {
+    const { getByText, container } = render(
+      <DFViewerInfinite
+        data_wrapper={{ data_type: "Raw", data: [{ index: 0, a: 1 }], length: 1 }}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        error_info="Boom"
+      />,
+    );
+
+    expect(getByText("Boom")).toBeInTheDocument();
+    expect(container.querySelector(".my-custom-theme")).toBeInTheDocument();
+  });
+
+  it("uses rowData for Raw mode and updates rowData via grid api on data change", () => {
+    const { rerender } = render(
+      <DFViewerInfinite
+        data_wrapper={{ data_type: "Raw", data: [{ index: 0, a: 1 }], length: 1 }}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+      />,
+    );
+
+    expect(latestAgGridProps.gridOptions.rowModelType).toBe("clientSide");
+    expect(latestAgGridProps.gridOptions.rowData).toEqual([{ index: 0, a: 1 }]);
+
+    rerender(
+      <DFViewerInfinite
+        data_wrapper={{ data_type: "Raw", data: [{ index: 0, a: 9 }], length: 1 }}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+      />,
+    );
+
+    expect(setGridOptionMock).toHaveBeenCalledWith("rowData", [{ index: 0, a: 9 }]);
+  });
+
+  it("applies pinned top rows on grid ready and summary updates", () => {
+    const { rerender } = render(
+      <DFViewerInfinite
+        data_wrapper={{ data_type: "Raw", data: [{ index: 0, a: 1 }], length: 1 }}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[{ index: "mean", a: 10 }]}
+        setActiveCol={jest.fn()}
+      />,
+    );
+
+    expect(setGridOptionMock).toHaveBeenCalledWith("pinnedTopRowData", [{ index: "mean", a: 10 }]);
+
+    rerender(
+      <DFViewerInfinite
+        data_wrapper={{ data_type: "Raw", data: [{ index: 0, a: 1 }], length: 1 }}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[{ index: "mean", a: 22 }]}
+        setActiveCol={jest.fn()}
+      />,
+    );
+
+    expect(setGridOptionMock).toHaveBeenCalledWith("pinnedTopRowData", [{ index: "mean", a: 22 }]);
+  });
+
+  it("switches to infinite row model for DataSource mode", () => {
+    render(
+      <DFViewerInfinite
+        data_wrapper={{
+          data_type: "DataSource",
+          length: 50,
+          datasource: { rowCount: 50, getRows: jest.fn() },
+        }}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+      />,
+    );
+
+    expect(latestAgGridProps.gridOptions.rowModelType).toBe("infinite");
+    expect(latestAgGridProps.datasource.rowCount).toBe(50);
+  });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import { DFViewerInfinite } from "./DFViewerInfinite";
 import { DFViewerConfig } from "./DFWhole";


### PR DESCRIPTION
### Motivation
- Jest was not discovering React test files (`.test.tsx`), which hid existing component tests and kept coverage artificially low.
- `DFViewerInfinite.tsx` was identified as a high-priority, low-coverage target needing focused unit tests to exercise rendering and grid integration behavior.

### Description
- Added a new test file `src/components/DFViewerParts/DFViewerInfinite.test.tsx` that mocks `@ag-grid-community/react` and `useColorScheme` and exercises error display, theme class wiring, Raw-mode `rowData` updates, pinned-top-row synchronization, and DataSource-mode infinite row model selection.
- Updated `jest.config.ts` to include `**/*.test.tsx` in `testMatch` so TSX-based React tests are discovered and run by Jest.
- Tests rely on a mocked AG Grid component exposing an `api.setGridOption` and trigger `onGridReady` to validate API interactions without the real grid dependency.

### Testing
- Ran unit tests with `pnpm test -- --runInBand` from `packages/buckaroo-js-core`, which reported `Test Suites: 5 passed, 5 total` and `Tests: 80 passed, 80 total`.
- Ran coverage with `pnpm test -- --coverage --runInBand`, which completed successfully and produced overall coverage `Statements: 64.49%`, `Branches: 45.63%`, `Functions: 54.73%`, `Lines: 63.87%` and improved `DFViewerInfinite.tsx` coverage to approximately `Statements: 69.33%`, `Branches: 53.48%`, `Functions: 73.52%`, `Lines: 70%`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699da4b22e588321a3338e971c09565f)