### PR TITLE
fix: add GH_TOKEN to Generate release notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Generate release notes
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           uv run python scripts/generate_release_notes.py \
             --tag-from "${{ steps.prev_tag.outputs.tag }}" \


### PR DESCRIPTION
## Summary

- Adds `GH_TOKEN: ${{ github.token }}` to the **Generate release notes** step in `.github/workflows/release.yml`

## Root cause

PR #574 introduced the release workflow, but the first run immediately failed ([job 64733354479](https://github.com/buckaroo-data/buckaroo/actions/runs/22366370085/job/64733354479)):

```
subprocess.CalledProcessError: Command '['gh', 'pr', 'list', ...]' returned non-zero exit status 4.
```

Exit code 4 from `gh` means authentication required. In GitHub Actions, `GITHUB_TOKEN` is a secret but is **not** automatically exported as an environment variable — `gh` CLI requires it to be set explicitly via `GH_TOKEN` or `GITHUB_TOKEN`. The other steps (`Create GitHub release`, `Upload release assets`) already set `GH_TOKEN: ${{ github.token }}` correctly; this step was missing it.

## Test plan

- [ ] Trigger the release workflow after merge to confirm `gh pr list` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)