### PR TITLE
fix: MCP + server reliability, observability, and hardening

### DIFF
--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -22,6 +22,14 @@ _BUCKAROO_DEBUG = os.environ.get("BUCKAROO_DEBUG", "").lower() in ("1", "true")
 
 LOG_DIR = os.path.join(os.path.expanduser("~"), ".buckaroo", "logs")
 
+
+def _parse_startup_timeout() -> float:
+    try:
+        return float(os.environ.get("BUCKAROO_STARTUP_TIMEOUT", "5.0"))
+    except ValueError:
+        log.warning("BUCKAROO_STARTUP_TIMEOUT is not a valid number; using default 5.0s")
+        return 5.0
+
 CRITICAL_STATIC_FILES = [
     "standalone.js",
     "standalone.css",
@@ -97,7 +105,7 @@ class DiagnosticsHandler(tornado.web.RequestHandler):
             "log_dir": LOG_DIR,
             "log_files": _list_log_files(),
             "sessions": session_info,
-            "startup_timeout_s": float(os.environ.get("BUCKAROO_STARTUP_TIMEOUT", "5.0")),
+            "startup_timeout_s": _parse_startup_timeout(),
             "dependencies": {
                 "tornado": _check_dependency("tornado"),
                 "pandas": _check_dependency("pandas"),

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -1,7 +1,15 @@
+import logging
+import time
 from dataclasses import dataclass, field
 from typing import Any, Optional
+
 import pandas as pd
 # polars is optional — only used in lazy mode
+
+log = logging.getLogger("buckaroo.server.session")
+
+_DEFAULT_SESSION_TTL_S = 3600.0      # 1 hour idle before eviction
+_DEFAULT_EVICTION_INTERVAL_S = 300.0  # check every 5 minutes
 
 
 @dataclass
@@ -27,14 +35,129 @@ class SessionState:
     operation_results: dict = field(default_factory=dict)
     operations: list = field(default_factory=list)
     prompt: str = ""
+    last_accessed: float = field(default_factory=time.time)
+
+    def touch(self) -> None:
+        """Update the last-accessed timestamp."""
+        self.last_accessed = time.time()
+
+
+def build_state_message(session: "SessionState", metadata: dict | None = None) -> dict:
+    """Build the full ``initial_state`` WebSocket payload from a session.
+
+    Args:
+        session: The session whose state to serialise.
+        metadata: Override metadata to include; defaults to ``session.metadata``.
+
+    Returns:
+        A dict ready to be JSON-serialised and sent to WebSocket clients.
+    """
+    msg: dict = {
+        "type": "initial_state",
+        "metadata": metadata if metadata is not None else session.metadata,
+        "prompt": session.prompt,
+        "df_display_args": session.df_display_args,
+        "df_data_dict": session.df_data_dict,
+        "df_meta": session.df_meta,
+        "mode": session.mode,
+    }
+    if session.mode == "buckaroo":
+        msg["buckaroo_state"] = session.buckaroo_state
+        msg["buckaroo_options"] = session.buckaroo_options
+        msg["command_config"] = session.command_config
+        msg["operation_results"] = session.operation_results
+        msg["operations"] = session.operations
+    return msg
 
 
 class SessionManager:
-    def __init__(self):
+    """Manages session lifecycle.
+
+    Thread-safety note: Buckaroo's server runs on a single Tornado IOLoop
+    thread. All session access and mutation is expected to happen on that
+    IOLoop thread. External background threads must not mutate sessions
+    directly. The periodic eviction callback is scheduled via
+    ``IOLoop.call_later`` so it also executes on the IOLoop thread.
+    """
+
+    def __init__(
+        self,
+        ttl_s: float = _DEFAULT_SESSION_TTL_S,
+        eviction_interval_s: float = _DEFAULT_EVICTION_INTERVAL_S,
+    ) -> None:
         self.sessions: dict[str, SessionState] = {}
+        self._ttl_s = ttl_s
+        self._eviction_interval_s = eviction_interval_s
+        self._evicted_count = 0
+        self._schedule_eviction()
+
+    # ------------------------------------------------------------------
+    # Eviction
+    # ------------------------------------------------------------------
+
+    def _schedule_eviction(self) -> None:
+        """Schedule the next eviction pass on the running Tornado IOLoop."""
+        try:
+            import tornado.ioloop
+            tornado.ioloop.IOLoop.current().call_later(
+                self._eviction_interval_s, self._evict_and_reschedule
+            )
+        except RuntimeError:
+            # No IOLoop running (e.g. unit tests without an IOLoop).
+            pass
+
+    def _evict_and_reschedule(self) -> None:
+        self.evict_idle_sessions()
+        self._schedule_eviction()
+
+    def evict_idle_sessions(self) -> int:
+        """Remove sessions idle longer than the configured TTL.
+
+        Only sessions with no active WebSocket clients are eligible.
+        Returns the number of sessions removed.
+        """
+        now = time.time()
+        to_evict = [
+            sid
+            for sid, s in self.sessions.items()
+            if not s.ws_clients and (now - s.last_accessed) > self._ttl_s
+        ]
+        for sid in to_evict:
+            del self.sessions[sid]
+            log.info("Evicted idle session=%s", sid)
+        if to_evict:
+            self._evicted_count += len(to_evict)
+            log.info(
+                "Evicted %d idle session(s); total_evicted=%d active=%d",
+                len(to_evict),
+                self._evicted_count,
+                len(self.sessions),
+            )
+        return len(to_evict)
+
+    # ------------------------------------------------------------------
+    # Metrics
+    # ------------------------------------------------------------------
+
+    @property
+    def active_session_count(self) -> int:
+        """Number of currently tracked sessions."""
+        return len(self.sessions)
+
+    @property
+    def total_evicted_count(self) -> int:
+        """Cumulative number of sessions evicted since startup."""
+        return self._evicted_count
+
+    # ------------------------------------------------------------------
+    # CRUD
+    # ------------------------------------------------------------------
 
     def get(self, session_id: str) -> Optional[SessionState]:
-        return self.sessions.get(session_id)
+        session = self.sessions.get(session_id)
+        if session:
+            session.touch()
+        return session
 
     def create(self, session_id: str, path: str) -> SessionState:
         session = SessionState(session_id=session_id, path=path)
@@ -48,13 +171,13 @@ class SessionManager:
             return existing
         return self.create(session_id, path)
 
-    def add_ws_client(self, session_id: str, client):
+    def add_ws_client(self, session_id: str, client) -> None:
         session = self.get(session_id)
         if not session:
             session = self.create(session_id, "")
         session.ws_clients.add(client)
 
-    def remove_ws_client(self, session_id: str, client):
+    def remove_ws_client(self, session_id: str, client) -> None:
         session = self.get(session_id)
         if session:
             session.ws_clients.discard(client)

--- a/buckaroo_mcp_tool.py
+++ b/buckaroo_mcp_tool.py
@@ -232,7 +232,11 @@ def ensure_server() -> dict:
         server_log_fh.close()
     _start_server_monitor(_server_proc.pid)
 
-    startup_timeout_s = float(os.environ.get("BUCKAROO_STARTUP_TIMEOUT", "5.0"))
+    try:
+        startup_timeout_s = float(os.environ.get("BUCKAROO_STARTUP_TIMEOUT", "5.0"))
+    except ValueError:
+        log.warning("BUCKAROO_STARTUP_TIMEOUT is not a valid number; using default 5.0s")
+        startup_timeout_s = 5.0
     startup_retries = max(1, int(startup_timeout_s / 0.25))
     log.info(
         "Starting server: %s (startup_timeout=%.1fs retries=%d)",

--- a/packages/buckaroo-js-core/pw-tests/server.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/server.spec.ts
@@ -228,7 +228,7 @@ test.describe('/load API', () => {
     });
     expect(resp.status()).toBe(404);
     const body = await resp.json();
-    expect(body.error).toContain("not found");
+    expect(body.message).toContain("not found");
   });
 
   test('400 on unsupported file extension', async ({ request }) => {
@@ -240,7 +240,7 @@ test.describe('/load API', () => {
       });
       expect(resp.status()).toBe(400);
       const body = await resp.json();
-      expect(body.error).toContain("Unsupported");
+      expect(body.message).toContain("Unsupported");
     } finally {
       cleanupFile(tmpPath);
     }
@@ -343,7 +343,7 @@ test.describe('session management', () => {
 
       await page.goto(`${BASE}/s/${session}`);
       await waitForGrid(page);
-      expect(await getRowCount(page)).toBe(3);
+      await expect.poll(() => getRowCount(page), { timeout: 10_000 }).toBe(3);
     } finally {
       cleanupFile(parquetPath);
     }
@@ -356,7 +356,7 @@ test.describe('session management', () => {
       // Refresh the page to pick up the new data
       await page.goto(`${BASE}/s/${session}`);
       await waitForGrid(page);
-      expect(await getRowCount(page)).toBe(5);
+      await expect.poll(() => getRowCount(page), { timeout: 10_000 }).toBe(5);
     } finally {
       cleanupFile(csvPath);
     }


### PR DESCRIPTION
## Summary

Addresses all P0/P1 items and selected P2 items from the MCP + server code review.

- **FD leak (P0):** Close parent-side `server_log_fh` after `Popen` in `ensure_server()` — child keeps its own copy, parent no longer leaks descriptors across repeated start/stop cycles
- **Session TTL eviction (P1):** `SessionManager` now evicts idle sessions (no active WS clients) after a configurable TTL (default 1 h) via a Tornado `call_later` callback; exposes `active_session_count` / `total_evicted_count` metrics
- **Shared state builder (P1):** Extract `build_state_message()` into `session.py`; removes duplicated `initial_state` payload assembly from `LoadHandler`, `DataStreamHandler.open`, and `_handle_buckaroo_state_change`
- **No-op suppression (P1):** `_handle_buckaroo_state_change` early-returns without touching the dataflow or rebroadcasting when `post_processing`, `cleaning_method`, and `quick_command_args` are all unchanged
- **Structured error schema (P1):** HTTP and WS error responses now use `{error_code, message, details?}`; raw tracebacks always logged server-side, only included in response body when `BUCKAROO_DEBUG=1`
- **Startup timeout configurability (P2):** `ensure_server()` retry count derived from `BUCKAROO_STARTUP_TIMEOUT` env var (default `5.0`s); value logged and surfaced in `/diagnostics`
- **Diagnostics (P2):** `/diagnostics` now includes session metrics (`active`, `total_evicted`, `ttl_s`) and `startup_timeout_s`
- **Origin policy (P2):** `check_origin` documented as local-only by design; `BUCKAROO_STRICT_ORIGIN=1` enables localhost-only enforcement

## Test plan

- [x] All 25 existing server + MCP tool cleanup tests pass locally (`pytest tests/unit/server/test_server.py tests/unit/server/test_mcp_tool_cleanup.py`)
- [ ] Verify `/diagnostics` response includes `sessions` and `startup_timeout_s` fields
- [ ] Verify `BUCKAROO_STARTUP_TIMEOUT=10` extends startup wait
- [ ] Verify `BUCKAROO_DEBUG=1` includes tracebacks in error responses
- [ ] Verify `BUCKAROO_STRICT_ORIGIN=1` rejects non-localhost WS origins

🤖 Generated with [Claude Code](https://claude.com/claude-code)