### PR TITLE
fix: harden release workflow — tag-based versioning, no push to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,14 +55,29 @@ jobs:
 
       - name: Determine versions
         id: versions
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Derive current version from the latest semver git tag so this
           # stays correct even when the pyproject.toml version-bump commit
           # hasn't been merged to main yet (e.g. partial previous run).
-          CURRENT=$(git tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-          if [ -z "$CURRENT" ]; then
+          # `|| true` prevents pipefail exit when no tags match the pattern.
+          LATEST_TAG=$(git tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1 || true)
+          if [ -z "$LATEST_TAG" ]; then
             CURRENT=$(grep -Po '^version = "\K[^"]+' pyproject.toml)
             echo "No semver tags found; falling back to pyproject.toml: $CURRENT"
+          else
+            # If the latest tag has no GitHub release, a prior run failed
+            # after tagging. Retry that version instead of bumping again.
+            if ! gh release view "$LATEST_TAG" &>/dev/null; then
+              PREV_TAG=$(git tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -n '2p' || true)
+              echo "::warning::Tag $LATEST_TAG exists without a release — retrying incomplete release."
+              echo "new=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+              echo "prev_tag=${PREV_TAG:-$LATEST_TAG}" >> "$GITHUB_OUTPUT"
+              echo "retry=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            CURRENT="$LATEST_TAG"
           fi
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
           case "${{ inputs.bump }}" in
@@ -71,44 +86,41 @@ jobs:
             patch) PATCH=$((PATCH + 1)) ;;
           esac
           NEW="${MAJOR}.${MINOR}.${PATCH}"
-          # Guard: abort early if this tag already exists (idempotency check)
+          # Guard: abort if this tag already exists with a completed release
           if git tag -l "$NEW" | grep -q "^${NEW}$"; then
             echo "::error::Tag $NEW already exists — this release may have already run. Aborting."
             exit 1
           fi
-          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "retry=false" >> "$GITHUB_OUTPUT"
           echo "Bumping $CURRENT → $NEW (${{ inputs.bump }})"
-
-      - name: Find previous release tag
-        id: prev_tag
-        run: |
-          # The previous tag is the current version (before this bump)
-          TAG="${{ steps.versions.outputs.current }}"
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Previous release tag: $TAG"
 
       - name: Generate release notes
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           uv run python scripts/generate_release_notes.py \
-            --tag-from "${{ steps.prev_tag.outputs.tag }}" \
+            --tag-from "${{ steps.versions.outputs.prev_tag }}" \
             --version "${{ steps.versions.outputs.new }}" \
             --date "$(date +%Y-%m-%d)" \
             --output-dir /tmp
 
-      - name: Bump version in pyproject.toml
-        # Local-only: updates pyproject.toml so the built wheel has the right
-        # version. Not committed here — add to your next dev PR via the
-        # changelog artifact uploaded at the end of this job.
+      - name: Bump version, commit, tag, and push
         run: |
           sed -i 's/^version = ".*"/version = "${{ steps.versions.outputs.new }}"/' pyproject.toml
-
-      - name: Tag and push
-        run: |
-          git tag "${{ steps.versions.outputs.new }}"
-          git push origin "${{ steps.versions.outputs.new }}"
+          if [ "${{ steps.versions.outputs.retry }}" = "true" ]; then
+            echo "Retry mode — tag ${{ steps.versions.outputs.new }} already exists, skipping."
+          else
+            # Commit the version bump so the tag points to correct source.
+            # Only the tag is pushed — not the branch (branch protection).
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add pyproject.toml
+            git commit -m "chore: release ${{ steps.versions.outputs.new }}"
+            git tag "${{ steps.versions.outputs.new }}"
+            git push origin "${{ steps.versions.outputs.new }}"
+          fi
 
       - name: Create GitHub release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,14 @@ jobs:
       - name: Determine versions
         id: versions
         run: |
-          CURRENT=$(grep -Po '^version = "\K[^"]+' pyproject.toml)
+          # Derive current version from the latest semver git tag so this
+          # stays correct even when the pyproject.toml version-bump commit
+          # hasn't been merged to main yet (e.g. partial previous run).
+          CURRENT=$(git tag --sort=-creatordate | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+          if [ -z "$CURRENT" ]; then
+            CURRENT=$(grep -Po '^version = "\K[^"]+' pyproject.toml)
+            echo "No semver tags found; falling back to pyproject.toml: $CURRENT"
+          fi
           IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
           case "${{ inputs.bump }}" in
             major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
@@ -64,6 +71,11 @@ jobs:
             patch) PATCH=$((PATCH + 1)) ;;
           esac
           NEW="${MAJOR}.${MINOR}.${PATCH}"
+          # Guard: abort early if this tag already exists (idempotency check)
+          if git tag -l "$NEW" | grep -q "^${NEW}$"; then
+            echo "::error::Tag $NEW already exists — this release may have already run. Aborting."
+            exit 1
+          fi
           echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
           echo "new=$NEW" >> "$GITHUB_OUTPUT"
           echo "Bumping $CURRENT → $NEW (${{ inputs.bump }})"
@@ -71,7 +83,8 @@ jobs:
       - name: Find previous release tag
         id: prev_tag
         run: |
-          TAG=$(git tag --sort=-creatordate | head -1)
+          # The previous tag is the current version (before this bump)
+          TAG="${{ steps.versions.outputs.current }}"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
           echo "Previous release tag: $TAG"
 
@@ -86,23 +99,16 @@ jobs:
             --output-dir /tmp
 
       - name: Bump version in pyproject.toml
+        # Local-only: updates pyproject.toml so the built wheel has the right
+        # version. Not committed here — add to your next dev PR via the
+        # changelog artifact uploaded at the end of this job.
         run: |
           sed -i 's/^version = ".*"/version = "${{ steps.versions.outputs.new }}"/' pyproject.toml
 
-      - name: Update CHANGELOG.md
+      - name: Tag and push
         run: |
-          if [ -f /tmp/changelog_entry.md ]; then
-            python scripts/update_changelog.py /tmp/changelog_entry.md
-          fi
-
-      - name: Commit, tag, and push
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml CHANGELOG.md
-          git commit -m "chore: release ${{ steps.versions.outputs.new }}"
           git tag "${{ steps.versions.outputs.new }}"
-          git push origin HEAD --tags
+          git push origin "${{ steps.versions.outputs.new }}"
 
       - name: Create GitHub release
         env:
@@ -125,3 +131,14 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Upload changelog entry artifact
+        # Download this artifact and apply it in your next dev PR:
+        #   python scripts/update_changelog.py changelog_entry.md
+        #   sed -i 's/^version = ".*"/version = "NEW"/' pyproject.toml
+        #   uv lock
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-${{ steps.versions.outputs.new }}
+          path: /tmp/changelog_entry.md
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Follow-up fixes to the automated release workflow after post-merge Codex review and CI failures.

- **Exclusive PR search boundary**: `get_tag_date()` was truncating tag timestamps to `YYYY-MM-DD` and using `merged:>=DATE`, which re-pulls same-day PRs into the next release. Fixed by returning the full ISO-8601 timestamp and using exclusive `merged:>TIMESTAMP`.
- **Release workflow no longer pushes to main**: The `chore: release` commit was blocked by branch protection (requires PR + merge queue). The workflow now pushes only the git tag (which bypasses branch protection — confirmed by the partially-successful run). pyproject.toml is bumped locally for the wheel build only.
- **Version derived from git tags**: Prevents version collisions when pyproject.toml on main lags behind (e.g. tag `0.12.13` exists but pyproject still says `0.12.12`). Includes an early-exit guard for duplicate tags.
- **Changelog as artifact**: The generated `changelog_entry.md` is uploaded as a workflow artifact to apply in the next dev PR via `python scripts/update_changelog.py`.
- **Lint**: Remove unused `pytest` import (ruff F401).

## Test plan
- [ ] Lint passes (ruff)
- [ ] Unit tests pass (`test_release_scripts.py`)
- [ ] Release workflow: tag push succeeds, no direct push to main attempted

🤖 Generated with [Claude Code](https://claude.com/claude-code)