### PR TITLE
feat: add custom theme support via component_config

### DIFF
--- a/buckaroo/dataflow/styling_core.py
+++ b/buckaroo/dataflow/styling_core.py
@@ -160,13 +160,44 @@ PinnedRowConfig = TypedDict('PinnedRowConfig', {
     'default_renderer_columns': NotRequired[List[str]]  # used to render index column values with string not the specified displayer
 })
 
+ThemeColorConfig = TypedDict('ThemeColorConfig', {
+    'accentColor': NotRequired[str],
+    'accentHoverColor': NotRequired[str],
+    'backgroundColor': NotRequired[str],
+    'foregroundColor': NotRequired[str],
+    'oddRowBackgroundColor': NotRequired[str],
+    'borderColor': NotRequired[str],
+    'headerBorderColor': NotRequired[str],
+    'headerBackgroundColor': NotRequired[str],
+    'spacing': NotRequired[int],
+    'cellHorizontalPaddingScale': NotRequired[float],
+    'rowVerticalPaddingScale': NotRequired[float],
+})
+
+ThemeConfig = TypedDict('ThemeConfig', {
+    'colorScheme': NotRequired[Literal["light", "dark", "auto"]],
+    'accentColor': NotRequired[str],
+    'accentHoverColor': NotRequired[str],
+    'backgroundColor': NotRequired[str],
+    'foregroundColor': NotRequired[str],
+    'oddRowBackgroundColor': NotRequired[str],
+    'borderColor': NotRequired[str],
+    'headerBorderColor': NotRequired[str],
+    'spacing': NotRequired[int],
+    'cellHorizontalPaddingScale': NotRequired[float],
+    'rowVerticalPaddingScale': NotRequired[float],
+    'light': NotRequired[ThemeColorConfig],
+    'dark': NotRequired[ThemeColorConfig],
+})
+
 ComponentConfig = TypedDict('ComponentConfig', {
     'height_fraction': NotRequired[float],
     'dfvHeight': NotRequired[int],  # temporary debugging prop
     'layoutType': NotRequired[Literal["autoHeight", "normal"]],
     'shortMode': NotRequired[bool],
     'selectionBackground': NotRequired[str],
-    'className': NotRequired[str]
+    'className': NotRequired[str],
+    'theme': NotRequired[ThemeConfig]
 })
 
 DFViewerConfig = TypedDict('DFViewerConfig', {

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -151,9 +151,9 @@ class LoadHandler(tornado.web.RequestHandler):
         return body
 
     def _validate_request(self, body: dict) -> tuple:
-        """Validate and extract session_id, path, mode, prompt, and no_browser from request.
+        """Validate and extract session_id, path, mode, prompt, no_browser, and component_config from request.
 
-        Returns (session_id, path, mode, prompt, no_browser) or a tuple of Nones on error.
+        Returns (session_id, path, mode, prompt, no_browser, component_config) or a tuple of Nones on error.
         """
         session_id = body.get("session")
         path = body.get("path")
@@ -161,12 +161,13 @@ class LoadHandler(tornado.web.RequestHandler):
         if not session_id or not path:
             self.set_status(400)
             self.write({"error": "Missing 'session' or 'path'"})
-            return None, None, None, None, None
+            return None, None, None, None, None, None
 
         mode = body.get("mode", "viewer")
         prompt = body.get("prompt", "")
         no_browser = bool(body.get("no_browser", False))
-        return session_id, path, mode, prompt, no_browser
+        component_config = body.get("component_config")
+        return session_id, path, mode, prompt, no_browser, component_config
 
     def _load_lazy_polars(self, session, path: str, ldf, metadata: dict):
         """Set up lazy polars session state."""
@@ -237,7 +238,7 @@ class LoadHandler(tornado.web.RequestHandler):
         if body is None:
             return
 
-        session_id, path, mode, prompt, no_browser = self._validate_request(body)
+        session_id, path, mode, prompt, no_browser, component_config = self._validate_request(body)
         if session_id is None:
             return
 
@@ -245,6 +246,8 @@ class LoadHandler(tornado.web.RequestHandler):
         session = sessions.get_or_create(session_id, path)
         session.mode = mode
         session.prompt = prompt
+        if component_config:
+            session.component_config = component_config
 
         # Load data in appropriate mode
         file_obj, metadata = self._load_file_with_error_handling(path, is_lazy=(mode == "lazy"))
@@ -273,6 +276,16 @@ class LoadHandler(tornado.web.RequestHandler):
                 session.df_display_args = display_state["df_display_args"]
                 session.df_data_dict = display_state["df_data_dict"]
                 session.df_meta = display_state["df_meta"]
+
+        # Merge component_config into df_display_args if provided
+        if component_config and session.df_display_args:
+            for key in session.df_display_args:
+                dvc = session.df_display_args[key].get("df_viewer_config")
+                if dvc is not None:
+                    dvc["component_config"] = {
+                        **dvc.get("component_config", {}),
+                        **component_config,
+                    }
 
         # Notify connected clients and open browser
         self._push_state_to_clients(session, metadata)

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -35,6 +35,7 @@ class SessionState:
     operation_results: dict = field(default_factory=dict)
     operations: list = field(default_factory=list)
     prompt: str = ""
+    component_config: Optional[dict] = None
     last_accessed: float = field(default_factory=time.time)
 
     def touch(self) -> None:

--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -88,6 +88,16 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             session.buckaroo_options = buckaroo_state["buckaroo_options"]
             session.command_config = buckaroo_state["command_config"]
 
+            # Re-apply component_config so theme settings survive state changes
+            if session.component_config and session.df_display_args:
+                for key in session.df_display_args:
+                    dvc = session.df_display_args[key].get("df_viewer_config")
+                    if dvc is not None:
+                        dvc["component_config"] = {
+                            **dvc.get("component_config", {}),
+                            **session.component_config,
+                        }
+
             # Broadcast updated state to all connected clients
             update_payload = json.dumps(build_state_message(session))
             for client in list(session.ws_clients):

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -34,6 +34,7 @@ build:
         - ./scripts/marimo_wasm_output.sh buckaroo_compare.py edit
         - ./scripts/marimo_wasm_output.sh full_tour.py edit
         - uv run python scripts/generate_ddd_static_html.py
+        - uv run python scripts/generate_theme_static_html.py
         - pnpm -C packages/buckaroo-js-core run build-storybook
         - cp -r packages/buckaroo-js-core/dist/storybook docs/extra-html/
         - cp -r docs/extra-html/* $READTHEDOCS_OUTPUT/html

--- a/docs/source/articles/theme-customization.rst
+++ b/docs/source/articles/theme-customization.rst
@@ -1,0 +1,649 @@
+Theme Customization
+===================
+
+Buckaroo tables automatically match your OS light/dark preference. But
+sometimes you want more control — a branded dashboard, a high-contrast
+accessibility mode, or just a color scheme you enjoy staring at for hours.
+
+The ``component_config.theme`` dictionary gives you full control over the
+color scheme without touching CSS. Every example on this page is a live
+static embed — no server, no kernel, just HTML and JavaScript.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+    import buckaroo
+
+    # Jupyter / IPython — just set component_config on the widget
+    w = buckaroo.BuckarooWidget(df, component_config={
+        'theme': {
+            'colorScheme': 'dark',
+            'accentColor': '#00bcd4',
+        }
+    })
+
+    # Static embed — inject theme into the artifact
+    from buckaroo.artifact import prepare_buckaroo_artifact, artifact_to_json
+
+    artifact = prepare_buckaroo_artifact(df)
+    artifact['df_viewer_config'].setdefault('component_config', {})['theme'] = {
+        'colorScheme': 'dark',
+        'accentColor': '#00bcd4',
+    }
+
+    # MCP server — pass component_config in the /load request body
+    {"session": "my-session", "path": "data.csv", "component_config": {
+        "theme": {"colorScheme": "dark", "accentColor": "#00bcd4"}
+    }}
+
+
+ThemeConfig reference
+---------------------
+
+All properties are optional. Omitted properties use sensible defaults
+based on the resolved color scheme.
+
+Color properties
+~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 14 50
+
+   * - Property
+     - Type
+     - Description
+   * - ``colorScheme``
+     - ``'light'`` | ``'dark'`` | ``'auto'``
+     - Override OS color scheme detection. ``'auto'`` (the default) respects
+       the user's system preference.
+   * - ``accentColor``
+     - CSS color
+     - Primary highlight color for column selection, active tabs, and buttons.
+       Default: ``#2196F3`` (blue).
+   * - ``accentHoverColor``
+     - CSS color
+     - Hover state for accent elements. Should be a darker shade of
+       ``accentColor``.
+   * - ``backgroundColor``
+     - CSS color
+     - Main table background. Default: ``#ffffff`` (light) or ``#181D1F``
+       (dark).
+   * - ``foregroundColor``
+     - CSS color
+     - Text and icon color. Passed through to AG Grid's theme system.
+   * - ``oddRowBackgroundColor``
+     - CSS color
+     - Alternating row stripe color. Default: ``#f5f5f5`` (light) or
+       ``#222628`` (dark).
+   * - ``borderColor``
+     - CSS color
+     - Grid line and border color. Passed through to AG Grid's theme system.
+   * - ``headerBorderColor``
+     - CSS color
+     - Border color between column headers. Controls the vertical dividers
+       between columns in the header row — including MultiIndex group headers.
+   * - ``headerBackgroundColor``
+     - CSS color
+     - Background color for all header rows. With MultiIndex columns, this
+       colors both the group header row and the leaf header row.
+
+Layout properties
+~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 10 48
+
+   * - Property
+     - Type
+     - Description
+   * - ``spacing``
+     - number
+     - Base spacing unit in pixels. Controls the overall density of the grid.
+       Default: ``5``. Lower values = more compact.
+   * - ``cellHorizontalPaddingScale``
+     - number
+     - Multiplier for horizontal cell padding. Default: ``0.3``. Use ``0.1``
+       for very tight or ``1.0`` for spacious.
+   * - ``rowVerticalPaddingScale``
+     - number
+     - Multiplier for vertical row padding. Default: ``0.5``. Use ``0.2``
+       for compact or ``1.2`` for airy.
+
+
+Auto light/dark with ``light`` and ``dark`` sub-dicts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When ``colorScheme`` is ``'auto'``, the table follows the OS preference.
+But a single set of colors can't look good in both modes. Use ``light``
+and ``dark`` sub-dicts to define separate palettes:
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'auto',
+        'light': {
+            'accentColor': '#e65100',
+            'backgroundColor': '#fff8f0',
+            'foregroundColor': '#3e2723',
+            'oddRowBackgroundColor': '#fff3e0',
+            'borderColor': '#ffe0b2',
+        },
+        'dark': {
+            'accentColor': '#ffab40',
+            'backgroundColor': '#1a1209',
+            'foregroundColor': '#ffe0b2',
+            'oddRowBackgroundColor': '#2a1e0f',
+            'borderColor': '#4e342e',
+        },
+    }}
+
+The resolution order is: **scheme-specific override > top-level color >
+built-in default**. This means you can set shared properties at the top
+level and override only what differs per scheme:
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'auto',
+        'spacing': 8,                     # shared — same in light and dark
+        'headerBorderColor': '#7c4dff',   # shared
+        'light': {
+            'accentColor': '#7c4dff',
+            'backgroundColor': '#faf8ff',
+        },
+        'dark': {
+            'accentColor': '#b388ff',
+            'backgroundColor': '#1a1028',
+        },
+    }}
+
+Both ``light`` and ``dark`` accept all color and layout properties from
+``ThemeColorConfig``.
+
+
+CSS custom properties
+~~~~~~~~~~~~~~~~~~~~~
+
+Theme properties are injected as CSS custom properties on the wrapper
+``div``, so they cascade into all child components:
+
+- ``--bk-accent-color`` — accent color
+- ``--bk-accent-hover-color`` — accent hover color
+- ``--bk-bg-color`` — background color (always set, with scheme-based fallback)
+- ``--bk-fg-color`` — foreground color
+
+
+Theme gallery
+-------------
+
+Each table below renders the same 10-row cities dataset with a different
+theme configuration. Click a column to see the accent color in action.
+
+
+Default (Light)
+~~~~~~~~~~~~~~~
+
+No theme overrides. Uses the OS-detected color scheme with built-in defaults.
+
+.. code-block:: python
+
+    component_config = {}  # no theme key needed
+
+.. raw:: html
+
+   <iframe src="../themes/default-light.html"
+           style="width:100%; height:280px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Default (Dark)
+~~~~~~~~~~~~~~
+
+Force dark mode with just ``colorScheme``. All other colors use the
+built-in dark defaults — no need to specify ``backgroundColor`` or
+``oddRowBackgroundColor``.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/default-dark.html"
+           style="width:100%; height:280px; border:1px solid #333; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+..
+   Custom Accent Color
+   ~~~~~~~~~~~~~~~~~~~
+
+   Override just the accent color. Everything else stays default. This is the
+   most common customization — match your brand without changing the overall
+   look.
+
+   .. code-block:: python
+
+       component_config = {'theme': {
+           'accentColor': '#ff6600',      # orange — click a column to see it
+           'accentHoverColor': '#cc5200', # darker orange — command UI buttons
+       }}
+
+   .. raw:: html
+
+      <iframe src="../themes/accent-color.html"
+              style="width:100%; height:280px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+      </iframe>
+
+
+Ocean Dark
+~~~~~~~~~~
+
+A deep ocean-inspired dark theme with cyan accents. Good for dashboards
+with a calm, professional feel.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+        'accentColor': '#00bcd4',
+        'accentHoverColor': '#0097a7',
+        'backgroundColor': '#0a1628',
+        'foregroundColor': '#b0bec5',
+        'oddRowBackgroundColor': '#0d2137',
+        'borderColor': '#1a3a5c',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/ocean-dark.html"
+           style="width:100%; height:280px; border:1px solid #1a3a5c; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Warm Light
+~~~~~~~~~~
+
+A warm, earthy light theme with orange accents. Works well for data
+presentations where the default blue feels too clinical.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'light',
+        'accentColor': '#e65100',
+        'accentHoverColor': '#bf360c',
+        'backgroundColor': '#fff8f0',
+        'foregroundColor': '#3e2723',
+        'oddRowBackgroundColor': '#fff3e0',
+        'borderColor': '#ffe0b2',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/warm-light.html"
+           style="width:100%; height:280px; border:1px solid #ffe0b2; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Neon Dark
+~~~~~~~~~
+
+A cyberpunk-inspired dark theme with hot pink accents. The same colors
+used in the Storybook ``FullCustom`` story.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+        'accentColor': '#e91e63',
+        'accentHoverColor': '#c2185b',
+        'backgroundColor': '#1a1a2e',
+        'foregroundColor': '#e0e0e0',
+        'oddRowBackgroundColor': '#16213e',
+        'borderColor': '#0f3460',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/neon-dark.html"
+           style="width:100%; height:280px; border:1px solid #0f3460; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Forest Dark
+~~~~~~~~~~~
+
+A dark theme with forest green accents — easy on the eyes for long
+data exploration sessions.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+        'accentColor': '#66bb6a',
+        'accentHoverColor': '#43a047',
+        'backgroundColor': '#1b2a1b',
+        'foregroundColor': '#c8e6c9',
+        'oddRowBackgroundColor': '#223322',
+        'borderColor': '#2e7d32',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/forest-dark.html"
+           style="width:100%; height:280px; border:1px solid #2e7d32; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Minimal Light
+~~~~~~~~~~~~~
+
+A neutral, low-contrast light theme that keeps data front and center.
+Uses only grays — no color distractions.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'light',
+        'accentColor': '#9e9e9e',
+        'accentHoverColor': '#757575',
+        'backgroundColor': '#ffffff',
+        'foregroundColor': '#212121',
+        'oddRowBackgroundColor': '#fafafa',
+        'borderColor': '#e0e0e0',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/minimal-light.html"
+           style="width:100%; height:280px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+High Contrast
+~~~~~~~~~~~~~
+
+Maximum contrast for accessibility. Bright yellow accents on pure black,
+with white text and borders.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+        'accentColor': '#ffff00',
+        'accentHoverColor': '#ffd600',
+        'backgroundColor': '#000000',
+        'foregroundColor': '#ffffff',
+        'oddRowBackgroundColor': '#1a1a1a',
+        'borderColor': '#ffffff',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/high-contrast.html"
+           style="width:100%; height:280px; border:1px solid #fff; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Auto Light/Dark (Branded)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Follows the OS preference with separate branded palettes for each scheme.
+Toggle your OS between light and dark mode to see it switch.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'auto',
+        'light': {
+            'accentColor': '#e65100',
+            'accentHoverColor': '#bf360c',
+            'backgroundColor': '#fff8f0',
+            'foregroundColor': '#3e2723',
+            'oddRowBackgroundColor': '#fff3e0',
+            'borderColor': '#ffe0b2',
+        },
+        'dark': {
+            'accentColor': '#ffab40',
+            'accentHoverColor': '#ff9100',
+            'backgroundColor': '#1a1209',
+            'foregroundColor': '#ffe0b2',
+            'oddRowBackgroundColor': '#2a1e0f',
+            'borderColor': '#4e342e',
+        },
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/auto-branded.html"
+           style="width:100%; height:280px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Spacious Layout
+~~~~~~~~~~~~~~~
+
+Increased spacing, padding, and a purple header border. Good for
+presentations and read-only dashboards where data density isn't critical.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+        'accentColor': '#7c4dff',
+        'accentHoverColor': '#651fff',
+        'spacing': 10,
+        'rowVerticalPaddingScale': 1.2,
+        'cellHorizontalPaddingScale': 0.8,
+        'headerBorderColor': '#7c4dff',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/spacious.html"
+           style="width:100%; height:360px; border:1px solid #7c4dff; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Compact Layout
+~~~~~~~~~~~~~~
+
+Minimal spacing for maximum data density. Fits more rows on screen — good
+for power users who want to see as much data as possible.
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'light',
+        'spacing': 2,
+        'rowVerticalPaddingScale': 0.2,
+        'cellHorizontalPaddingScale': 0.15,
+        'headerBorderColor': '#bdbdbd',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/compact.html"
+           style="width:100%; height:240px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+VC Pricing Page
+~~~~~~~~~~~~~~~
+
+Buckaroo's default styling is what I call **trader styling** — jam
+information into every pixel, minimize whitespace, maximize data density.
+This is the opposite: **VC styling**. Generous padding, pastel accents,
+and three columns where the last one says "Call us for pricing".
+
+.. code-block:: python
+
+    # The data
+    df = pd.DataFrame({
+        'Feature': ['Seats', 'Storage', 'API calls/mo',
+                    'SSO', 'Audit log', 'Support'],
+        'Starter': ['5', '10 GB', '1,000',
+                    'No', 'No', 'Email'],
+        'Enterprise': ['Unlimited', 'Unlimited', 'Unlimited',
+                       'Yes', 'Yes', 'Call us for pricing'],
+    })
+
+    # The theme
+    component_config = {'theme': {
+        'colorScheme': 'light',
+        'accentColor': '#6c5ce7',
+        'accentHoverColor': '#5a4bd1',
+        'backgroundColor': '#ffffff',
+        'foregroundColor': '#2d3436',
+        'oddRowBackgroundColor': '#f8f9ff',
+        'borderColor': '#e8e8f0',
+        'headerBorderColor': '#6c5ce7',
+        'spacing': 16,
+        'rowVerticalPaddingScale': 2.0,
+        'cellHorizontalPaddingScale': 1.5,
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/vc-pricing.html"
+           style="width:100%; height:700px; border:1px solid #e8e8f0; border-radius:12px; margin:1em 0;">
+   </iframe>
+
+
+MultiIndex Headers
+~~~~~~~~~~~~~~~~~~
+
+MultiIndex (hierarchical) column headers are common after ``pivot_table()``
+and ``groupby().agg()``. Three theme properties target the header area:
+
+- ``borderColor`` — controls all grid borders, including the thick separator
+  below the header and the vertical dividers between MultiIndex group cells
+- ``headerBorderColor`` — targets only the vertical dividers between column
+  headers (overrides ``borderColor`` for header cells)
+- ``headerBackgroundColor`` — colors all header rows, making the group
+  hierarchy visually distinct from the data area
+
+.. code-block:: python
+
+    # The data — what pivot_table() produces
+    cols = pd.MultiIndex.from_tuples([
+        ('Revenue', 'Q1'), ('Revenue', 'Q2'), ('Revenue', 'Q3'),
+        ('Headcount', 'Engineering'), ('Headcount', 'Sales'),
+        ('Headcount', 'Support'),
+    ], names=['Category', 'Detail'])
+    df = pd.DataFrame(..., columns=cols)
+
+Every property below uses a deliberately garish color so you can see
+exactly what it controls:
+
+.. code-block:: python
+
+    component_config = {'theme': {
+        'colorScheme': 'dark',
+        'accentColor': 'purple',
+        'accentHoverColor': 'orange',
+        'backgroundColor': 'blue',
+        'foregroundColor': 'teal',
+        'oddRowBackgroundColor': 'red',
+        'borderColor': 'pink',
+        'headerBorderColor': 'green',
+        'headerBackgroundColor': 'brown',
+    }}
+
+.. raw:: html
+
+   <iframe src="../themes/multiindex-headers.html"
+           style="width:100%; height:360px; border:1px solid #ff69b4; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+How theming works under the hood
+---------------------------------
+
+Theme configuration flows through three layers:
+
+1. **Python** — ``component_config['theme']`` is a dict that rides alongside
+   the DataFrame display configuration. It's stored in ``df_viewer_config``
+   and serialized to JSON.
+
+2. **CSS custom properties** — The React layer reads the theme dict and
+   sets ``--bk-accent-color``, ``--bk-bg-color``, etc. as inline styles
+   on the wrapper ``div``. All child components inherit these variables.
+
+3. **AG Grid theme API** — ``backgroundColor``, ``foregroundColor``,
+   ``oddRowBackgroundColor``, ``borderColor``, ``spacing``, and the padding
+   scale properties are passed directly to AG Grid's ``Theme.withParams()``
+   method, which handles the grid's internal styling.
+
+The ``resolveColorScheme()`` function is the single source of truth for
+light/dark resolution. It checks ``themeConfig.colorScheme`` first; if
+that's ``'auto'`` or absent, it falls back to the OS preference detected
+via ``window.matchMedia('(prefers-color-scheme: dark)')``.
+
+After the color scheme is resolved, ``resolveThemeColors()`` merges
+the matching ``light`` or ``dark`` sub-dict (if present) with the
+top-level properties. Scheme-specific values take priority, so you can
+set shared defaults at the top level and only override what differs per
+scheme.
+
+In server mode (``mode="buckaroo"``), ``component_config`` is persisted
+in the session state. When a user changes the cleaning method or
+post-processing option, the dataflow rebuilds ``df_display_args`` from
+scratch — but ``component_config`` is re-applied afterward, so the theme
+survives interaction.
+
+
+Building your own theme
+-----------------------
+
+Start from the closest built-in and override what you need:
+
+.. code-block:: python
+
+    # Start with forced dark, customize from there
+    my_theme = {
+        'colorScheme': 'dark',
+        'accentColor': '#your-brand-color',
+    }
+
+    # Only add background/foreground/border if the defaults don't work
+    # for your accent color. The built-in dark/light palettes are designed
+    # to work with any accent.
+
+Tips:
+
+- ``accentColor`` is the highest-impact single property — it controls
+  column selection highlighting, active tab backgrounds, and button colors.
+- Always pair ``accentColor`` with ``accentHoverColor`` (a slightly darker
+  shade) for consistent interaction feedback.
+- ``oddRowBackgroundColor`` should be close to ``backgroundColor`` — just
+  enough contrast to distinguish rows without creating visual noise.
+- Use ``spacing``, ``rowVerticalPaddingScale``, and
+  ``cellHorizontalPaddingScale`` to control density. Lower values = more
+  compact. The defaults (``5``, ``0.5``, ``0.3``) are a good middle ground.
+- ``headerBorderColor`` is useful when you want headers to stand out from
+  data rows — set it to your accent color for a subtle branded touch.
+- For auto light/dark, put shared values at the top level and
+  scheme-specific colors in ``light``/``dark`` sub-dicts.
+- Test with actual data. A theme that looks great on 5 rows might be
+  overwhelming on 500.
+
+
+Generating static theme demos
+------------------------------
+
+The embeds on this page were generated with:
+
+.. code-block:: bash
+
+    python scripts/generate_theme_static_html.py
+
+This produces HTML files in ``docs/extra-html/themes/`` that reference the
+shared ``static-embed.js`` and ``static-embed.css`` bundles.

--- a/packages/buckaroo-js-core/pw-tests/theme-custom-server.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-custom-server.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { waitForGrid } from './server-helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const screenshotsDir = path.join(__dirname, '..', 'screenshots');
+
+const PORT = 8701;
+const BASE = `http://localhost:${PORT}`;
+
+function writeTempCsv(): string {
+  const header = 'name,age,score';
+  const rows = [
+    'Alice,30,88.5',
+    'Bob,25,92.3',
+    'Charlie,35,76.1',
+    'Diana,28,95.0',
+    'Eve,32,81.7',
+  ];
+  const content = [header, ...rows].join('\n') + '\n';
+  const tmpPath = path.join(os.tmpdir(), `buckaroo_theme_${Date.now()}.csv`);
+  fs.writeFileSync(tmpPath, content);
+  return tmpPath;
+}
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+test('server: theme config applied via /load', async ({ page, request }) => {
+  const csvPath = writeTempCsv();
+  const session = `theme-${Date.now()}`;
+  const resp = await request.post(`${BASE}/load`, {
+    data: {
+      session,
+      path: csvPath,
+      component_config: {
+        theme: {
+          accentColor: '#ff6600',
+          backgroundColor: '#1a1a2e',
+          colorScheme: 'dark',
+        },
+      },
+    },
+  });
+  expect(resp.ok()).toBeTruthy();
+
+  await page.goto(`${BASE}/s/${session}`);
+  await waitForGrid(page);
+
+  // Assert background color on the grid
+  const gridBody = page.locator('.ag-body-viewport').first();
+  const bg = await gridBody.evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(26, 26, 46)'); // #1a1a2e
+
+  await page.screenshot({
+    path: path.join(screenshotsDir, 'server-theme-custom.png'),
+    fullPage: true,
+  });
+
+  fs.unlinkSync(csvPath);
+});
+
+test('server: no theme = default rendering', async ({ page, request }) => {
+  const csvPath = writeTempCsv();
+  const session = `no-theme-${Date.now()}`;
+  const resp = await request.post(`${BASE}/load`, {
+    data: { session, path: csvPath },
+  });
+  expect(resp.ok()).toBeTruthy();
+
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.goto(`${BASE}/s/${session}`);
+  await waitForGrid(page);
+
+  const gridBody = page.locator('.ag-body-viewport').first();
+  const bg = await gridBody.evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(255, 255, 255)');
+
+  fs.unlinkSync(csvPath);
+});

--- a/packages/buckaroo-js-core/pw-tests/theme-custom.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/theme-custom.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from '@playwright/test';
+import { waitForCells } from './ag-pw-utils';
+import * as path from 'path';
+import * as fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const screenshotsDir = path.join(__dirname, '..', 'screenshots');
+
+const STORYBOOK_BASE = 'http://localhost:6006/iframe.html?viewMode=story&id=';
+
+// Ensure screenshots directory exists
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+test('default story renders without theme overrides', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--default-no-theme`);
+  await waitForCells(page);
+
+  const gridBody = page.locator('.ag-body-viewport').first();
+  const bg = await gridBody.evaluate(el => getComputedStyle(el).backgroundColor);
+  // Light mode default: white
+  expect(bg).toBe('rgb(255, 255, 255)');
+});
+
+test('custom accent color applied to selected column', async ({ page }) => {
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--custom-accent`);
+  await waitForCells(page);
+
+  // Click column header to select it
+  await page.locator('.ag-header-cell').nth(1).click();
+
+  // Assert the accent color is applied to cells
+  const cell = page.locator('.ag-cell[col-id="a"]').first();
+  await expect(cell).toHaveCSS('background-color', 'rgb(255, 102, 0)'); // #ff6600
+});
+
+test('forced dark scheme ignores OS light preference', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'light' }); // OS says light
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--forced-dark`);
+  await waitForCells(page);
+
+  // Grid should use dark background despite OS light mode
+  const gridBody = page.locator('.ag-body-viewport').first();
+  const bg = await gridBody.evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(26, 26, 46)'); // #1a1a2e
+});
+
+test('forced light scheme ignores OS dark preference', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'dark' }); // OS says dark
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--forced-light`);
+  await waitForCells(page);
+
+  const gridBody = page.locator('.ag-body-viewport').first();
+  const bg = await gridBody.evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(250, 250, 250)'); // #fafafa
+});
+
+test('full custom theme applies all properties', async ({ page }) => {
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--full-custom`);
+  await waitForCells(page);
+
+  // Background
+  const gridBody = page.locator('.ag-body-viewport').first();
+  const bg = await gridBody.evaluate(el => getComputedStyle(el).backgroundColor);
+  expect(bg).toBe('rgb(26, 26, 46)'); // #1a1a2e
+
+  // Screenshot for visual debugging
+  await page.screenshot({
+    path: path.join(screenshotsDir, 'theme-full-custom.png'),
+    fullPage: true,
+  });
+});
+
+test('screenshot: default vs custom comparison', async ({ page }) => {
+  await page.emulateMedia({ colorScheme: 'light' });
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--default-no-theme`);
+  await waitForCells(page);
+  await page.screenshot({
+    path: path.join(screenshotsDir, 'theme-default-light.png'),
+    fullPage: true,
+  });
+
+  await page.goto(`${STORYBOOK_BASE}buckaroo-theme-themecustomization--forced-dark`);
+  await waitForCells(page);
+  await page.screenshot({
+    path: path.join(screenshotsDir, 'theme-forced-dark.png'),
+    fullPage: true,
+  });
+});

--- a/packages/buckaroo-js-core/src/components/BuckarooStaticTable.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooStaticTable.tsx
@@ -113,6 +113,7 @@ function BuckarooStaticWidget({
                     buckarooState={buckarooState}
                     setBuckarooState={setBuckarooState}
                     buckarooOptions={artifact.buckaroo_options!}
+                    themeConfig={cDisp.df_viewer_config?.component_config?.theme}
                 />
                 <DFViewerInfinite
                     data_wrapper={dataWrapper}

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -183,6 +183,7 @@ export function BuckarooInfiniteWidget({
                         buckarooState={buckaroo_state}
                         setBuckarooState={on_buckaroo_state}
                         buckarooOptions={buckaroo_options}
+                        themeConfig={cDisp.df_viewer_config?.component_config?.theme}
                     />
                     <DFViewerInfinite
                         data_wrapper={data_wrapper}

--- a/packages/buckaroo-js-core/src/components/DCFCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DCFCell.tsx
@@ -61,6 +61,7 @@ export function WidgetDCFCell({
                     buckarooState={buckaroo_state}
                     setBuckarooState={on_buckaroo_state}
                     buckarooOptions={buckaroo_options}
+                    themeConfig={cDisp.df_viewer_config?.component_config?.theme}
                 />
                 <DFViewer
                     df_data={dfData}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -34,8 +34,9 @@ import {
     HeightStyleI,
     SetColumnFunc
 } from "./gridUtils";
-import { getThemeForScheme } from './gridUtils';
+import { getThemeForScheme, resolveColorScheme, resolveThemeColors } from './gridUtils';
 import { useColorScheme } from '../useColorScheme';
+import type { ThemeConfig } from './gridUtils';
 
 ModuleRegistry.registerModules([
     ClientSideRowModelModule,
@@ -167,13 +168,26 @@ export function DFViewerInfinite({
         )}, [hsCacheKey]
     );
   const defaultActiveCol:[string, string] = ["", ""];
-    const colorScheme = useColorScheme();
-    const defaultThemeClass = colorScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
-    const divClass = df_viewer_config?.component_config?.className || defaultThemeClass;
+    const osColorScheme = useColorScheme();
+    const rawThemeConfig = compConfig?.theme;
+    const effectiveScheme = resolveColorScheme(osColorScheme, rawThemeConfig);
+    const themeConfig = resolveThemeColors(effectiveScheme, rawThemeConfig);
+    const defaultThemeClass = effectiveScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
+    const divClass = `${defaultThemeClass} ${compConfig?.className || ''}`.trim();
+
+    const bgColor = themeConfig?.backgroundColor || (effectiveScheme === 'light' ? '#ffffff' : '#181D1F');
+    const themeStyle: React.CSSProperties = {
+        ...hs.applicableStyle,
+        ...(themeConfig?.accentColor ? { '--bk-accent-color': themeConfig.accentColor } as any : {}),
+        ...(themeConfig?.accentHoverColor ? { '--bk-accent-hover-color': themeConfig.accentHoverColor } as any : {}),
+        ...({ '--bk-bg-color': bgColor } as any),
+        ...(themeConfig?.foregroundColor ? { '--bk-fg-color': themeConfig.foregroundColor } as any : {}),
+    };
+
     return (
         <div className={`df-viewer  ${hs.classMode} ${hs.inIframe}`}>
             {error_info ? <pre>{error_info}</pre> : null}
-            <div style={hs.applicableStyle}
+            <div style={themeStyle}
                 className={`theme-hanger ${divClass}`}>
                 <DFViewerInfiniteInner
                     data_wrapper={data_wrapper}
@@ -184,6 +198,8 @@ export function DFViewerInfinite({
                     outside_df_params={outside_df_params}
                     renderStartTime={renderStartTime}
                     hs={hs}
+                    themeConfig={themeConfig}
+                    effectiveScheme={effectiveScheme}
                 />
             </div>
         </div>)
@@ -196,7 +212,9 @@ export function DFViewerInfiniteInner({
     setActiveCol,
     outside_df_params,
     renderStartTime: _renderStartTime,
-    hs
+    hs,
+    themeConfig,
+    effectiveScheme
 }: {
     data_wrapper: DatasourceOrRaw;
     df_viewer_config: DFViewerConfig;
@@ -208,7 +226,9 @@ export function DFViewerInfiniteInner({
     // them as keys to get updated data
     outside_df_params?: any;
     renderStartTime:any;
-    hs:HeightStyleI
+    hs:HeightStyleI;
+    themeConfig?: ThemeConfig;
+    effectiveScheme?: 'light' | 'dark';
 }) {
 
 
@@ -266,7 +286,7 @@ export function DFViewerInfiniteInner({
                 }
                 if (activeCol === field) {
                     //return {background:selectBackground}
-                    return { background: AccentColor }
+                    return { background: themeConfig?.accentColor || AccentColor }
 
                 }
                 return { background: "inherit" }
@@ -301,15 +321,15 @@ export function DFViewerInfiniteInner({
         [outside_df_params],
     );
 
-    const colorScheme = useColorScheme();
-    const myTheme = useMemo(() => getThemeForScheme(colorScheme).withParams({
+    const resolvedScheme = effectiveScheme || 'dark';
+    const myTheme = useMemo(() => getThemeForScheme(resolvedScheme, themeConfig).withParams({
         headerRowBorder: true,
         headerColumnBorder: true,
         headerColumnResizeHandleWidth: 0,
-        ...(colorScheme === 'dark'
-            ? { backgroundColor: "#121212", oddRowBackgroundColor: '#3f3f3f' }
-            : { backgroundColor: "#ffffff", oddRowBackgroundColor: '#f0f0f0' }),
-    }), [colorScheme]);
+        ...(resolvedScheme === 'dark'
+            ? { backgroundColor: themeConfig?.backgroundColor || "#121212", oddRowBackgroundColor: themeConfig?.oddRowBackgroundColor || '#3f3f3f' }
+            : { backgroundColor: themeConfig?.backgroundColor || "#ffffff", oddRowBackgroundColor: themeConfig?.oddRowBackgroundColor || '#f0f0f0' }),
+    }), [resolvedScheme, themeConfig]);
     const gridOptions: GridOptions = useMemo( () => {
         return {
         ...outerGridOptions(setActiveCol, df_viewer_config.extra_grid_config),

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -187,6 +187,26 @@ export type PinnedRowConfig = {
     default_renderer_columns?: string[];
 };
 
+export type ThemeColorConfig = {
+    accentColor?: string;
+    accentHoverColor?: string;
+    backgroundColor?: string;
+    foregroundColor?: string;
+    oddRowBackgroundColor?: string;
+    borderColor?: string;
+    headerBorderColor?: string;
+    headerBackgroundColor?: string;
+    spacing?: number;
+    cellHorizontalPaddingScale?: number;
+    rowVerticalPaddingScale?: number;
+};
+
+export type ThemeConfig = ThemeColorConfig & {
+    colorScheme?: 'light' | 'dark' | 'auto';
+    light?: ThemeColorConfig;
+    dark?: ThemeColorConfig;
+};
+
 export type ComponentConfig = {
     height_fraction?: number;
     // temporary debugging props
@@ -195,6 +215,7 @@ export type ComponentConfig = {
     shortMode?: boolean;
     selectionBackground?: string;
     className?: string;
+    theme?: ThemeConfig;
 };
 
 export interface DFViewerConfig {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -586,6 +586,69 @@ export const myThemeLight: Theme = themeAlpine.withPart(colorSchemeLight).withPa
 /** @deprecated Use getThemeForScheme() instead */
 export const myTheme: Theme = myThemeDark;
 
-export function getThemeForScheme(scheme: 'light' | 'dark'): Theme {
-    return scheme === 'light' ? myThemeLight : myThemeDark;
+export type ThemeColorConfig = {
+    accentColor?: string;
+    accentHoverColor?: string;
+    backgroundColor?: string;
+    foregroundColor?: string;
+    oddRowBackgroundColor?: string;
+    borderColor?: string;
+    headerBorderColor?: string;
+    headerBackgroundColor?: string;
+    spacing?: number;
+    cellHorizontalPaddingScale?: number;
+    rowVerticalPaddingScale?: number;
+};
+
+export type ThemeConfig = ThemeColorConfig & {
+    colorScheme?: 'light' | 'dark' | 'auto';
+    light?: ThemeColorConfig;
+    dark?: ThemeColorConfig;
+};
+
+export function resolveColorScheme(
+    osScheme: 'light' | 'dark',
+    themeConfig?: ThemeConfig
+): 'light' | 'dark' {
+    const override = themeConfig?.colorScheme;
+    if (override && override !== 'auto') {
+        return override;
+    }
+    return osScheme;
+}
+
+/**
+ * Merge scheme-specific color overrides (light/dark sub-dicts) with
+ * top-level color properties.  Returns a flat ThemeConfig suitable for
+ * passing to getThemeForScheme and CSS variable injection.
+ *
+ * Priority: scheme-specific override > top-level color > defaults.
+ */
+export function resolveThemeColors(
+    effectiveScheme: 'light' | 'dark',
+    themeConfig?: ThemeConfig
+): ThemeConfig | undefined {
+    if (!themeConfig) return undefined;
+    const schemeOverrides = effectiveScheme === 'light' ? themeConfig.light : themeConfig.dark;
+    if (!schemeOverrides) return themeConfig;
+    return { ...themeConfig, ...schemeOverrides };
+}
+
+export function getThemeForScheme(scheme: 'light' | 'dark', themeConfig?: ThemeConfig): Theme {
+    const base = scheme === 'light' ? myThemeLight : myThemeDark;
+    if (!themeConfig) return base;
+
+    const overrides: Record<string, any> = {};
+    if (themeConfig.backgroundColor) overrides.backgroundColor = themeConfig.backgroundColor;
+    if (themeConfig.foregroundColor) overrides.foregroundColor = themeConfig.foregroundColor;
+    if (themeConfig.oddRowBackgroundColor) overrides.oddRowBackgroundColor = themeConfig.oddRowBackgroundColor;
+    if (themeConfig.borderColor) overrides.borderColor = themeConfig.borderColor;
+    if (themeConfig.headerBorderColor) overrides.headerColumnBorderColor = themeConfig.headerBorderColor;
+    if (themeConfig.headerBackgroundColor) overrides.headerBackgroundColor = themeConfig.headerBackgroundColor;
+    if (themeConfig.spacing != null) overrides.spacing = themeConfig.spacing;
+    if (themeConfig.cellHorizontalPaddingScale != null) overrides.cellHorizontalPaddingScale = themeConfig.cellHorizontalPaddingScale;
+    if (themeConfig.rowVerticalPaddingScale != null) overrides.rowVerticalPaddingScale = themeConfig.rowVerticalPaddingScale;
+
+    if (Object.keys(overrides).length === 0) return base;
+    return base.withParams(overrides);
 }

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -8,7 +8,8 @@ import { DFMeta } from "./WidgetTypes";
 import { BuckarooOptions } from "./WidgetTypes";
 import { BuckarooState, BKeys } from "./WidgetTypes";
 import { CustomCellEditorProps } from 'ag-grid-react';
-import { getThemeForScheme } from "./DFViewerParts/gridUtils";
+import { getThemeForScheme, resolveColorScheme, resolveThemeColors } from "./DFViewerParts/gridUtils";
+import type { ThemeConfig } from "./DFViewerParts/gridUtils";
 import { Theme } from "ag-grid-community";
 import { useColorScheme } from "./useColorScheme";
 
@@ -200,13 +201,15 @@ export function StatusBar({
     buckarooState,
     setBuckarooState,
     buckarooOptions,
-    heightOverride
+    heightOverride,
+    themeConfig
 }: {
     dfMeta: DFMeta;
     buckarooState: BuckarooState;
     setBuckarooState: React.Dispatch<React.SetStateAction<BuckarooState>>;
     buckarooOptions: BuckarooOptions;
     heightOverride?: number;
+    themeConfig?: ThemeConfig;
 }) {
     if (false) {
 	console.log("heightOverride", heightOverride);
@@ -362,12 +365,14 @@ export function StatusBar({
         cellStyle: { textAlign: "left" },
     };
 
-    const colorScheme = useColorScheme();
-    const statusTheme: Theme = useMemo(()=> getThemeForScheme(colorScheme).withParams({
+    const osColorScheme = useColorScheme();
+    const effectiveScheme = resolveColorScheme(osColorScheme, themeConfig);
+    const resolvedTheme = resolveThemeColors(effectiveScheme, themeConfig);
+    const statusTheme: Theme = useMemo(()=> getThemeForScheme(effectiveScheme, resolvedTheme).withParams({
         headerFontSize: 14,
         rowVerticalPaddingScale: 0.8,
-    }), [colorScheme]);
-    const themeClass = colorScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
+    }), [effectiveScheme, resolvedTheme]);
+    const themeClass = effectiveScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
     return (
         <div className="status-bar">
             <div

--- a/packages/buckaroo-js-core/src/stories/ThemeCustomization.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/ThemeCustomization.stories.tsx
@@ -1,0 +1,128 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
+import { DFViewerConfig, NormalColumnConfig, ThemeConfig } from "../components/DFViewerParts/DFWhole";
+import { SetColumnFunc } from "../components/DFViewerParts/gridUtils";
+import { DatasourceOrRaw } from "../components/DFViewerParts/DFViewerDataHelper";
+
+const DFViewerInfiniteWrap = ({
+    data_wrapper,
+    df_viewer_config,
+}: {
+    data_wrapper: DatasourceOrRaw;
+    df_viewer_config: DFViewerConfig;
+}) => {
+  const defaultSetColumnFunc = (newCol:[string, string]):void => {
+    console.log("defaultSetColumnFunc", newCol)
+  }
+  const sac:SetColumnFunc = defaultSetColumnFunc;
+
+  return (
+     <div style={{height:500, width:800}}>
+      <DFViewerInfinite
+        data_wrapper={data_wrapper}
+        df_viewer_config={df_viewer_config}
+        setActiveCol={sac}
+      />
+     </div>);
+}
+
+const meta = {
+  title: "Buckaroo/Theme/ThemeCustomization",
+  component: DFViewerInfiniteWrap,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {},
+} satisfies Meta<typeof DFViewerInfiniteWrap>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const INDEX_COL_CONFIG: NormalColumnConfig = {
+  col_name: 'index',
+  header_name: 'index',
+  displayer_args: { displayer: 'string' },
+};
+
+const left_col_configs = [INDEX_COL_CONFIG];
+
+const sampleData = [
+  { index: "0", a: 10, b: "foo", c: 100 },
+  { index: "1", a: 20, b: "bar", c: 200 },
+  { index: "2", a: 30, b: "baz", c: 300 },
+  { index: "3", a: 40, b: "qux", c: 400 },
+  { index: "4", a: 50, b: "quux", c: 500 },
+];
+
+const rawData: DatasourceOrRaw = {
+  data_type: "Raw",
+  data: sampleData,
+  length: sampleData.length,
+};
+
+const baseColumnConfig: NormalColumnConfig[] = [
+  { col_name: 'a', header_name: 'a', displayer_args: { displayer: 'integer', min_digits: 1, max_digits: 5 } },
+  { col_name: 'b', header_name: 'b', displayer_args: { displayer: 'obj' } },
+  { col_name: 'c', header_name: 'c', displayer_args: { displayer: 'integer', min_digits: 1, max_digits: 5 } },
+];
+
+function makeConfig(theme?: ThemeConfig): DFViewerConfig {
+  return {
+    column_config: baseColumnConfig,
+    pinned_rows: [],
+    left_col_configs,
+    component_config: theme ? { theme } : undefined,
+  };
+}
+
+export const DefaultNoTheme: Story = {
+  args: {
+    data_wrapper: rawData,
+    df_viewer_config: makeConfig(),
+  },
+};
+
+export const CustomAccent: Story = {
+  args: {
+    data_wrapper: rawData,
+    df_viewer_config: makeConfig({
+      accentColor: '#ff6600',
+    }),
+  },
+};
+
+export const ForcedDark: Story = {
+  args: {
+    data_wrapper: rawData,
+    df_viewer_config: makeConfig({
+      colorScheme: 'dark',
+      backgroundColor: '#1a1a2e',
+    }),
+  },
+};
+
+export const ForcedLight: Story = {
+  args: {
+    data_wrapper: rawData,
+    df_viewer_config: makeConfig({
+      colorScheme: 'light',
+      backgroundColor: '#fafafa',
+    }),
+  },
+};
+
+export const FullCustom: Story = {
+  args: {
+    data_wrapper: rawData,
+    df_viewer_config: makeConfig({
+      colorScheme: 'dark',
+      accentColor: '#e91e63',
+      accentHoverColor: '#c2185b',
+      backgroundColor: '#1a1a2e',
+      foregroundColor: '#e0e0e0',
+      oddRowBackgroundColor: '#16213e',
+      borderColor: '#0f3460',
+    }),
+  },
+};

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -145,7 +145,7 @@
 
 .operation-adder button {
   padding: 1px 2px;
-  background-color: #007bff;
+  background-color: var(--bk-accent-color, #007bff);
   color: white;
   border: none;
   border-radius: 0;
@@ -155,7 +155,7 @@
 }
 
 .operation-adder button:hover {
-  background-color: #0056b3;
+  background-color: var(--bk-accent-hover-color, #0056b3);
 }
 
 .operations-list {
@@ -371,7 +371,7 @@
  }
 
 div.dependent-tabs ul.tabs li.active {
-    background:rgba(33, 150, 243, 0.49);
+    background: var(--bk-accent-color, rgba(33, 150, 243, 0.49));
 /*    border:1px solid red; */
 }
 
@@ -431,11 +431,11 @@ div.dependent-tabs ul.tabs li.active {
 
 /* Ensure empty grid area below rows has proper background */
 .theme-hanger {
-    background-color: #181D1F;
+    background-color: var(--bk-bg-color, #181D1F);
 }
 @media (prefers-color-scheme: light) {
     .theme-hanger {
-        background-color: #ffffff;
+        background-color: var(--bk-bg-color, #ffffff);
     }
 }
 

--- a/scripts/generate_theme_static_html.py
+++ b/scripts/generate_theme_static_html.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+"""Generate static embed HTML pages for the theme customization article.
+
+Produces one HTML file per theme variant in docs/extra-html/themes/,
+demonstrating the full range of buckaroo theming options.
+"""
+
+import sys
+import os
+
+# Ensure the repo root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pandas as pd
+import numpy as np
+
+from buckaroo.artifact import (
+    prepare_buckaroo_artifact,
+    artifact_to_json,
+    _HTML_TEMPLATE,
+)
+
+
+OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "docs", "extra-html", "themes")
+os.makedirs(OUT_DIR, exist_ok=True)
+
+
+def sample_df():
+    """A small but varied DataFrame for theme demos."""
+    np.random.seed(42)
+    return pd.DataFrame(
+        {
+            "city": [
+                "Tokyo",
+                "London",
+                "New York",
+                "Paris",
+                "Sydney",
+                "Berlin",
+                "Toronto",
+                "Mumbai",
+                "Seoul",
+                "Lagos",
+            ],
+            "population_m": [
+                13.96,
+                8.98,
+                8.34,
+                2.16,
+                5.31,
+                3.64,
+                2.93,
+                20.67,
+                9.78,
+                15.39,
+            ],
+            "area_km2": [2194, 1572, 783, 105, 12368, 892, 630, 603, 605, 1171],
+            "founded": [1457, 47, 1624, 250, 1788, 1237, 1793, 1507, 18, 1472],
+            "continent": [
+                "Asia",
+                "Europe",
+                "N. America",
+                "Europe",
+                "Oceania",
+                "Europe",
+                "N. America",
+                "Asia",
+                "Asia",
+                "Africa",
+            ],
+        }
+    )
+
+
+def multiindex_df():
+    """A DataFrame with MultiIndex columns — the kind pivot_table produces."""
+    cols = pd.MultiIndex.from_tuples(
+        [
+            ("Revenue", "Q1"),
+            ("Revenue", "Q2"),
+            ("Revenue", "Q3"),
+            ("Headcount", "Engineering"),
+            ("Headcount", "Sales"),
+            ("Headcount", "Support"),
+        ],
+        names=["Category", "Detail"],
+    )
+    return pd.DataFrame(
+        [
+            [1.2, 1.4, 1.8, 45, 12, 8],
+            [0.9, 1.1, 1.3, 30, 8, 5],
+            [2.1, 2.5, 3.0, 80, 20, 15],
+            [0.5, 0.6, 0.7, 15, 5, 3],
+            [3.4, 3.8, 4.2, 120, 35, 22],
+        ],
+        index=pd.Index(
+            ["ACME Corp", "Widgets Inc", "MegaTech", "StartupCo", "BigData Ltd"]
+        ),
+        columns=cols,
+    )
+
+
+def vc_pricing_df():
+    """The kind of table you see on a VC-backed SaaS pricing page."""
+    return pd.DataFrame(
+        {
+            "Feature": [
+                "Seats",
+                "Storage",
+                "API calls/mo",
+                "SSO",
+                "Audit log",
+                "Support",
+            ],
+            "Starter": ["5", "10 GB", "1,000", "No", "No", "Email"],
+            "Enterprise": [
+                "Unlimited",
+                "Unlimited",
+                "Unlimited",
+                "Yes",
+                "Yes",
+                "Call us for pricing",
+            ],
+        }
+    )
+
+
+def themed_html(df, title, theme_config):
+    """Generate a static embed HTML with a theme applied to the artifact."""
+    artifact = prepare_buckaroo_artifact(df, embed_type="Buckaroo")
+
+    # Inject theme into the top-level df_viewer_config
+    cc = artifact["df_viewer_config"].setdefault("component_config", {})
+    cc["theme"] = theme_config
+
+    # Also inject into each display's df_viewer_config so Buckaroo mode picks it up
+    for display_args in artifact.get("df_display_args", {}).values():
+        dvc = display_args.get("df_viewer_config")
+        if dvc is not None:
+            dvc.setdefault("component_config", {})["theme"] = theme_config
+
+    return _HTML_TEMPLATE.format(
+        title=title,
+        artifact_json=artifact_to_json(artifact),
+    )
+
+
+# Each entry: (filename, title, theme_config, description[, df_override])
+THEME_ENTRIES = [
+    (
+        "default-light",
+        "Default (Light)",
+        {},
+        "No theme overrides — uses the OS-detected light scheme with default colors.",
+    ),
+    (
+        "default-dark",
+        "Default (Dark)",
+        {"colorScheme": "dark"},
+        "Force dark mode with colorScheme. No explicit colors — uses built-in dark defaults.",
+    ),
+    (
+        "accent-color",
+        "Custom Accent Color",
+        {"accentColor": "#ff6600", "accentHoverColor": "#cc5200"},
+        "Override the accent color used for column selection highlights and interactive elements.",
+    ),
+    (
+        "ocean-dark",
+        "Ocean Dark",
+        {
+            "colorScheme": "dark",
+            "accentColor": "#00bcd4",
+            "accentHoverColor": "#0097a7",
+            "backgroundColor": "#0a1628",
+            "foregroundColor": "#b0bec5",
+            "oddRowBackgroundColor": "#0d2137",
+            "borderColor": "#1a3a5c",
+        },
+        "A deep ocean-inspired dark theme with cyan accents.",
+    ),
+    (
+        "warm-light",
+        "Warm Light",
+        {
+            "colorScheme": "light",
+            "accentColor": "#e65100",
+            "accentHoverColor": "#bf360c",
+            "backgroundColor": "#fff8f0",
+            "foregroundColor": "#3e2723",
+            "oddRowBackgroundColor": "#fff3e0",
+            "borderColor": "#ffe0b2",
+        },
+        "A warm, earthy light theme with orange accents.",
+    ),
+    (
+        "neon-dark",
+        "Neon Dark",
+        {
+            "colorScheme": "dark",
+            "accentColor": "#e91e63",
+            "accentHoverColor": "#c2185b",
+            "backgroundColor": "#1a1a2e",
+            "foregroundColor": "#e0e0e0",
+            "oddRowBackgroundColor": "#16213e",
+            "borderColor": "#0f3460",
+        },
+        "A cyberpunk-inspired dark theme with hot pink accents.",
+    ),
+    (
+        "forest-dark",
+        "Forest Dark",
+        {
+            "colorScheme": "dark",
+            "accentColor": "#66bb6a",
+            "accentHoverColor": "#43a047",
+            "backgroundColor": "#1b2a1b",
+            "foregroundColor": "#c8e6c9",
+            "oddRowBackgroundColor": "#223322",
+            "borderColor": "#2e7d32",
+        },
+        "A dark theme with forest green accents — easy on the eyes for long sessions.",
+    ),
+    (
+        "minimal-light",
+        "Minimal Light",
+        {
+            "colorScheme": "light",
+            "accentColor": "#9e9e9e",
+            "accentHoverColor": "#757575",
+            "backgroundColor": "#ffffff",
+            "foregroundColor": "#212121",
+            "oddRowBackgroundColor": "#fafafa",
+            "borderColor": "#e0e0e0",
+        },
+        "A neutral, low-contrast light theme that keeps data front and center.",
+    ),
+    (
+        "high-contrast",
+        "High Contrast",
+        {
+            "colorScheme": "dark",
+            "accentColor": "#ffff00",
+            "accentHoverColor": "#ffd600",
+            "backgroundColor": "#000000",
+            "foregroundColor": "#ffffff",
+            "oddRowBackgroundColor": "#1a1a1a",
+            "borderColor": "#ffffff",
+        },
+        "Maximum contrast for accessibility — bright yellow accents on pure black.",
+    ),
+    (
+        "auto-branded",
+        "Auto Light/Dark (Branded)",
+        {
+            "colorScheme": "auto",
+            "light": {
+                "accentColor": "#e65100",
+                "accentHoverColor": "#bf360c",
+                "backgroundColor": "#fff8f0",
+                "foregroundColor": "#3e2723",
+                "oddRowBackgroundColor": "#fff3e0",
+                "borderColor": "#ffe0b2",
+            },
+            "dark": {
+                "accentColor": "#ffab40",
+                "accentHoverColor": "#ff9100",
+                "backgroundColor": "#1a1209",
+                "foregroundColor": "#ffe0b2",
+                "oddRowBackgroundColor": "#2a1e0f",
+                "borderColor": "#4e342e",
+            },
+        },
+        "Auto light/dark with separate branded palettes for each scheme.",
+    ),
+    (
+        "spacious",
+        "Spacious Layout",
+        {
+            "colorScheme": "dark",
+            "accentColor": "#7c4dff",
+            "accentHoverColor": "#651fff",
+            "spacing": 10,
+            "rowVerticalPaddingScale": 1.2,
+            "cellHorizontalPaddingScale": 0.8,
+            "headerBorderColor": "#7c4dff",
+        },
+        "Increased spacing, padding, and a purple header border for a more airy layout.",
+    ),
+    (
+        "compact",
+        "Compact Layout",
+        {
+            "colorScheme": "light",
+            "spacing": 2,
+            "rowVerticalPaddingScale": 0.2,
+            "cellHorizontalPaddingScale": 0.15,
+            "headerBorderColor": "#bdbdbd",
+        },
+        "Minimal spacing for maximum data density — fits more rows on screen.",
+    ),
+    (
+        "vc-pricing",
+        "VC Pricing Page",
+        {
+            "colorScheme": "light",
+            "accentColor": "#6c5ce7",
+            "accentHoverColor": "#5a4bd1",
+            "backgroundColor": "#ffffff",
+            "foregroundColor": "#2d3436",
+            "oddRowBackgroundColor": "#f8f9ff",
+            "borderColor": "#e8e8f0",
+            "headerBorderColor": "#6c5ce7",
+            "spacing": 16,
+            "rowVerticalPaddingScale": 2.0,
+            "cellHorizontalPaddingScale": 1.5,
+        },
+        'The opposite of trader styling. Maximum whitespace, three columns, last column ends with "Call us for pricing".',
+        "vc",
+    ),
+    (
+        "multiindex-headers",
+        "MultiIndex Headers",
+        {
+            "colorScheme": "dark",
+            "accentColor": "purple",
+            "accentHoverColor": "orange",
+            "backgroundColor": "blue",
+            "foregroundColor": "teal",
+            "oddRowBackgroundColor": "red",
+            "borderColor": "pink",
+            "headerBorderColor": "green",
+            "headerBackgroundColor": "brown",
+        },
+        "Garish colors so you can see exactly which property targets which piece.",
+        "multiindex",
+    ),
+]
+
+
+def generate_embed(filename, title, df, theme_config):
+    """Generate a single themed static embed HTML file."""
+    html = themed_html(df, title, theme_config)
+    path = os.path.join(OUT_DIR, f"{filename}.html")
+    with open(path, "w") as f:
+        f.write(html)
+    print(f"  Generated {path}")
+
+
+def copy_static_assets():
+    """Copy static-embed.js and static-embed.css into the output directory."""
+    import shutil
+
+    static_dir = os.path.join(os.path.dirname(__file__), "..", "buckaroo", "static")
+    for fname in ("static-embed.js", "static-embed.css"):
+        src = os.path.join(static_dir, fname)
+        dst = os.path.join(OUT_DIR, fname)
+        if os.path.exists(src):
+            shutil.copy2(src, dst)
+            print(f"  Copied {fname}")
+        else:
+            print(f"  WARNING: {src} not found — run full_build.sh first")
+
+
+DF_OVERRIDES = {
+    "vc": vc_pricing_df,
+    "multiindex": multiindex_df,
+}
+
+
+if __name__ == "__main__":
+    print("Generating theme customization static embeds...")
+    copy_static_assets()
+    df = sample_df()
+    for entry in THEME_ENTRIES:
+        filename, title, theme_config, description = entry[:4]
+        df_key = entry[4] if len(entry) > 4 else None
+        entry_df = DF_OVERRIDES[df_key]() if df_key else df
+        generate_embed(filename, title, entry_df, theme_config)
+    print(f"\nDone. Files in {OUT_DIR}")

--- a/tests/unit/test_theme_config.py
+++ b/tests/unit/test_theme_config.py
@@ -1,0 +1,44 @@
+import pandas as pd
+from buckaroo.buckaroo_widget import BuckarooWidget
+
+
+simple_df = pd.DataFrame({"int_col": [1, 2, 3], "str_col": ["a", "b", "c"]})
+
+
+def test_theme_flows_through_widget():
+    theme = {"colorScheme": "dark", "accentColor": "#ff6600"}
+    w = BuckarooWidget(simple_df, component_config={"theme": theme})
+    cc = w.df_display_args["main"]["df_viewer_config"].get("component_config", {})
+    assert cc["theme"] == theme
+
+
+def test_theme_absent_by_default():
+    w = BuckarooWidget(simple_df)
+    cc = w.df_display_args["main"]["df_viewer_config"].get("component_config", {})
+    assert "theme" not in cc or cc.get("theme") is None
+
+
+def test_full_theme_config_roundtrips():
+    theme = {
+        "colorScheme": "dark",
+        "accentColor": "#e91e63",
+        "accentHoverColor": "#c2185b",
+        "backgroundColor": "#1a1a2e",
+        "foregroundColor": "#e0e0e0",
+        "oddRowBackgroundColor": "#16213e",
+        "borderColor": "#0f3460",
+    }
+    w = BuckarooWidget(simple_df, component_config={"theme": theme})
+    cc = w.df_display_args["main"]["df_viewer_config"].get("component_config", {})
+    assert cc["theme"] == theme
+
+
+def test_theme_with_other_component_config():
+    """Theme coexists with other component_config properties."""
+    theme = {"accentColor": "#ff6600"}
+    w = BuckarooWidget(
+        simple_df, component_config={"theme": theme, "className": "my-class"}
+    )
+    cc = w.df_display_args["main"]["df_viewer_config"].get("component_config", {})
+    assert cc["theme"] == theme
+    assert cc["className"] == "my-class"


### PR DESCRIPTION
## Summary

- Add `ThemeConfig` type (7 optional color/scheme properties) nested inside `ComponentConfig` — rides the existing pipeline with no new traitlets or sync wiring
- `resolveColorScheme()` is the single source of truth for light/dark resolution — respects `colorScheme` override or falls back to OS detection
- `className` is now **additive** to the auto-detected AG Grid theme class (no longer replaces it)
- CSS custom properties (`--bk-accent-color`, `--bk-accent-hover-color`, `--bk-bg-color`) scoped per-instance via inline style on the wrapper div
- Server `/load` endpoint accepts optional `component_config` and merges it into `df_display_args`

## Usage

```python
import buckaroo
w = buckaroo.BuckarooWidget(df, component_config={
    'theme': {
        'colorScheme': 'dark',
        'accentColor': '#ff6600',
        'accentHoverColor': '#cc5200',
        'backgroundColor': '#1a1a2e',
    }
})
```

## Test plan

- [x] `uv run pytest tests/unit/test_theme_config.py -v` — 4 Python config flow tests pass
- [x] `uv run pytest tests/unit/ -v` — 574 existing tests pass, 0 regressions
- [x] `uv run pytest tests/unit/server/ -v` — 13 server tests pass
- [x] TS compiles clean (`tsc --noEmit` — only pre-existing FloatingTooltip errors)
- [ ] `npx playwright test theme-custom` — Storybook visual assertions
- [ ] `npx playwright test theme-custom-server` — Server integration assertions
- [ ] Manual: load themed stories in Storybook, verify colors

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)