### PR TITLE
Fix left-pinned index column for summary stats

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -265,14 +265,13 @@ export function dfToAgrid(
     pinned:'left'}
   }
   const lcc3 = lcc2.map(addPinned)
-  console.log("lcc3", lcc3);
 
   const columnConfigs: ColumnConfig[] =  dfviewer_config.column_config;
   const groupedColumnConfigs = getSubChildren(columnConfigs, 0);
   const flattenedColumnConfigs = groupedColumnConfigs.map(switchToColDef)
 
   const retMultiColumns:(ColDef|ColGroupDef)[] = [
-    ...lcc2,
+    ...lcc3,
     ...flattenedColumnConfigs]
   return retMultiColumns
 }


### PR DESCRIPTION
## Summary
- Fixed bug where `left_col_configs` columns weren't actually pinned left — return statement used `lcc2` instead of `lcc3` (which has `pinned: 'left'` applied)
- Removed leftover `console.log("lcc3", lcc3)` debug statement
- The index/stat label column now stays visible when scrolling horizontally through wide DataFrames

Supersedes #541 (rebased cleanly on current main).

## Test plan
- [x] All 80 jest tests pass
- [ ] Verify in Storybook stories with `left_col_configs` that the index column stays pinned left on horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)