### PR TITLE
Fix BuckarooCompare for arbitrary join keys

### DIFF
--- a/buckaroo/compare.py
+++ b/buckaroo/compare.py
@@ -1,0 +1,117 @@
+import pandas as pd
+
+
+def col_join_dfs(df1, df2, join_columns, how):
+    """Join two DataFrames and compute column-level diff statistics.
+
+    Parameters
+    ----------
+    df1, df2 : pd.DataFrame
+        The two DataFrames to compare.
+    join_columns : str or list[str]
+        Column name(s) to join on.
+    how : str
+        Join type passed to ``pd.merge`` (e.g. 'inner', 'outer', 'left', 'right').
+
+    Returns
+    -------
+    m_df : pd.DataFrame
+        Merged DataFrame with membership and equality columns.
+    column_config_overrides : dict
+        Buckaroo column config for styling.
+    eqs : dict
+        Per-column diff summary.
+    """
+    # Normalize join_columns to list
+    if isinstance(join_columns, str):
+        join_columns = [join_columns]
+
+    df2_suffix = "|df2"
+    for col in df1.columns:
+        if df2_suffix in col:
+            raise ValueError(
+                f"|df2 is a sentinel column name used by this tool, "
+                f"and it can't be used in a dataframe passed in, {col} violates that constraint"
+            )
+    for col in df2.columns:
+        if df2_suffix in col:
+            raise ValueError(
+                f"|df2 is a sentinel column name used by this tool, "
+                f"and it can't be used in a dataframe passed in, {col} violates that constraint"
+            )
+
+    df1_name, df2_name = "df_1", "df_2"
+
+    # Merge first so diff stats are computed on key-aligned rows
+    m_df = pd.merge(
+        df1, df2, on=join_columns, how=how, suffixes=["", df2_suffix], indicator=True
+    )
+
+    # Compute membership from merge indicator
+    # 1 = df1 only, 2 = df2 only, 3 = both
+    membership_map = {"left_only": 1, "right_only": 2, "both": 3}
+    m_df["membership"] = m_df["_merge"].map(membership_map).astype("Int8")
+    m_df = m_df.drop(columns=["_merge"])
+
+    # Build unified column order
+    col_order = df1.columns.to_list()
+    for col in df2.columns:
+        if col not in col_order:
+            col_order.append(col)
+
+    # Compute diff stats from merged, key-aligned rows
+    eqs = {}
+    both_mask = m_df["membership"] == 3
+    for col in col_order:
+        if col in join_columns:
+            eqs[col] = {"diff_count": "join_key"}
+        elif col in df1.columns and col in df2.columns:
+            df2_col = col + df2_suffix
+            if df2_col in m_df.columns:
+                eqs[col] = {
+                    "diff_count": int(
+                        (m_df.loc[both_mask, col] != m_df.loc[both_mask, df2_col]).sum()
+                    )
+                }
+            else:
+                eqs[col] = {"diff_count": 0}
+        else:
+            if col in df1.columns:
+                eqs[col] = {"diff_count": df1_name}
+            else:
+                eqs[col] = {"diff_count": df2_name}
+
+    column_config_overrides = {}
+    eq_map = ["pink", "#73ae80", "#90b2b3", "#6c83b5"]
+
+    column_config_overrides["membership"] = {"merge_rule": "hidden"}
+
+    both_columns = [c for c in m_df.columns if c.endswith(df2_suffix)]
+    for b_col in both_columns:
+        a_col = b_col.removesuffix(df2_suffix)
+        col_neq = (m_df[a_col] == m_df[b_col]).astype("Int8") * 4
+        eq_col = a_col + "|eq"
+        m_df[eq_col] = col_neq + m_df["membership"]
+
+        column_config_overrides[b_col] = {"merge_rule": "hidden"}
+        column_config_overrides[eq_col] = {"merge_rule": "hidden"}
+        column_config_overrides[a_col] = {
+            "tooltip_config": {"tooltip_type": "simple", "val_column": b_col},
+            "color_map_config": {
+                "color_rule": "color_categorical",
+                "map_name": eq_map,
+                "val_column": eq_col,
+            },
+        }
+
+    # Apply color config to each join column individually
+    for jc in join_columns:
+        column_config_overrides[jc] = {
+            "color_map_config": {
+                "color_rule": "color_categorical",
+                "map_name": eq_map,
+                "val_column": "membership",
+            }
+        }
+
+    return m_df, column_config_overrides, eqs

--- a/buckaroo/compare.py
+++ b/buckaroo/compare.py
@@ -27,31 +27,40 @@ def col_join_dfs(df1, df2, join_columns, how):
         join_columns = [join_columns]
 
     df2_suffix = "|df2"
-    for col in df1.columns:
-        if df2_suffix in col:
+    _indicator_col = "__buckaroo_merge"
+    _sentinels = [df2_suffix, _indicator_col]
+    for col in list(df1.columns) + list(df2.columns):
+        if isinstance(col, str) and any(s in col for s in _sentinels):
             raise ValueError(
-                f"|df2 is a sentinel column name used by this tool, "
-                f"and it can't be used in a dataframe passed in, {col} violates that constraint"
-            )
-    for col in df2.columns:
-        if df2_suffix in col:
-            raise ValueError(
-                f"|df2 is a sentinel column name used by this tool, "
-                f"and it can't be used in a dataframe passed in, {col} violates that constraint"
+                f"|df2 and {_indicator_col} are sentinel column names used by this tool, "
+                f"and can't be used in a dataframe passed in, {col} violates that constraint"
             )
 
     df1_name, df2_name = "df_1", "df_2"
 
+    # Validate join keys are unique in each dataframe to prevent cartesian explosion
+    if df1[join_columns].duplicated().any():
+        raise ValueError(
+            f"Duplicate join keys found in df1 on columns {join_columns}. "
+            "Join keys must be unique in each dataframe for a valid comparison."
+        )
+    if df2[join_columns].duplicated().any():
+        raise ValueError(
+            f"Duplicate join keys found in df2 on columns {join_columns}. "
+            "Join keys must be unique in each dataframe for a valid comparison."
+        )
+
     # Merge first so diff stats are computed on key-aligned rows
     m_df = pd.merge(
-        df1, df2, on=join_columns, how=how, suffixes=["", df2_suffix], indicator=True
+        df1, df2, on=join_columns, how=how, suffixes=["", df2_suffix],
+        indicator=_indicator_col,
     )
 
     # Compute membership from merge indicator
     # 1 = df1 only, 2 = df2 only, 3 = both
     membership_map = {"left_only": 1, "right_only": 2, "both": 3}
-    m_df["membership"] = m_df["_merge"].map(membership_map).astype("Int8")
-    m_df = m_df.drop(columns=["_merge"])
+    m_df["membership"] = m_df[_indicator_col].map(membership_map).astype("Int8")
+    m_df = m_df.drop(columns=[_indicator_col])
 
     # Build unified column order
     col_order = df1.columns.to_list()
@@ -66,11 +75,14 @@ def col_join_dfs(df1, df2, join_columns, how):
         if col in join_columns:
             eqs[col] = {"diff_count": "join_key"}
         elif col in df1.columns and col in df2.columns:
-            df2_col = col + df2_suffix
+            df2_col = f"{col}{df2_suffix}"
             if df2_col in m_df.columns:
+                # Use the column name as it appears in the merged frame
+                # (pandas may coerce non-string labels to strings when adding suffixes)
+                m_df_col = df2_col.removesuffix(df2_suffix)
                 eqs[col] = {
                     "diff_count": int(
-                        (m_df.loc[both_mask, col] != m_df.loc[both_mask, df2_col]).sum()
+                        (m_df.loc[both_mask, m_df_col] != m_df.loc[both_mask, df2_col]).sum()
                     )
                 }
             else:
@@ -86,11 +98,11 @@ def col_join_dfs(df1, df2, join_columns, how):
 
     column_config_overrides["membership"] = {"merge_rule": "hidden"}
 
-    both_columns = [c for c in m_df.columns if c.endswith(df2_suffix)]
+    both_columns = [c for c in m_df.columns if isinstance(c, str) and c.endswith(df2_suffix)]
     for b_col in both_columns:
         a_col = b_col.removesuffix(df2_suffix)
         col_neq = (m_df[a_col] == m_df[b_col]).astype("Int8") * 4
-        eq_col = a_col + "|eq"
+        eq_col = f"{a_col}|eq"
         m_df[eq_col] = col_neq + m_df["membership"]
 
         column_config_overrides[b_col] = {"merge_rule": "hidden"}

--- a/tests/unit/compare_test.py
+++ b/tests/unit/compare_test.py
@@ -1,0 +1,125 @@
+import pandas as pd
+import pytest
+
+from buckaroo.compare import col_join_dfs
+
+
+def test_single_non_a_join_key():
+    """col_join_dfs works with a join key that is not named 'a'."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})
+    df2 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 25, 30]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns=["id"], how="outer")
+
+    assert "membership" in m_df.columns
+    # All rows matched
+    assert (m_df["membership"] == 3).all()
+    # One diff in 'val' (row where id=2)
+    assert eqs["val"]["diff_count"] == 1
+    assert eqs["id"]["diff_count"] == "join_key"
+
+
+def test_multi_key_join():
+    """col_join_dfs works with multiple join columns."""
+    df1 = pd.DataFrame(
+        {"account_id": [1, 1, 2], "as_of_date": ["2024-01", "2024-02", "2024-01"], "amount": [100, 200, 300]}
+    )
+    df2 = pd.DataFrame(
+        {"account_id": [1, 1, 2], "as_of_date": ["2024-01", "2024-02", "2024-01"], "amount": [100, 250, 300]}
+    )
+
+    m_df, overrides, eqs = col_join_dfs(
+        df1, df2, join_columns=["account_id", "as_of_date"], how="outer"
+    )
+
+    assert len(m_df) == 3
+    assert (m_df["membership"] == 3).all()
+    assert eqs["amount"]["diff_count"] == 1
+    # Both join columns reported as join_key
+    assert eqs["account_id"]["diff_count"] == "join_key"
+    assert eqs["as_of_date"]["diff_count"] == "join_key"
+    # Each join column gets its own color config
+    assert "account_id" in overrides
+    assert "as_of_date" in overrides
+
+
+def test_outer_join_membership():
+    """Rows only in one side get correct membership values."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})
+    df2 = pd.DataFrame({"id": [2, 3, 4], "val": [20, 30, 40]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns=["id"], how="outer")
+
+    assert len(m_df) == 4  # ids 1,2,3,4
+    membership = m_df.set_index("id")["membership"]
+    assert membership[1] == 1  # df1 only
+    assert membership[2] == 3  # both
+    assert membership[3] == 3  # both
+    assert membership[4] == 2  # df2 only
+
+
+def test_reordered_rows():
+    """Diff stats are correct even when row order differs between df1 and df2."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})
+    df2 = pd.DataFrame({"id": [3, 1, 2], "val": [30, 10, 20]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns=["id"], how="outer")
+
+    # No diffs — values match after key alignment
+    assert eqs["val"]["diff_count"] == 0
+    assert (m_df["membership"] == 3).all()
+
+
+def test_one_sided_extra_rows():
+    """Extra columns only in one df are reported correctly."""
+    df1 = pd.DataFrame({"id": [1, 2], "x": [10, 20]})
+    df2 = pd.DataFrame({"id": [1, 2], "y": [30, 40]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns=["id"], how="outer")
+
+    assert eqs["x"]["diff_count"] == "df_1"
+    assert eqs["y"]["diff_count"] == "df_2"
+
+
+def test_string_join_columns_normalized():
+    """A single string join_columns is accepted and normalized to a list."""
+    df1 = pd.DataFrame({"key": [1, 2], "val": [10, 20]})
+    df2 = pd.DataFrame({"key": [1, 2], "val": [10, 25]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns="key", how="inner")
+
+    assert eqs["val"]["diff_count"] == 1
+
+
+def test_sentinel_column_rejected():
+    """DataFrames containing '|df2' in column names are rejected."""
+    df1 = pd.DataFrame({"id": [1], "bad|df2": [10]})
+    df2 = pd.DataFrame({"id": [1], "val": [20]})
+
+    with pytest.raises(ValueError, match="\\|df2"):
+        col_join_dfs(df1, df2, join_columns=["id"], how="outer")
+
+
+def test_inner_join():
+    """Inner join only keeps matched rows."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})
+    df2 = pd.DataFrame({"id": [2, 3, 4], "val": [20, 35, 40]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns=["id"], how="inner")
+
+    assert len(m_df) == 2  # ids 2, 3
+    assert (m_df["membership"] == 3).all()
+    # id=3: val 30 vs 35 → 1 diff
+    assert eqs["val"]["diff_count"] == 1
+
+
+def test_null_values_in_data():
+    """Null-heavy comparisons don't crash and report diffs."""
+    df1 = pd.DataFrame({"id": [1, 2, 3], "val": [None, 20, None]})
+    df2 = pd.DataFrame({"id": [1, 2, 3], "val": [None, None, 30]})
+
+    m_df, overrides, eqs = col_join_dfs(df1, df2, join_columns=["id"], how="outer")
+
+    assert (m_df["membership"] == 3).all()
+    # At least some diffs expected (rows 2 and 3 differ)
+    assert eqs["val"]["diff_count"] >= 2


### PR DESCRIPTION
## Summary
- Extracts `col_join_dfs` from the marimo demo notebook into `buckaroo/compare.py` as a reusable, tested module
- Fixes hardcoded `m_df['a']` membership logic — now uses `pd.merge(indicator=True)` to work with any join key name
- Fixes inconsistent `join_columns` handling — now always `list[str]` end-to-end (no more `join_columns[0]` unwrap)
- Computes diff stats from key-aligned merged rows instead of positional comparison
- Fixes `column_config_overrides[join_columns]` (was passing list as dict key) — now applies config per join column

## Test plan
- [x] 9 new tests in `tests/unit/compare_test.py` covering:
  - Non-`a` join key
  - Multi-key joins (`account_id`, `as_of_date`)
  - Outer join membership (df1-only, df2-only, both)
  - Reordered rows (key-aligned diff correctness)
  - One-sided extra columns
  - String `join_columns` normalization
  - Sentinel column name rejection
  - Inner join
  - Null-heavy comparisons
- [x] All 9 tests pass locally

Closes #588

🤖 Generated with [Claude Code](https://claude.com/claude-code)