### PR TITLE
fix: Playwright row count off-by-one with pinned columns

### DIFF
--- a/packages/buckaroo-js-core/pw-tests/ag-pw-utils.ts
+++ b/packages/buckaroo-js-core/pw-tests/ag-pw-utils.ts
@@ -18,7 +18,7 @@ export type ColumnLocatorOptions = {
  */
 export async function getRowCount(page: Page) {
     // We have to subtract the number of header rows from the total aria-rowcount to get the actual row count
-    const headers = await page.locator('.ag-header .ag-header-row').and(page.getByRole('row')).all();
+    const headers = await page.locator('.ag-header-viewport .ag-header-row').and(page.getByRole('row')).all();
     const gridLocator = page.getByRole('treegrid').or(page.getByRole('grid'));
     const totalAriaRowCount = await gridLocator.first().getAttribute('aria-rowcount');
     return Number(totalAriaRowCount) - Number(headers.length);

--- a/packages/buckaroo-js-core/pw-tests/marimo.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/marimo.spec.ts
@@ -36,7 +36,7 @@ async function getRowCount(container: import('@playwright/test').Locator): Promi
   const grid = dfViewer.getByRole('treegrid').or(dfViewer.getByRole('grid'));
   const total = await grid.first().getAttribute('aria-rowcount');
   const headers = await dfViewer
-    .locator('.ag-header .ag-header-row')
+    .locator('.ag-header-viewport .ag-header-row')
     .all();
   return Number(total) - headers.length;
 }

--- a/packages/buckaroo-js-core/pw-tests/server-helpers.ts
+++ b/packages/buckaroo-js-core/pw-tests/server-helpers.ts
@@ -34,7 +34,7 @@ export async function waitForGrid(page: Page) {
  */
 export async function getRowCount(page: Page): Promise<number> {
   const headers = await page
-    .locator('.ag-header .ag-header-row')
+    .locator('.ag-header-viewport .ag-header-row')
     .and(page.getByRole('row'))
     .all();
   const grid = page.getByRole('treegrid').or(page.getByRole('grid'));


### PR DESCRIPTION
## Summary

- PR #587 pinned the index column (`pinned: 'left'`), which makes ag-grid create a separate `.ag-pinned-left-header` section with its own `.ag-header-row` elements
- The `getRowCount` helpers in all three Playwright test utils were using `.ag-header .ag-header-row` to count header rows and subtract from `aria-rowcount`
- With pinning, that selector matches headers from **both** the pinned and center sections, double-counting and returning `count - 1`
- Fix: scope to `.ag-header-viewport .ag-header-row` (center headers only)

Files changed:
- `pw-tests/server-helpers.ts`
- `pw-tests/ag-pw-utils.ts`
- `pw-tests/marimo.spec.ts`

## Test plan
- [ ] Server Playwright Tests pass
- [ ] Marimo Playwright Tests pass
- [ ] All other existing CI checks remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)