### PR TITLE
feat: add /load_compare endpoint for col_join_dfs diff styling

### DIFF
--- a/buckaroo/server/app.py
+++ b/buckaroo/server/app.py
@@ -3,7 +3,7 @@ import time
 
 import tornado.web
 
-from buckaroo.server.handlers import HealthHandler, DiagnosticsHandler, LoadHandler, SessionPageHandler
+from buckaroo.server.handlers import HealthHandler, DiagnosticsHandler, LoadHandler, LoadCompareHandler, SessionPageHandler
 from buckaroo.server.websocket_handler import DataStreamHandler
 from buckaroo.server.session import SessionManager
 
@@ -21,6 +21,7 @@ def make_app(sessions: SessionManager | None = None, port: int = 8888, open_brow
             (r"/health", HealthHandler),
             (r"/diagnostics", DiagnosticsHandler),
             (r"/load", LoadHandler),
+            (r"/load_compare", LoadCompareHandler),
             (r"/s/([^/]+)", SessionPageHandler),
             (r"/ws/([^/]+)", DataStreamHandler),
         ],

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -12,7 +12,6 @@ from buckaroo.server.data_loading import (
     load_file, get_metadata, get_display_state,
     create_dataflow, get_buckaroo_display_state,
     load_file_lazy, get_metadata_lazy, get_display_state_lazy,
-    get_df_viewer_config,
 )
 from buckaroo.compare import col_join_dfs
 from buckaroo.df_util import old_col_new_col

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -12,7 +12,10 @@ from buckaroo.server.data_loading import (
     load_file, get_metadata, get_display_state,
     create_dataflow, get_buckaroo_display_state,
     load_file_lazy, get_metadata_lazy, get_display_state_lazy,
+    get_df_viewer_config,
 )
+from buckaroo.compare import col_join_dfs
+from buckaroo.df_util import old_col_new_col
 from buckaroo.server.focus import find_or_create_session_window
 from buckaroo.server.session import build_state_message
 
@@ -283,6 +286,160 @@ class LoadHandler(tornado.web.RequestHandler):
             "server_pid": os.getpid(),
             "browser_action": browser_action,
             **metadata,
+        })
+
+
+class LoadCompareHandler(tornado.web.RequestHandler):
+    """POST /load_compare — load two files, diff them via col_join_dfs, and
+    serve the merged result with diff styling applied."""
+
+    def _parse_request_body(self) -> dict:
+        try:
+            body = json.loads(self.request.body)
+        except (json.JSONDecodeError, TypeError):
+            self.set_status(400)
+            self.write({"error": "Invalid JSON body"})
+            return None
+        if not isinstance(body, dict):
+            self.set_status(400)
+            self.write({"error": "Invalid JSON body"})
+            return None
+        return body
+
+    def _validate_request(self, body: dict):
+        """Return (session_id, path1, path2, join_columns, how, no_browser)
+        or all-Nones on error."""
+        session_id = body.get("session")
+        path1 = body.get("path1")
+        path2 = body.get("path2")
+        join_columns = body.get("join_columns")
+
+        if not session_id or not path1 or not path2 or not join_columns:
+            self.set_status(400)
+            self.write({"error": "Missing required field(s): session, path1, path2, join_columns"})
+            return None, None, None, None, None, None
+
+        how = body.get("how", "outer")
+        no_browser = bool(body.get("no_browser", False))
+        return session_id, path1, path2, join_columns, how, no_browser
+
+    def _load_file(self, path: str):
+        """Load a single file, writing error response on failure.
+        Returns DataFrame or None."""
+        try:
+            return load_file(path)
+        except FileNotFoundError:
+            self.set_status(404)
+            self.write({"error_code": "file_not_found", "message": f"File not found: {path}"})
+            return None
+        except ValueError as e:
+            self.set_status(400)
+            self.write({"error_code": "invalid_file", "message": str(e)})
+            return None
+        except Exception:
+            tb = traceback.format_exc()
+            log.error("load error path=%s: %s", path, tb)
+            resp: dict = {"error_code": "load_error", "message": f"Failed to load file: {path}"}
+            if _BUCKAROO_DEBUG:
+                resp["details"] = tb
+            self.set_status(500)
+            self.write(resp)
+            return None
+
+    async def post(self):
+        body = self._parse_request_body()
+        if body is None:
+            return
+
+        session_id, path1, path2, join_columns, how, no_browser = self._validate_request(body)
+        if session_id is None:
+            return
+
+        df1 = self._load_file(path1)
+        if df1 is None:
+            return
+        df2 = self._load_file(path2)
+        if df2 is None:
+            return
+
+        try:
+            merged_df, column_config_overrides, eqs = col_join_dfs(df1, df2, join_columns, how)
+        except ValueError as e:
+            self.set_status(400)
+            self.write({"error_code": "compare_error", "message": str(e)})
+            return
+        except Exception:
+            tb = traceback.format_exc()
+            log.error("compare error: %s", tb)
+            resp: dict = {"error_code": "compare_error", "message": "Failed to compare files"}
+            if _BUCKAROO_DEBUG:
+                resp["details"] = tb
+            self.set_status(500)
+            self.write(resp)
+            return
+
+        # Build display state from merged DataFrame
+        display_state = get_display_state(merged_df, path1)
+
+        # Apply column_config_overrides with name translation
+        orig_to_renamed = dict(old_col_new_col(merged_df))
+        column_config = display_state["df_display_args"]["main"]["df_viewer_config"]["column_config"]
+
+        for cc_entry in column_config:
+            orig_name = cc_entry["header_name"]
+            override = column_config_overrides.get(orig_name)
+            if override is None:
+                continue
+            for key, value in override.items():
+                if key == "merge_rule":
+                    cc_entry["merge_rule"] = value
+                elif key in ("tooltip_config", "color_map_config"):
+                    translated = dict(value)
+                    if "val_column" in translated:
+                        translated["val_column"] = orig_to_renamed.get(
+                            translated["val_column"], translated["val_column"]
+                        )
+                    cc_entry[key] = translated
+                else:
+                    cc_entry[key] = value
+
+        # Store session state
+        sessions = self.application.settings["sessions"]
+        session = sessions.get_or_create(session_id, path1)
+        session.df = merged_df
+        session.metadata = {"path": path1, "path2": path2, "rows": len(merged_df),
+                            "columns": [{"name": str(c), "dtype": str(merged_df[c].dtype)} for c in merged_df.columns]}
+        session.df_display_args = display_state["df_display_args"]
+        session.df_data_dict = display_state["df_data_dict"]
+        session.df_meta = display_state["df_meta"]
+        session.mode = "viewer"
+
+        # Push to WebSocket clients
+        if session.ws_clients:
+            push_msg = json.dumps(build_state_message(session))
+            for client in list(session.ws_clients):
+                try:
+                    client.write_message(push_msg)
+                except Exception:
+                    session.ws_clients.discard(client)
+
+        # Browser window
+        if no_browser or not self.application.settings.get("open_browser", True):
+            browser_action = "skipped"
+        else:
+            port = self.application.settings.get("port", 8888)
+            browser_action = find_or_create_session_window(session_id, port, reload_if_found=True)
+
+        log.info("load_compare session=%s path1=%s path2=%s rows=%d",
+                 session_id, path1, path2, len(merged_df))
+
+        self.write({
+            "session": session_id,
+            "server_pid": os.getpid(),
+            "browser_action": browser_action,
+            "rows": len(merged_df),
+            "columns": [str(c) for c in merged_df.columns],
+            "eqs": eqs,
         })
 
 

--- a/tests/unit/server/test_load_compare.py
+++ b/tests/unit/server/test_load_compare.py
@@ -1,0 +1,229 @@
+import json
+import os
+import sys
+import tempfile
+
+import pandas as pd
+import pytest
+import tornado.testing
+
+from buckaroo.server.app import make_app as _make_app
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Temp file locking prevents cleanup on Windows",
+)
+
+
+def make_app():
+    return _make_app(open_browser=False)
+
+
+def _write_df(df, path):
+    ext = os.path.splitext(path)[1]
+    if ext == ".csv":
+        df.to_csv(path, index=False)
+    elif ext == ".parquet":
+        df.to_parquet(path, index=False)
+    else:
+        raise ValueError(f"Unsupported: {ext}")
+
+
+class TestLoadCompare(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_app()
+
+    def _post_compare(self, body):
+        return self.fetch(
+            "/load_compare",
+            method="POST",
+            body=json.dumps(body),
+            headers={"Content-Type": "application/json"},
+        )
+
+    def test_basic_compare(self):
+        df1 = pd.DataFrame({"id": [1, 2, 3], "name": ["a", "b", "c"], "val": [10, 20, 30]})
+        df2 = pd.DataFrame({"id": [1, 2, 4], "name": ["a", "B", "d"], "val": [10, 99, 40]})
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f1, \
+             tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f2:
+            _write_df(df1, f1.name)
+            _write_df(df2, f2.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-1",
+                    "path1": f1.name,
+                    "path2": f2.name,
+                    "join_columns": ["id"],
+                })
+                self.assertEqual(resp.code, 200)
+                body = json.loads(resp.body)
+                self.assertEqual(body["session"], "cmp-1")
+                self.assertIn("eqs", body)
+                self.assertIn("rows", body)
+                self.assertIn("columns", body)
+                # Outer join: 1,2,3,4 → 4 rows
+                self.assertEqual(body["rows"], 4)
+                # eqs should have entries for each column
+                self.assertIn("id", body["eqs"])
+                self.assertEqual(body["eqs"]["id"]["diff_count"], "join_key")
+            finally:
+                os.unlink(f1.name)
+                os.unlink(f2.name)
+
+    def test_column_config_overrides_applied(self):
+        """Verify that diff styling (hidden cols, color_map, tooltip) is in the session."""
+        df1 = pd.DataFrame({"id": [1, 2], "score": [100, 200]})
+        df2 = pd.DataFrame({"id": [1, 2], "score": [100, 999]})
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f1, \
+             tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f2:
+            _write_df(df1, f1.name)
+            _write_df(df2, f2.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-style",
+                    "path1": f1.name,
+                    "path2": f2.name,
+                    "join_columns": ["id"],
+                })
+                self.assertEqual(resp.code, 200)
+
+                sessions = self._app.settings["sessions"]
+                session = sessions.get("cmp-style")
+                self.assertIsNotNone(session)
+
+                cc = session.df_display_args["main"]["df_viewer_config"]["column_config"]
+                cc_by_header = {e["header_name"]: e for e in cc}
+
+                # "score" should have color_map_config and tooltip_config
+                score_entry = cc_by_header["score"]
+                self.assertIn("color_map_config", score_entry)
+                self.assertIn("tooltip_config", score_entry)
+                # val_column should be translated to renamed column name
+                self.assertNotEqual(score_entry["color_map_config"]["val_column"], "score|eq")
+
+                # Hidden columns should have merge_rule=hidden
+                self.assertEqual(cc_by_header["score|df2"]["merge_rule"], "hidden")
+                self.assertEqual(cc_by_header["score|eq"]["merge_rule"], "hidden")
+                self.assertEqual(cc_by_header["membership"]["merge_rule"], "hidden")
+            finally:
+                os.unlink(f1.name)
+                os.unlink(f2.name)
+
+    def test_eqs_reports_diffs(self):
+        df1 = pd.DataFrame({"k": [1, 2], "v": [10, 20]})
+        df2 = pd.DataFrame({"k": [1, 2], "v": [10, 99]})
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f1, \
+             tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f2:
+            _write_df(df1, f1.name)
+            _write_df(df2, f2.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-eqs",
+                    "path1": f1.name,
+                    "path2": f2.name,
+                    "join_columns": ["k"],
+                })
+                self.assertEqual(resp.code, 200)
+                body = json.loads(resp.body)
+                self.assertEqual(body["eqs"]["v"]["diff_count"], 1)
+            finally:
+                os.unlink(f1.name)
+                os.unlink(f2.name)
+
+    def test_missing_fields(self):
+        resp = self._post_compare({"session": "x", "path1": "/a"})
+        self.assertEqual(resp.code, 400)
+
+    def test_missing_file(self):
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f1:
+            _write_df(pd.DataFrame({"id": [1]}), f1.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-miss",
+                    "path1": f1.name,
+                    "path2": "/nonexistent.csv",
+                    "join_columns": ["id"],
+                })
+                self.assertEqual(resp.code, 404)
+            finally:
+                os.unlink(f1.name)
+
+    def test_bad_json(self):
+        resp = self.fetch(
+            "/load_compare",
+            method="POST",
+            body="not json",
+            headers={"Content-Type": "application/json"},
+        )
+        self.assertEqual(resp.code, 400)
+
+    def test_duplicate_join_keys(self):
+        df1 = pd.DataFrame({"id": [1, 1], "v": [10, 20]})
+        df2 = pd.DataFrame({"id": [1, 2], "v": [10, 30]})
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f1, \
+             tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f2:
+            _write_df(df1, f1.name)
+            _write_df(df2, f2.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-dup",
+                    "path1": f1.name,
+                    "path2": f2.name,
+                    "join_columns": ["id"],
+                })
+                self.assertEqual(resp.code, 400)
+                body = json.loads(resp.body)
+                self.assertEqual(body["error_code"], "compare_error")
+            finally:
+                os.unlink(f1.name)
+                os.unlink(f2.name)
+
+    def test_parquet_files(self):
+        df1 = pd.DataFrame({"id": [1, 2], "val": [10, 20]})
+        df2 = pd.DataFrame({"id": [1, 2], "val": [10, 99]})
+
+        with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f1, \
+             tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f2:
+            _write_df(df1, f1.name)
+            _write_df(df2, f2.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-pq",
+                    "path1": f1.name,
+                    "path2": f2.name,
+                    "join_columns": ["id"],
+                })
+                self.assertEqual(resp.code, 200)
+                body = json.loads(resp.body)
+                self.assertEqual(body["rows"], 2)
+            finally:
+                os.unlink(f1.name)
+                os.unlink(f2.name)
+
+    def test_how_inner_join(self):
+        df1 = pd.DataFrame({"id": [1, 2, 3], "v": [10, 20, 30]})
+        df2 = pd.DataFrame({"id": [2, 3, 4], "v": [20, 99, 40]})
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f1, \
+             tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f2:
+            _write_df(df1, f1.name)
+            _write_df(df2, f2.name)
+            try:
+                resp = self._post_compare({
+                    "session": "cmp-inner",
+                    "path1": f1.name,
+                    "path2": f2.name,
+                    "join_columns": ["id"],
+                    "how": "inner",
+                })
+                self.assertEqual(resp.code, 200)
+                body = json.loads(resp.body)
+                # Inner join: only 2,3 → 2 rows
+                self.assertEqual(body["rows"], 2)
+            finally:
+                os.unlink(f1.name)
+                os.unlink(f2.name)


### PR DESCRIPTION
## Summary

- Adds `POST /load_compare` endpoint to `buckaroo/server/handlers.py` that accepts two file paths and join columns
- Calls `col_join_dfs(df1, df2, join_columns, how)` to produce merged DataFrame with diff statistics
- Applies `column_config_overrides` (hidden columns, color maps, tooltips) to the viewer's `column_config`, translating original column names to renamed names via `old_col_new_col`
- Stores session state and pushes to connected WebSocket clients
- Registers route in `app.py`

## API

```
POST /load_compare
{
  "session":      "<id>",
  "path1":        "/abs/path/a.csv",
  "path2":        "/abs/path/b.csv",
  "join_columns": ["playerID", "yearID"],
  "how":          "outer",        // optional, default "outer"
  "no_browser":   false           // optional
}
```

Returns `{"session", "rows", "columns", "eqs", "server_pid", "browser_action"}`.

## Test plan

- [x] 9 unit tests in `tests/unit/server/test_load_compare.py` covering:
  - Basic compare (outer join row count, eqs structure)
  - Column config overrides applied (hidden cols, color_map, tooltip with translated val_column)
  - Diff count reporting
  - Missing required fields (400)
  - Missing file (404)
  - Bad JSON (400)
  - Duplicate join keys (400)
  - Parquet file support
  - Inner join mode
- [x] All 547 existing unit tests pass (no regressions)

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)