### PR TITLE
Add CLAUDE.md for Claude Code development guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,61 +1,63 @@
-# Buckaroo Development Guide
+# Buckaroo
 
-## Architecture Philosophy
-
-Buckaroo is a **framework** for building table-based data applications, plus a set of
-reference apps built on that framework. This distinction matters when making changes:
-
-- **Framework features** belong in the core (styling config, column config, displayers,
-  color rules, etc.). They should be general-purpose and usable by any app built on
-  buckaroo — not special-cased for one use case.
-- **App-specific behaviour** (e.g. compare tool styling, Jupyter widget defaults) lives
-  in the app layer and uses framework primitives to express its intent.
-- **Never add CSS hacks or one-off special cases** for a specific app feature. If a
-  visual need arises for an app (e.g. "highlight PK columns differently"), the right fix
-  is to add a general framework primitive (e.g. a `color_static` color rule) and then
-  express the app logic through that primitive.
+DataFrame viewer widget for Jupyter + standalone browser. Python backend (uv/hatch), TypeScript/React frontend (AG-Grid, pnpm workspaces).
 
 ## Project Layout
 
 ```
-buckaroo/          Python package — analysis pipeline, server, compare tool
+buckaroo/              Python package — analysis pipeline, server, compare tool, MCP
 packages/
-  buckaroo-js-core/   Core TS/React components, styling config, ag-Grid integration
-  js/                 Widget build (Jupyter)
+  buckaroo-js-core/    Core TS/React components, AG-Grid integration, Storybook
+  buckaroo-widget/     anywidget wrapper (esbuild)
 tests/
-  unit/              Python unit tests
-  pw-tests/          Playwright browser tests
+  unit/                Python unit tests (pytest)
+scripts/               Build, test, release scripts
 ```
 
-## Key Styling Config Concepts
-
-Column behaviour is driven by a JSON `column_config` list passed from Python to JS.
-Each entry supports:
-
-- `color_map_config` — cell background coloring (`color_map`, `color_categorical`,
-  `color_not_null`, `color_from_column`, `color_static`)
-- `tooltip_config` — cell tooltip content
-- `merge_rule` — visibility (`"hidden"`)
-- `ag_grid_specs` — escape hatch for raw ag-Grid `ColDef` properties
-
-If a visual need requires a new `color_rule` variant, add it to:
-1. `DFWhole.ts` — TypeScript interface + union type
-2. `Styler.tsx` — `colorXxx()` function + `getStyler()` case
-3. Python docs / tests
-
-## Running Tests
+## Build & Test
 
 ```bash
-# Python unit tests
-pytest tests/unit -v
+# Full build (JS + Python wheel)
+./scripts/full_build.sh
 
-# Playwright tests (requires built JS + running server)
-cd packages/buckaroo-js-core && npx playwright test
+# Python
+uv sync --dev --all-extras
+pytest -vv tests/unit/
+uv run ruff check --fix
+
+# JavaScript
+cd packages && pnpm install
+cd packages/buckaroo-js-core && pnpm run build && pnpm test
+cd packages/buckaroo-js-core && pnpm run test:pw    # Playwright E2E against Storybook
+
+# Storybook (component dev)
+cd packages/buckaroo-js-core && pnpm storybook
 ```
 
-## JS Build
+Test suite should complete in under 40 seconds. If it doesn't, something is wrong.
 
-```bash
-cd packages/buckaroo-js-core && npm run build
-cd packages/js && npm run build
-```
+## CI
+
+Runs on push to main and PRs. Key jobs: LintPython, TestJS, BuildWheel, TestPython (3.11-3.14), Playwright (Storybook, Jupyter, Marimo, WASM). Uses `depot-ubuntu-latest` runners.
+
+## Architecture Notes
+
+- **Column renaming**: Internally rewrites column names to a,b,c... — use `orig_col_name` to map back to real names.
+- **Styling config**: Column behaviour driven by `column_config` JSON from Python→JS. Supports `color_map_config`, `tooltip_config`, `merge_rule`, `ag_grid_specs`.
+- **Adding a new color rule**: Update `DFWhole.ts` (TS interface), `Styler.tsx` (function + case), Python docs/tests.
+- **gridUtils.ts**: `dfToAgrid` must use `lcc3` (pinned), not `lcc2`. Linter may revert this — commit promptly.
+- **`provides_defaults` in ColAnalysis**: Use `np.nan` not `0` for numeric stats fallbacks.
+
+## Code Style
+
+- No bare `except:` — use `except Exception:` (bare catches SystemExit).
+- Don't put imports inside functions unless absolutely necessary.
+- Prefer surgical, generalizable changes — don't special-case code to pass tests.
+- Slot new tests into existing test files when possible.
+
+## Release Process
+
+1. Update CHANGELOG.md
+2. Tag (no 'v' prefix): `git tag 0.12.13`
+3. Push tag: `git push origin tag 0.12.13`
+4. Release workflow generates notes and publishes to PyPI


### PR DESCRIPTION
## Summary
- Add CLAUDE.md with project-specific guidance for Claude Code
- Covers build/test commands, architecture notes, code style, and common pitfalls
- Consolidates tribal knowledge from .cursorrules and development experience

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)