### PR TITLE
fix: set defaultMinWidth to prevent narrow columns (#599)

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -172,6 +172,7 @@ describe("testing utility functions in gridUtils ", () => {
     it("should return fitCellContents for positive columns", () => {
       const result = getAutoSize(5);
       expect(result.type).toBe("fitCellContents");
+      expect(result).toHaveProperty("defaultMinWidth", 80);
     });
   });
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -541,7 +541,8 @@ export const getAutoSize = (
     }
     return {
         type: "fitCellContents",
-    };
+        defaultMinWidth: 80,
+    } as SizeColumnsToContentStrategy & { defaultMinWidth: number };
 };
 
 


### PR DESCRIPTION
## Summary
- Adds `defaultMinWidth: 80` to the `fitCellContents` auto-size strategy in `getAutoSize()`
- Prevents columns with short values (e.g. "yearID" showing 2009) from being rendered too narrow
- Updates test to verify the new minimum width is present

## Test plan
- [x] `pnpm test -- gridUtils.test.ts` passes (22/22)
- [x] `pnpm run build` succeeds
- [ ] Visual check: columns like yearID no longer truncated in Storybook/Jupyter

Fixes #599

🤖 Generated with [Claude Code](https://claude.com/claude-code)