### PR TITLE
feat: content-aware column widths, width estimation tests, and screenshot comparison infra

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -442,10 +442,6 @@ jobs:
           SCREENSHOT_DIR: screenshots/after
         run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
       # ── BEFORE: baseline commit b7956f8 (pre-#587) ───────────────────────
-      - name: Kill leftover Storybook from AFTER step
-        run: |
-          lsof -ti :6006 | xargs kill -9 2>/dev/null || true
-          sleep 1
       - name: Save new stories + spec
         run: |
           cp packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx /tmp/StylingIssues.stories.tsx

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -407,6 +407,76 @@ jobs:
           path: packages/buckaroo-js-core/screenshots/
           if-no-files-found: ignore
 
+  StylingScreenshots:
+    name: Styling Before/After Screenshots
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0  # need full history to access baseline commit
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.10.0
+      - name: Setup Node.js with pnpm cache
+        uses: actions/setup-node@v6
+        with:
+          cache: 'pnpm'
+          cache-dependency-path: 'packages/pnpm-lock.yaml'
+      - name: Install pnpm dependencies
+        working-directory: packages
+        run: pnpm install --frozen-lockfile
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ hashFiles('packages/buckaroo-js-core/package.json') }}
+      - name: Install Playwright browsers
+        working-directory: packages/buckaroo-js-core
+        run: pnpm exec playwright install chromium
+      # ── AFTER: current branch ────────────────────────────────────────────
+      - name: Capture AFTER screenshots
+        working-directory: packages/buckaroo-js-core
+        env:
+          SCREENSHOT_DIR: screenshots/after
+        run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
+      # ── BEFORE: baseline commit b7956f8 (pre-#587) ───────────────────────
+      - name: Save new stories + spec
+        run: |
+          cp packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx /tmp/StylingIssues.stories.tsx
+          cp packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts /tmp/styling-issues-screenshots.spec.ts
+      - name: Checkout baseline commit into worktree
+        run: git worktree add /tmp/baseline b7956f8
+      - name: Restore stories + spec into baseline
+        run: |
+          cp /tmp/StylingIssues.stories.tsx /tmp/baseline/packages/buckaroo-js-core/src/stories/
+          cp /tmp/styling-issues-screenshots.spec.ts /tmp/baseline/packages/buckaroo-js-core/pw-tests/
+      - name: Install deps for baseline
+        working-directory: /tmp/baseline/packages
+        run: pnpm install --no-frozen-lockfile
+      - name: Capture BEFORE screenshots
+        working-directory: /tmp/baseline/packages/buckaroo-js-core
+        env:
+          SCREENSHOT_DIR: screenshots/before
+        continue-on-error: true
+        run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
+      # ── Upload both artifact sets ────────────────────────────────────────
+      - name: Upload before screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: styling-screenshots-before
+          path: /tmp/baseline/packages/buckaroo-js-core/screenshots/before/
+          if-no-files-found: ignore
+      - name: Upload after screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: styling-screenshots-after
+          path: packages/buckaroo-js-core/screenshots/after/
+          if-no-files-found: ignore
+
   TestServer:
     name: Server Playwright Tests
     needs: [BuildWheel]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -408,13 +408,14 @@ jobs:
           if-no-files-found: ignore
 
   StylingScreenshots:
-    name: Styling Screenshots
+    name: Styling Screenshots (Before / After)
     runs-on: depot-ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -424,28 +425,84 @@ jobs:
         with:
           cache: 'pnpm'
           cache-dependency-path: 'packages/pnpm-lock.yaml'
-      - name: Install pnpm dependencies
-        working-directory: packages
-        run: pnpm install --no-frozen-lockfile
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ hashFiles('packages/buckaroo-js-core/package.json') }}
+
+      # Save story + spec from current branch (baseline commit won't have them)
+      - name: Save story and spec files
+        run: |
+          mkdir -p /tmp/styling-stories
+          cp packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx /tmp/styling-stories/
+          cp packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts /tmp/styling-stories/
+
+      # ── Before screenshots (baseline b7956f8, pre-#587) ──
+      - name: Checkout baseline (b7956f8)
+        run: git checkout b7956f8
+      - name: Copy stories to baseline
+        run: |
+          cp /tmp/styling-stories/StylingIssues.stories.tsx packages/buckaroo-js-core/src/stories/
+          cp /tmp/styling-stories/styling-issues-screenshots.spec.ts packages/buckaroo-js-core/pw-tests/
+      - name: Install pnpm deps (baseline)
+        working-directory: packages
+        run: pnpm install --no-frozen-lockfile
       - name: Install Playwright browsers
         working-directory: packages/buckaroo-js-core
         run: pnpm exec playwright install chromium
-      - name: Capture screenshots
+      - name: Capture before screenshots
         working-directory: packages/buckaroo-js-core
         env:
-          SCREENSHOT_DIR: screenshots/styling
-        run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
-      - name: Upload screenshots
+          SCREENSHOT_DIR: screenshots/before
+        run: |
+          pnpm storybook --no-open &
+          SB_PID=$!
+          timeout=60; elapsed=0
+          while ! curl -sf http://localhost:6006 > /dev/null 2>&1; do
+            sleep 2; elapsed=$((elapsed + 2))
+            if [ $elapsed -ge $timeout ]; then echo "Storybook failed to start"; exit 1; fi
+          done
+          pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line || true
+          kill $SB_PID 2>/dev/null || true
+          lsof -ti:6006 | xargs kill -9 2>/dev/null || true
+
+      # ── After screenshots (current branch) ──
+      - name: Checkout current branch
+        run: git checkout ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Install pnpm deps (current)
+        working-directory: packages
+        run: pnpm install --no-frozen-lockfile
+      - name: Capture after screenshots
+        working-directory: packages/buckaroo-js-core
+        env:
+          SCREENSHOT_DIR: screenshots/after
+        run: |
+          pnpm storybook --no-open &
+          SB_PID=$!
+          timeout=60; elapsed=0
+          while ! curl -sf http://localhost:6006 > /dev/null 2>&1; do
+            sleep 2; elapsed=$((elapsed + 2))
+            if [ $elapsed -ge $timeout ]; then echo "Storybook failed to start"; exit 1; fi
+          done
+          pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
+          kill $SB_PID 2>/dev/null || true
+          lsof -ti:6006 | xargs kill -9 2>/dev/null || true
+
+      # ── Upload artifacts ──
+      - name: Upload before screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: styling-screenshots
-          path: packages/buckaroo-js-core/screenshots/styling/
+          name: styling-screenshots-before
+          path: packages/buckaroo-js-core/screenshots/before/
+          if-no-files-found: ignore
+      - name: Upload after screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: styling-screenshots-after
+          path: packages/buckaroo-js-core/screenshots/after/
           if-no-files-found: ignore
 
   TestServer:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -469,7 +469,9 @@ jobs:
 
       # ── After screenshots (current branch) ──
       - name: Checkout current branch
-        run: git checkout ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          git checkout -f ${{ github.event.pull_request.head.sha || github.sha }}
+          git clean -fd packages/
       - name: Install pnpm deps (current)
         working-directory: packages
         run: pnpm install --no-frozen-lockfile

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -408,13 +408,11 @@ jobs:
           if-no-files-found: ignore
 
   StylingScreenshots:
-    name: Styling Before/After Screenshots
+    name: Styling Screenshots
     runs-on: depot-ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # need full history to access baseline commit
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -435,46 +433,17 @@ jobs:
       - name: Install Playwright browsers
         working-directory: packages/buckaroo-js-core
         run: pnpm exec playwright install chromium
-      # ── AFTER: current branch ────────────────────────────────────────────
-      - name: Capture AFTER screenshots
+      - name: Capture screenshots
         working-directory: packages/buckaroo-js-core
         env:
-          SCREENSHOT_DIR: screenshots/after
+          SCREENSHOT_DIR: screenshots/styling
         run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
-      # ── BEFORE: baseline commit b7956f8 (pre-#587) ───────────────────────
-      - name: Save new stories + spec
-        run: |
-          cp packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx /tmp/StylingIssues.stories.tsx
-          cp packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts /tmp/styling-issues-screenshots.spec.ts
-      - name: Checkout baseline commit into worktree
-        run: git worktree add /tmp/baseline b7956f8
-      - name: Restore stories + spec into baseline
-        run: |
-          cp /tmp/StylingIssues.stories.tsx /tmp/baseline/packages/buckaroo-js-core/src/stories/
-          cp /tmp/styling-issues-screenshots.spec.ts /tmp/baseline/packages/buckaroo-js-core/pw-tests/
-      - name: Install deps for baseline
-        working-directory: /tmp/baseline/packages
-        run: pnpm install --no-frozen-lockfile
-      - name: Capture BEFORE screenshots
-        working-directory: /tmp/baseline/packages/buckaroo-js-core
-        env:
-          SCREENSHOT_DIR: screenshots/before
-        continue-on-error: true
-        run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
-      # ── Upload both artifact sets ────────────────────────────────────────
-      - name: Upload before screenshots
+      - name: Upload screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: styling-screenshots-before
-          path: /tmp/baseline/packages/buckaroo-js-core/screenshots/before/
-          if-no-files-found: ignore
-      - name: Upload after screenshots
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: styling-screenshots-after
-          path: packages/buckaroo-js-core/screenshots/after/
+          name: styling-screenshots
+          path: packages/buckaroo-js-core/screenshots/styling/
           if-no-files-found: ignore
 
   TestServer:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -413,6 +413,8 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -424,7 +426,7 @@ jobs:
           cache-dependency-path: 'packages/pnpm-lock.yaml'
       - name: Install pnpm dependencies
         working-directory: packages
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -442,6 +442,10 @@ jobs:
           SCREENSHOT_DIR: screenshots/after
         run: pnpm exec playwright test pw-tests/styling-issues-screenshots.spec.ts --reporter=line
       # ── BEFORE: baseline commit b7956f8 (pre-#587) ───────────────────────
+      - name: Kill leftover Storybook from AFTER step
+        run: |
+          lsof -ti :6006 | xargs kill -9 2>/dev/null || true
+          sleep 1
       - name: Save new stories + spec
         run: |
           cp packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx /tmp/StylingIssues.stories.tsx

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -2,6 +2,61 @@ from buckaroo.dataflow.dataflow import StylingAnalysis
 from typing import Any
 from buckaroo.styling_helpers import obj_, float_, inherit_, pinned_histogram
 
+# Pixel-width estimation constants, calibrated to AG-Grid theme with
+# spacing:5, cellHorizontalPaddingScale:0.3, fontSize:12, headerFontSize:14
+_CHAR_PX_DATA = 7       # approx width per character in data cells
+_CHAR_PX_HEADER = 8     # approx width per character in header
+_CELL_PAD = 16          # total horizontal padding inside a cell
+_SORT_ICON = 14         # sort indicator + gap in header
+_HISTOGRAM_MIN_PX = 100 # minimum width for a histogram pinned row to render usefully
+_MIN_COL_PX = 30        # absolute floor
+
+
+def _formatted_char_count(displayer_args, column_metadata):
+    """Estimate the character count of the widest formatted value."""
+    d = displayer_args.get('displayer')
+
+    if d == 'float':
+        max_val = column_metadata.get('max', 0) or 0
+        min_val = column_metadata.get('min', 0) or 0
+        max_abs = max(abs(max_val), abs(min_val))
+        int_digits = max(1, len(str(int(max_abs)))) if max_abs == max_abs else 1  # nan guard
+        commas = (int_digits - 1) // 3
+        frac = displayer_args.get('max_fraction_digits', 0)
+        decimal = 1 if frac > 0 else 0
+        sign = 1 if min_val < 0 else 0
+        return int_digits + commas + decimal + frac + sign
+
+    if d == 'integer':
+        max_digits = displayer_args.get('max_digits', 4)
+        commas = (max_digits - 1) // 3
+        return max_digits + commas
+
+    if d == 'compact_number':
+        return 5  # e.g. "5.7B"
+
+    if d == 'string':
+        return min(displayer_args.get('max_length', 20), 20)
+
+    if d in ('datetimeLocaleString', 'datetimeDefault'):
+        return 18  # "12/31/2024, 11:59 PM"
+
+    return 8  # obj / fallback
+
+
+def estimate_min_width_px(displayer_args, header_name, column_metadata, has_histogram=False):
+    """Compute a per-column minWidth in pixels from content analysis."""
+    data_chars = _formatted_char_count(displayer_args, column_metadata)
+    data_px = data_chars * _CHAR_PX_DATA + _CELL_PAD
+
+    hdr_chars = len(str(header_name)) if header_name else 1
+    header_px = hdr_chars * _CHAR_PX_HEADER + _SORT_ICON + _CELL_PAD
+
+    width = max(data_px, header_px)
+    if has_histogram:
+        width = max(width, _HISTOGRAM_MIN_PX)
+    return max(width, _MIN_COL_PX)
+
 
 class DefaultMainStyling(StylingAnalysis):
     requires_summary = ["histogram", "is_numeric", "dtype", "_type"]
@@ -30,7 +85,17 @@ class DefaultMainStyling(StylingAnalysis):
         else:
             disp = {'displayer': 'obj'}
             base_config['tooltip_config'] = {'tooltip_type':'simple', 'val_column': str(col)}
-        base_config['displayer_args'] = disp 
+        base_config['displayer_args'] = disp
+
+        # Compute content-aware minWidth
+        header_name = column_metadata.get('orig_col_name', col)
+        has_histogram = any(
+            pr.get('displayer_args', {}).get('displayer') == 'histogram'
+            for pr in kls.pinned_rows
+        )
+        min_w = estimate_min_width_px(disp, header_name, column_metadata, has_histogram)
+        base_config['ag_grid_specs'] = {'minWidth': min_w}
+
         return base_config
 
 

--- a/docs/column-width-design.md
+++ b/docs/column-width-design.md
@@ -1,0 +1,253 @@
+# Column Width: Problems, Levers, and Approaches
+
+## The Core Tension
+
+A data grid must assign pixel widths to columns. The "right" width depends on context:
+- A column of 2-digit integers needs ~40px of data space
+- A column header "customer_lifetime_value" needs ~150px
+- A histogram pinned row needs ~100px to be legible
+- The viewport might be 800px wide with 25 columns (32px each if divided equally)
+
+There is no single correct answer. Different users looking at the same data want different things:
+one wants every column readable without scrolling; another wants compact data with a scrollbar.
+This means we need **multiple levers** that can be composed into different **sizing strategies**.
+
+---
+
+## The Problems (by issue)
+
+### #595 / #599 / #600 — Columns crushed to unreadable widths
+**Scenario:** 25+ columns in an 800px viewport with `fitGridWidth` or `fitCellContents`.
+AG-Grid divides space equally → 32px per column → data shows "..." truncation.
+
+**Root cause:** No minimum width floor. AG-Grid will shrink columns to nothing.
+
+### #596 — Header vs data width contention
+**Scenario:** Long headers ("customer_lifetime_value") on columns with short data (integers 1-99),
+or short headers ("a") on columns with long data (formatted floats with 6+ digits).
+The column should be as wide as the *wider* of the two, but AG-Grid's auto-sizing
+may not see the header or the data correctly (especially with formatted values).
+
+**Root cause:** Need to predict width from *both* header and formatted data, not just one.
+
+### #597 / #601 — Large numbers waste space
+**Scenario:** Values like 5,700,000,000 displayed as floats consume ~15 characters.
+With `compact_number` displayer they become "5.7B" (4 chars) — 3x narrower.
+
+**Root cause:** The displayer choice dramatically affects needed column width.
+
+### #602 — Compact numbers lose precision on clustered values
+**Scenario:** All values between 5.60B and 5.68B. Compact format shows "5.6B" for all of them —
+you lose the distinguishing digits. Float format "5,600,000,000" vs "5,680,000,000" preserves them.
+
+**Root cause:** Compact notation is lossy. Some datasets need full precision.
+This is a displayer choice, not a width problem, but it interacts with width.
+
+### #587 — Pinned row / index column alignment
+**Scenario:** Left-pinned index column scrolls out of view when there are many columns.
+Summary stats rows misalign with data columns.
+
+**Root cause:** Was a code bug (using `lcc2` instead of `lcc3` in `dfToAgrid`). Fixed.
+But the visual interaction of pinned rows with narrow columns remains relevant —
+a histogram pinned row in a 40px-wide column is unreadable.
+
+---
+
+## The Levers (what exists today)
+
+### Per-column levers (set via `ag_grid_specs` in Python `column_config`)
+
+These flow from Python through `column_config[i].ag_grid_specs` and get spread
+into the AG-Grid `ColDef` at `baseColToColDef()` (gridUtils.ts:120):
+
+| Property | Effect | Example |
+|----------|--------|---------|
+| `minWidth` | Floor — column never narrower than this | `{'minWidth': 85}` |
+| `maxWidth` | Ceiling — column never wider than this | `{'maxWidth': 200}` |
+| `width` | Fixed width (ignores auto-sizing) | `{'width': 150}` |
+| `flex` | Relative weight for distributing leftover space | `{'flex': 2}` |
+
+**Current state:** Python's `estimate_min_width_px()` sets only `minWidth`.
+The other three (`maxWidth`, `width`, `flex`) are available but unused.
+
+### Grid-level levers (set via `extra_grid_config` in Python or stories)
+
+These flow through `DFViewerConfig.extra_grid_config` and get merged into AG-Grid `GridOptions`:
+
+| Property | Effect | Example |
+|----------|--------|---------|
+| `autoSizeStrategy` | Controls how AG-Grid distributes column widths | See table below |
+
+**`autoSizeStrategy` options (AG-Grid 32+):**
+
+| Strategy | Behavior | Good for | Bad for |
+|----------|----------|----------|---------|
+| `fitCellContents` | Each column sized to fit its widest cell | General use — respects content | Can create wide grids with scrollbar |
+| `fitGridWidth` | Columns stretched/compressed to fill viewport exactly | No horizontal scrollbar | Crushes columns when there are many |
+| `fitProvidedWidth` | Like fitGridWidth but to a specified pixel width | Embedding at known width | Same crushing problem |
+
+**Current default:** `fitCellContents` (for 1+ columns), set in `getAutoSize()` (gridUtils.ts:539).
+Override via `extra_grid_config.autoSizeStrategy`.
+
+### Default column lever (`defaultColDef`)
+
+Set in `DFViewerInfinite.tsx:245`. Applied to ALL columns as a base.
+Currently contains `sortable`, `type`, `cellStyle`, `cellRendererSelector` — **no width properties**.
+
+Could add `minWidth`, `maxWidth`, etc. here as a blanket floor, but we removed `minWidth: 80`
+because it was too blunt (wasted space on narrow-data columns like single-digit integers).
+
+### Displayer choice (affects needed width)
+
+The displayer determines how values are formatted, which determines character count:
+
+| Displayer | Example output | Char count | Notes |
+|-----------|---------------|------------|-------|
+| `float` (3 frac digits) | "5,700,000,000.000" | ~18 | Widest for large numbers |
+| `float` (0 frac digits) | "5,700,000,000" | ~13 | Integers formatted as float |
+| `integer` | "5700000000" | ~10 | No commas in current impl |
+| `compact_number` | "5.7B" | ~4 | Lossy but very compact |
+| `string` | "hello world..." | up to 20 | Capped by max_length |
+| `datetimeLocaleString` | "12/31/2024, 11:59 PM" | ~18 | Fixed format |
+| `obj` | varies | ~8 | Fallback |
+
+Python's `_formatted_char_count()` estimates this per-displayer.
+
+### Theme parameters (affect pixel calibration)
+
+Set in `gridUtils.ts:555`:
+```
+spacing: 5
+cellHorizontalPaddingScale: 0.3
+fontSize: 12
+headerFontSize: 14
+iconSize: 10
+```
+
+The Python constants (`_CHAR_PX_DATA=7`, `_CHAR_PX_HEADER=8`, `_CELL_PAD=16`, `_SORT_ICON=14`)
+are calibrated to these theme values. If the theme changes, the constants need recalibration.
+
+---
+
+## Width Approaches (valid strategies for different goals)
+
+Given the same data, there are multiple valid ways to assign column widths.
+Each is a combination of the levers above.
+
+### Approach 1: "Readable" — every column wide enough for its content
+
+**Goal:** No truncation. Every value and header fully visible. Histogram pinned rows legible.
+Horizontal scrollbar is acceptable.
+
+**Lever settings:**
+- `autoSizeStrategy`: `fitCellContents` (default)
+- Per-column `minWidth`: computed by `estimate_min_width_px()` from data range + header + histogram
+- No `maxWidth` or `flex`
+
+**When it works well:** Few columns, or wide viewport. Data exploration.
+**When it fails:** 25+ columns — grid becomes very wide, lots of scrolling.
+
+### Approach 2: "Compact" — minimize horizontal space
+
+**Goal:** See as many columns as possible without scrolling. Accept that some values truncate.
+Histograms may be cut off. Headers may truncate.
+
+**Lever settings:**
+- `autoSizeStrategy`: `fitGridWidth`
+- Per-column `minWidth`: small floor (30-50px) based on data only, ignore header width
+- Possibly `maxWidth` to prevent any single column from hogging space
+
+**When it works well:** Overview/scanning mode, many columns.
+**When it fails:** Values unreadable if columns get too narrow.
+
+### Approach 3: "Balanced" — fit viewport but enforce minimums
+
+**Goal:** Fill the viewport width (no scrollbar) but ensure no column drops below
+a content-aware minimum. If total minimums exceed viewport, allow scrollbar.
+
+**Lever settings:**
+- `autoSizeStrategy`: `fitGridWidth`
+- Per-column `minWidth`: computed by `estimate_min_width_px()` (content-aware floor)
+- Per-column `flex`: proportional to content width (wider content gets more space)
+
+**When it works well:** Moderate column counts (5-15).
+**When it fails:** Many columns where minimums already exceed viewport → degrades to scrollbar.
+
+### Approach 4: "Data-priority" — size to data, ignore headers
+
+**Goal:** Column exactly as wide as its data needs. Long headers get truncated/tooltipped.
+
+**Lever settings:**
+- `autoSizeStrategy`: `fitCellContents`
+- Per-column `minWidth`: based on data width only (not header)
+- Per-column `maxWidth`: same as minWidth (fixed to data width)
+- Header truncation via AG-Grid's built-in `headerClass` or `autoHeaderHeight`
+
+**Not currently possible:** AG-Grid header truncation needs additional CSS/config work.
+
+---
+
+## What's Implemented vs What's Missing
+
+### Implemented (levers that work today)
+
+| Lever | Status | Where |
+|-------|--------|-------|
+| Per-column `minWidth` from Python | Working | `styling.py:96-97` → `gridUtils.ts:120` |
+| Per-column `maxWidth` from Python | **Available** (unused) | Same pipeline, just set `ag_grid_specs.maxWidth` |
+| Per-column `width` from Python | **Available** (unused) | Same pipeline |
+| Per-column `flex` from Python | **Available** (unused) | Same pipeline |
+| Grid `autoSizeStrategy` override | Working | `extra_grid_config.autoSizeStrategy` → `DFViewerInfinite.tsx:306` |
+| Content-aware char count estimation | Working | `_formatted_char_count()` in `styling.py` |
+| Histogram min width (100px) | Working | `_HISTOGRAM_MIN_PX` in `styling.py` |
+| Displayer choice affects width | Working | `compact_number` vs `float` etc. |
+
+### Missing (levers we don't have yet)
+
+| Lever | What it would do | Difficulty |
+|-------|-----------------|------------|
+| **Multiple StylingAnalysis configs** | Let user switch between "readable" and "compact" | Medium — Python `df_display_klasses` already supports multiple classes; need UI toggle |
+| **Header truncation / tooltip** | Truncate long headers with CSS, show full name on hover | Easy — AG-Grid supports `headerClass` and `headerTooltip` |
+| **`defaultColDef.minWidth` as context-dependent floor** | Different floor per sizing strategy | Easy — set in `defaultColDef` based on strategy choice |
+| **`flex` distribution** | Proportional space allocation when using `fitGridWidth` | Easy — Python can compute and set `flex` per column |
+
+### Missing (tests / visual proof)
+
+| Gap | Impact |
+|-----|--------|
+| No unit tests for `estimate_min_width_px()` | Can't verify char count logic for edge cases |
+| No stories exercise Python-computed `ag_grid_specs` | All 17 stories construct configs in TypeScript, bypass Python |
+| No histogram + narrow columns story | Can't see if 100px minimum actually helps |
+
+---
+
+## Key Insight: The JS Side Already Has All the Levers
+
+The `ag_grid_specs` spread at `gridUtils.ts:120` (`...f.ag_grid_specs`) is a **pass-through
+for any AG-Grid ColDef property**. Since `AGGrid_ColDef = ColDef`, Python can set:
+
+- `minWidth`, `maxWidth`, `width`, `flex`
+- `suppressSizeToFit`, `resizable`, `lockPosition`
+- `headerClass`, `headerTooltip`
+- Any other ColDef property
+
+Similarly, `extra_grid_config` at `DFViewerInfinite.tsx:306` is a pass-through for
+any AG-Grid `GridOptions`, including `autoSizeStrategy` with all its sub-options.
+
+**The JS side doesn't need new code to support different sizing strategies.**
+All the work is in Python: computing the right values and offering the user a way to switch.
+
+The one thing the JS side *would* need for a full solution is a **UI control to switch
+between sizing strategies** — but that's a React component concern, not an AG-Grid lever issue.
+
+---
+
+## Recommended Next Steps
+
+1. **Unit tests for `estimate_min_width_px()`** — verify the math for each displayer type
+2. **Stories with `ag_grid_specs.minWidth` set** — visual proof the lever works in the grid
+3. **Story combining histogram pinned rows + narrow columns** — verify the 100px floor
+4. **Prototype "compact" StylingAnalysis** — a second Python class that uses different
+   width constants (smaller minWidth, ignore header, smaller histogram floor)
+5. **Header truncation** — add `headerTooltip` to `ag_grid_specs` when header is wider
+   than data, so users can hover to see full column name

--- a/docs/compare-tool-approach.md
+++ b/docs/compare-tool-approach.md
@@ -1,0 +1,38 @@
+# Screenshot Compare Approach
+
+## The method
+
+When working on visual/styling changes, write the failing test first — as a Storybook story that reproduces the problem — then use automated screenshot capture and a generated comparison webpage to evaluate whether changes actually improved things.
+
+The loop is:
+
+1. **Write stories that expose the bug** — create Storybook stories with specific data shapes that trigger the visual problem. Cover the combinatorial space (few/many columns, short/long headers, short/long data, with/without pinned rows).
+
+2. **Capture "before" screenshots** — run Playwright against the stories at the baseline commit to record what the bug looks like.
+
+3. **Make the fix** — change the code.
+
+4. **Capture "after" screenshots** — run Playwright again on the new code.
+
+5. **Generate comparison webpage** — a Python script reads both screenshot directories, embeds images as base64, and produces a self-contained HTML file with before/after stacked per story, sidebar navigation, zoom/pan, and keyboard nav.
+
+6. **Review visually** — open the HTML, click through each story, judge whether the change helped or hurt. No pixel-diff automation — human eyes are the test.
+
+7. **Iterate** — if the fix helped some cases but hurt others, adjust and re-capture.
+
+## Why this instead of pixel-diff testing
+
+Visual correctness for a data grid is subjective and context-dependent. A column being 80px vs 60px isn't "wrong" in a way a pixel diff can catch — it depends on what's in the column. The generated comparison page lets you rapidly scan all scenarios and make a judgment call, which is what you actually need for styling work.
+
+## Why stories as the test harness
+
+- Stories are the **specification** — they encode the exact data shape, column config, and displayer that triggers the issue.
+- They're reusable — once written, they work for any future before/after comparison, not just the current fix.
+- They run in the real rendering pipeline (ShadowDomWrapper + DFViewerInfinite + AG-Grid), so what you see is what users get.
+- They're combinatorial — covering the matrix of dimensions (column count x header width x data width x pinned rows) systematically catches regressions that spot-checking misses.
+
+## CI integration
+
+CI captures screenshots automatically on every PR, so you always have a fresh "after" set. The "before" baseline is a fixed commit. Screenshots are uploaded as artifacts — never committed to the repo. A download script pulls them locally, then the comparison generator produces the HTML viewer.
+
+This keeps the repo clean (no PNGs in git) while making the visual evidence reproducible and accessible to anyone reviewing the PR.

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -87,32 +87,14 @@ for (const story of STORIES) {
 
     // For pinned-index stories, scroll the grid body right so the
     // index column is out of view — exposes #587 alignment bug.
+    // Use keyboard End key to scroll to the rightmost column.
     if (story.name.includes('Pinned')) {
-      const scrolled = await page.evaluate(() => {
-        // Playwright locators pierce shadow DOM but evaluate doesn't.
-        // Manually walk shadow roots to find the AG-Grid viewport.
-        function findInShadow(selector: string): Element | null {
-          const light = document.querySelector(selector);
-          if (light) return light;
-          const walk = (root: Document | ShadowRoot): Element | null => {
-            const el = root.querySelector(selector);
-            if (el) return el;
-            for (const child of root.querySelectorAll('*')) {
-              if (child.shadowRoot) {
-                const found = walk(child.shadowRoot);
-                if (found) return found;
-              }
-            }
-            return null;
-          };
-          return walk(document);
-        }
-        const vp = findInShadow('.ag-body-viewport');
-        if (!vp) return 'not found';
-        vp.scrollLeft = vp.scrollWidth;
-        return `scrolled to ${vp.scrollLeft} of ${vp.scrollWidth} (client: ${vp.clientWidth})`;
-      });
-      console.log(`Scroll result for ${story.name}: ${scrolled}`);
+      // Click a cell first to give the grid focus
+      const firstCell = page.locator('.ag-cell').first();
+      await firstCell.click();
+      await page.waitForTimeout(200);
+      // Press End to scroll to the last column
+      await page.keyboard.press('End');
       await page.waitForTimeout(400);
     }
 

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -85,6 +85,14 @@ for (const story of STORIES) {
     // Settle time for animations / lazy column-width calculation
     await page.waitForTimeout(800);
 
+    // For pinned-index stories, scroll the grid body right so the
+    // index column is out of view — exposes #587 alignment bug.
+    if (story.name.includes('Pinned')) {
+      const viewport = page.locator('.ag-body-viewport');
+      await viewport.evaluate((el) => { el.scrollLeft = 200; });
+      await page.waitForTimeout(400);
+    }
+
     await page.screenshot({
       path: path.join(screenshotsDir, `${story.name}.png`),
       fullPage: true,

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -28,33 +28,34 @@ const screenshotsDir = path.resolve(
  * All 16 styling-issue stories.
  * Story IDs follow Storybook's slug rules:
  *   title "Buckaroo/DFViewer/StylingIssues" → "buckaroo-dfviewer-stylingissues"
- *   export name e.g. FewCols_ShortHdr_ShortData → "fewcols-shorthdr-shortdata"
+ *   export name e.g. FewCols_ShortHdr_ShortData → "few-cols-short-hdr-short-data"
+ *   (Storybook runs startCase() on the export name before slugifying)
  */
 const STORIES = [
   // Section A – width/contention (#595, #596, #599, #600)
-  { id: 'buckaroo-dfviewer-stylingissues--fewcols-shorthdr-shortdata',  name: 'A1_FewCols_ShortHdr_ShortData',  issues: '#599' },
-  { id: 'buckaroo-dfviewer-stylingissues--fewcols-shorthdr-longdata',   name: 'A2_FewCols_ShortHdr_LongData',   issues: '' },
-  { id: 'buckaroo-dfviewer-stylingissues--fewcols-longhdr-shortdata',   name: 'A3_FewCols_LongHdr_ShortData',   issues: '' },
-  { id: 'buckaroo-dfviewer-stylingissues--fewcols-longhdr-longdata',    name: 'A4_FewCols_LongHdr_LongData',    issues: '' },
-  { id: 'buckaroo-dfviewer-stylingissues--manycols-shorthdr-shortdata', name: 'A5_ManyCols_ShortHdr_ShortData', issues: '#595 #599' },
-  { id: 'buckaroo-dfviewer-stylingissues--manycols-shorthdr-longdata',  name: 'A6_ManyCols_ShortHdr_LongData',  issues: '#596' },
-  { id: 'buckaroo-dfviewer-stylingissues--manycols-longhdr-shortdata',  name: 'A7_ManyCols_LongHdr_ShortData',  issues: '#596' },
-  { id: 'buckaroo-dfviewer-stylingissues--manycols-longhdr-longdata',   name: 'A8_ManyCols_LongHdr_LongData',   issues: '#596 worst-case' },
+  { id: 'buckaroo-dfviewer-stylingissues--few-cols-short-hdr-short-data',  name: 'A1_FewCols_ShortHdr_ShortData',  issues: '#599' },
+  { id: 'buckaroo-dfviewer-stylingissues--few-cols-short-hdr-long-data',   name: 'A2_FewCols_ShortHdr_LongData',   issues: '' },
+  { id: 'buckaroo-dfviewer-stylingissues--few-cols-long-hdr-short-data',   name: 'A3_FewCols_LongHdr_ShortData',   issues: '' },
+  { id: 'buckaroo-dfviewer-stylingissues--few-cols-long-hdr-long-data',    name: 'A4_FewCols_LongHdr_LongData',    issues: '' },
+  { id: 'buckaroo-dfviewer-stylingissues--many-cols-short-hdr-short-data', name: 'A5_ManyCols_ShortHdr_ShortData', issues: '#595 #599' },
+  { id: 'buckaroo-dfviewer-stylingissues--many-cols-short-hdr-long-data',  name: 'A6_ManyCols_ShortHdr_LongData',  issues: '#596' },
+  { id: 'buckaroo-dfviewer-stylingissues--many-cols-long-hdr-short-data',  name: 'A7_ManyCols_LongHdr_ShortData',  issues: '#596' },
+  { id: 'buckaroo-dfviewer-stylingissues--many-cols-long-hdr-long-data',   name: 'A8_ManyCols_LongHdr_LongData',   issues: '#596 worst-case' },
 
   // Section B – large numbers / compact_number (#597, #602)
   // Note: compact_number stories may render raw values on pre-#597 commits.
-  { id: 'buckaroo-dfviewer-stylingissues--largenumbers-float',          name: 'B9_LargeNumbers_Float',          issues: '#597 before' },
-  { id: 'buckaroo-dfviewer-stylingissues--largenumbers-compact',        name: 'B10_LargeNumbers_Compact',        issues: '#597 after' },
-  { id: 'buckaroo-dfviewer-stylingissues--clusteredbillions-float',     name: 'B11_ClusteredBillions_Float',     issues: '#602 baseline' },
-  { id: 'buckaroo-dfviewer-stylingissues--clusteredbillions-compact',   name: 'B12_ClusteredBillions_Compact',   issues: '#602 precision' },
+  { id: 'buckaroo-dfviewer-stylingissues--large-numbers-float',            name: 'B9_LargeNumbers_Float',          issues: '#597 before' },
+  { id: 'buckaroo-dfviewer-stylingissues--large-numbers-compact',          name: 'B10_LargeNumbers_Compact',        issues: '#597 after' },
+  { id: 'buckaroo-dfviewer-stylingissues--clustered-billions-float',       name: 'B11_ClusteredBillions_Float',     issues: '#602 baseline' },
+  { id: 'buckaroo-dfviewer-stylingissues--clustered-billions-compact',     name: 'B12_ClusteredBillions_Compact',   issues: '#602 precision' },
 
   // Section C – pinned row / index alignment (#587)
-  { id: 'buckaroo-dfviewer-stylingissues--pinnedindex-fewcols',         name: 'C13_PinnedIndex_FewCols',         issues: '#587' },
-  { id: 'buckaroo-dfviewer-stylingissues--pinnedindex-manycols',        name: 'C14_PinnedIndex_ManyCols',        issues: '#587' },
+  { id: 'buckaroo-dfviewer-stylingissues--pinned-index-few-cols',          name: 'C13_PinnedIndex_FewCols',         issues: '#587' },
+  { id: 'buckaroo-dfviewer-stylingissues--pinned-index-many-cols',         name: 'C14_PinnedIndex_ManyCols',        issues: '#587' },
 
   // Section D – mixed cross-issue scenarios
-  { id: 'buckaroo-dfviewer-stylingissues--mixed-manynarrow-withpinned', name: 'D15_Mixed_ManyNarrow_WithPinned', issues: '#595 #587 #599' },
-  { id: 'buckaroo-dfviewer-stylingissues--mixed-fewwide-withpinned',    name: 'D16_Mixed_FewWide_WithPinned',    issues: '#587 baseline' },
+  { id: 'buckaroo-dfviewer-stylingissues--mixed-many-narrow-with-pinned',  name: 'D15_Mixed_ManyNarrow_WithPinned', issues: '#595 #587 #599' },
+  { id: 'buckaroo-dfviewer-stylingissues--mixed-few-wide-with-pinned',     name: 'D16_Mixed_FewWide_WithPinned',    issues: '#587 baseline' },
 ];
 
 test.beforeAll(() => {

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -90,11 +90,16 @@ for (const story of STORIES) {
     // Grid is inside a Shadow DOM, so we pierce it via evaluate.
     if (story.name.includes('Pinned')) {
       await page.evaluate(() => {
-        const host = document.querySelector('div[ref]') ??
-                     document.querySelector('#storybook-root > div');
-        const shadow = host?.shadowRoot;
-        const vp = shadow?.querySelector('.ag-body-viewport') ??
-                   document.querySelector('.ag-body-viewport');
+        // Walk all elements looking for shadow roots containing AG-Grid
+        const allEls = document.querySelectorAll('*');
+        for (const el of allEls) {
+          if (el.shadowRoot) {
+            const vp = el.shadowRoot.querySelector('.ag-body-viewport');
+            if (vp) { vp.scrollLeft = 400; return; }
+          }
+        }
+        // Fallback: no shadow DOM
+        const vp = document.querySelector('.ag-body-viewport');
         if (vp) vp.scrollLeft = 400;
       });
       await page.waitForTimeout(400);

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Playwright screenshot capture for styling-issue stories.
+ * Follows the theme-screenshots.spec.ts pattern (light-only).
+ *
+ * SCREENSHOT_DIR env var controls output directory (default: screenshots/after).
+ * Run once on each commit to produce "before" and "after" sets:
+ *
+ *   SCREENSHOT_DIR=screenshots/before npx playwright test pw-tests/styling-issues-screenshots.spec.ts
+ *   SCREENSHOT_DIR=screenshots/after  npx playwright test pw-tests/styling-issues-screenshots.spec.ts
+ */
+import { test } from '@playwright/test';
+import path from 'path';
+import fs from 'fs';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const STORYBOOK_BASE = 'http://localhost:6006/iframe.html?viewMode=story&id=';
+
+// Output directory — overridable via env var
+const screenshotsDir = path.resolve(
+  __dirname,
+  '..',
+  process.env.SCREENSHOT_DIR ?? 'screenshots/after',
+);
+
+/**
+ * All 16 styling-issue stories.
+ * Story IDs follow Storybook's slug rules:
+ *   title "Buckaroo/DFViewer/StylingIssues" → "buckaroo-dfviewer-stylingissues"
+ *   export name e.g. FewCols_ShortHdr_ShortData → "fewcols-shorthdr-shortdata"
+ */
+const STORIES = [
+  // Section A – width/contention (#595, #596, #599, #600)
+  { id: 'buckaroo-dfviewer-stylingissues--fewcols-shorthdr-shortdata',  name: 'A1_FewCols_ShortHdr_ShortData',  issues: '#599' },
+  { id: 'buckaroo-dfviewer-stylingissues--fewcols-shorthdr-longdata',   name: 'A2_FewCols_ShortHdr_LongData',   issues: '' },
+  { id: 'buckaroo-dfviewer-stylingissues--fewcols-longhdr-shortdata',   name: 'A3_FewCols_LongHdr_ShortData',   issues: '' },
+  { id: 'buckaroo-dfviewer-stylingissues--fewcols-longhdr-longdata',    name: 'A4_FewCols_LongHdr_LongData',    issues: '' },
+  { id: 'buckaroo-dfviewer-stylingissues--manycols-shorthdr-shortdata', name: 'A5_ManyCols_ShortHdr_ShortData', issues: '#595 #599' },
+  { id: 'buckaroo-dfviewer-stylingissues--manycols-shorthdr-longdata',  name: 'A6_ManyCols_ShortHdr_LongData',  issues: '#596' },
+  { id: 'buckaroo-dfviewer-stylingissues--manycols-longhdr-shortdata',  name: 'A7_ManyCols_LongHdr_ShortData',  issues: '#596' },
+  { id: 'buckaroo-dfviewer-stylingissues--manycols-longhdr-longdata',   name: 'A8_ManyCols_LongHdr_LongData',   issues: '#596 worst-case' },
+
+  // Section B – large numbers / compact_number (#597, #602)
+  // Note: compact_number stories may render raw values on pre-#597 commits.
+  { id: 'buckaroo-dfviewer-stylingissues--largenumbers-float',          name: 'B9_LargeNumbers_Float',          issues: '#597 before' },
+  { id: 'buckaroo-dfviewer-stylingissues--largenumbers-compact',        name: 'B10_LargeNumbers_Compact',        issues: '#597 after' },
+  { id: 'buckaroo-dfviewer-stylingissues--clusteredbillions-float',     name: 'B11_ClusteredBillions_Float',     issues: '#602 baseline' },
+  { id: 'buckaroo-dfviewer-stylingissues--clusteredbillions-compact',   name: 'B12_ClusteredBillions_Compact',   issues: '#602 precision' },
+
+  // Section C – pinned row / index alignment (#587)
+  { id: 'buckaroo-dfviewer-stylingissues--pinnedindex-fewcols',         name: 'C13_PinnedIndex_FewCols',         issues: '#587' },
+  { id: 'buckaroo-dfviewer-stylingissues--pinnedindex-manycols',        name: 'C14_PinnedIndex_ManyCols',        issues: '#587' },
+
+  // Section D – mixed cross-issue scenarios
+  { id: 'buckaroo-dfviewer-stylingissues--mixed-manynarrow-withpinned', name: 'D15_Mixed_ManyNarrow_WithPinned', issues: '#595 #587 #599' },
+  { id: 'buckaroo-dfviewer-stylingissues--mixed-fewwide-withpinned',    name: 'D16_Mixed_FewWide_WithPinned',    issues: '#587 baseline' },
+];
+
+test.beforeAll(() => {
+  fs.mkdirSync(screenshotsDir, { recursive: true });
+});
+
+for (const story of STORIES) {
+  test(`screenshot ${story.name}`, async ({ page }) => {
+    await page.emulateMedia({ colorScheme: 'light' });
+    await page.goto(`${STORYBOOK_BASE}${story.id}`);
+
+    // Wait for AG-Grid cells or any visible content
+    const cell        = page.locator('.ag-cell');
+    const cellWrapper = page.locator('.ag-cell-wrapper');
+    const noRows      = page.locator('.ag-overlay-no-rows-center');
+    const fullWidth   = page.locator('.ag-full-width-row');
+    const sbContent   = page.locator('#storybook-root');
+
+    await cell
+      .or(cellWrapper)
+      .or(noRows)
+      .or(fullWidth)
+      .or(sbContent)
+      .first()
+      .waitFor({ state: 'visible', timeout: 15000 });
+
+    // Settle time for animations / lazy column-width calculation
+    await page.waitForTimeout(800);
+
+    await page.screenshot({
+      path: path.join(screenshotsDir, `${story.name}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -87,9 +87,16 @@ for (const story of STORIES) {
 
     // For pinned-index stories, scroll the grid body right so the
     // index column is out of view — exposes #587 alignment bug.
+    // Grid is inside a Shadow DOM, so we pierce it via evaluate.
     if (story.name.includes('Pinned')) {
-      const viewport = page.locator('.ag-body-viewport');
-      await viewport.evaluate((el) => { el.scrollLeft = 200; });
+      await page.evaluate(() => {
+        const host = document.querySelector('div[ref]') ??
+                     document.querySelector('#storybook-root > div');
+        const shadow = host?.shadowRoot;
+        const vp = shadow?.querySelector('.ag-body-viewport') ??
+                   document.querySelector('.ag-body-viewport');
+        if (vp) vp.scrollLeft = 400;
+      });
       await page.waitForTimeout(400);
     }
 

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -57,6 +57,15 @@ const STORIES = [
   // Section D – mixed cross-issue scenarios
   { id: 'buckaroo-dfviewer-stylingissues--mixed-many-narrow-with-pinned',  name: 'D15_Mixed_ManyNarrow_WithPinned', issues: '#595 #587 #599' },
   { id: 'buckaroo-dfviewer-stylingissues--mixed-few-wide-with-pinned',     name: 'D16_Mixed_FewWide_WithPinned',    issues: '#587 baseline' },
+
+  // Section E – Python-computed ag_grid_specs.minWidth
+  { id: 'buckaroo-dfviewer-stylingissues--python-min-width-narrow-ints',   name: 'E17_PythonMinWidth_NarrowInts',   issues: 'minWidth lever' },
+  { id: 'buckaroo-dfviewer-stylingissues--python-min-width-long-headers',  name: 'E18_PythonMinWidth_LongHeaders',  issues: 'minWidth lever' },
+  { id: 'buckaroo-dfviewer-stylingissues--python-min-width-mixed-types',   name: 'E19_PythonMinWidth_MixedTypes',   issues: 'minWidth lever' },
+
+  // Section F – Histogram + narrow columns
+  { id: 'buckaroo-dfviewer-stylingissues--histogram-narrow-cols',              name: 'F20_Histogram_NarrowCols',            issues: 'histogram min' },
+  { id: 'buckaroo-dfviewer-stylingissues--histogram-narrow-cols-no-hist-min',  name: 'F21_Histogram_NarrowCols_NoHistMin',  issues: 'histogram crushed' },
 ];
 
 test.beforeAll(() => {

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -41,6 +41,7 @@ const STORIES = [
   { id: 'buckaroo-dfviewer-stylingissues--many-cols-short-hdr-long-data',  name: 'A6_ManyCols_ShortHdr_LongData',  issues: '#596' },
   { id: 'buckaroo-dfviewer-stylingissues--many-cols-long-hdr-short-data',  name: 'A7_ManyCols_LongHdr_ShortData',  issues: '#596' },
   { id: 'buckaroo-dfviewer-stylingissues--many-cols-long-hdr-long-data',   name: 'A8_ManyCols_LongHdr_LongData',   issues: '#596 worst-case' },
+  { id: 'buckaroo-dfviewer-stylingissues--many-cols-long-hdr-year-data',  name: 'A9_ManyCols_LongHdr_YearData',   issues: '#595 primary' },
 
   // Section B – large numbers / compact_number (#597, #602)
   // Note: compact_number stories may render raw values on pre-#597 commits.

--- a/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/styling-issues-screenshots.spec.ts
@@ -87,21 +87,10 @@ for (const story of STORIES) {
 
     // For pinned-index stories, scroll the grid body right so the
     // index column is out of view — exposes #587 alignment bug.
-    // Grid is inside a Shadow DOM, so we pierce it via evaluate.
+    // Playwright CSS locators pierce shadow DOM by default.
     if (story.name.includes('Pinned')) {
-      await page.evaluate(() => {
-        // Walk all elements looking for shadow roots containing AG-Grid
-        const allEls = document.querySelectorAll('*');
-        for (const el of allEls) {
-          if (el.shadowRoot) {
-            const vp = el.shadowRoot.querySelector('.ag-body-viewport');
-            if (vp) { vp.scrollLeft = 400; return; }
-          }
-        }
-        // Fallback: no shadow DOM
-        const vp = document.querySelector('.ag-body-viewport');
-        if (vp) vp.scrollLeft = 400;
-      });
+      const viewport = page.locator('.ag-body-viewport').first();
+      await viewport.evaluate((el) => { el.scrollLeft = el.scrollWidth; });
       await page.waitForTimeout(400);
     }
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -246,6 +246,7 @@ export function DFViewerInfiniteInner({
         return {
             sortable: true,
             type: "rightAligned",
+            minWidth: 80,
             cellStyle: (params: CellClassParams) => {
                 const colDef = params.column.getColDef();
                 const field = colDef.field;

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -246,7 +246,6 @@ export function DFViewerInfiniteInner({
         return {
             sortable: true,
             type: "rightAligned",
-            minWidth: 80,
             cellStyle: (params: CellClassParams) => {
                 const colDef = params.column.getColDef();
                 const field = colDef.field;

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -304,7 +304,7 @@ export function DFViewerInfiniteInner({
         return {
         ...outerGridOptions(setActiveCol, df_viewer_config.extra_grid_config),
         domLayout:  hs.domLayout,
-        autoSizeStrategy: getAutoSize(styledColumns.length),
+        autoSizeStrategy: df_viewer_config.extra_grid_config?.autoSizeStrategy || getAutoSize(styledColumns.length),
         onFirstDataRendered: (_params) => {
             // Grid finished rendering
         },

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -181,7 +181,6 @@ describe("testing utility functions in gridUtils ", () => {
     it("should return fitCellContents for positive columns", () => {
       const result = getAutoSize(5);
       expect(result.type).toBe("fitCellContents");
-      expect(result).toHaveProperty("defaultMinWidth", 80);
     });
   });
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -547,8 +547,7 @@ export const getAutoSize = (
     }
     return {
         type: "fitCellContents",
-        defaultMinWidth: 80,
-    } as SizeColumnsToContentStrategy & { defaultMinWidth: number };
+    };
 };
 
 

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -180,12 +180,13 @@ function makeStoryComponent(
   config: DFViewerConfig,
   data: DFRow[],
   summary: DFRow[] = [],
+  width = 800,
 ) {
   const data_wrapper = { data_type: "Raw" as const, data, length: data.length };
   return function StoryInner() {
     return (
       <ShadowDomWrapper>
-        <div style={{ height: 500, width: 800 }}>
+        <div style={{ height: 500, width }}>
           <DFViewerInfinite
             data_wrapper={data_wrapper}
             df_viewer_config={config}
@@ -364,7 +365,7 @@ const pinnedFewCfg = genConfig(10, "long", "short", true);
 const pinnedFewData = genData(10, "short");
 const pinnedFewSummary = genSummary(10, "short");
 
-const PinnedIndexFewInner = makeStoryComponent(pinnedFewCfg, pinnedFewData, pinnedFewSummary);
+const PinnedIndexFewInner = makeStoryComponent(pinnedFewCfg, pinnedFewData, pinnedFewSummary, 400);
 /** 10 long-header cols + pinned summary stats + left index. Tests #587 alignment. */
 export const PinnedIndex_FewCols: Story = {
   render: () => <PinnedIndexFewInner />,
@@ -374,7 +375,7 @@ const pinnedManyCfg = genConfig(20, "long", "short", true);
 const pinnedManyData = genData(20, "short");
 const pinnedManySummary = genSummary(20, "short");
 
-const PinnedIndexManyInner = makeStoryComponent(pinnedManyCfg, pinnedManyData, pinnedManySummary);
+const PinnedIndexManyInner = makeStoryComponent(pinnedManyCfg, pinnedManyData, pinnedManySummary, 400);
 /** 20 long-header cols + pinned summary stats. #587 alignment under width contention. */
 export const PinnedIndex_ManyCols: Story = {
   render: () => <PinnedIndexManyInner />,
@@ -387,7 +388,7 @@ const mixedManyNarrowData = genData(20, "short");
 const mixedManyNarrowSummary = genSummary(20, "short");
 
 const MixedManyNarrowInner = makeStoryComponent(
-  mixedManyNarrowCfg, mixedManyNarrowData, mixedManyNarrowSummary,
+  mixedManyNarrowCfg, mixedManyNarrowData, mixedManyNarrowSummary, 400,
 );
 /** 20 narrow cols + pinned rows. Cross-issue: #595 + #587 + #599. */
 export const Mixed_ManyNarrow_WithPinned: Story = {
@@ -399,7 +400,7 @@ const mixedFewWideData = genData(5, "long");
 const mixedFewWideSummary = genSummary(5, "long");
 
 const MixedFewWideInner = makeStoryComponent(
-  mixedFewWideCfg, mixedFewWideData, mixedFewWideSummary,
+  mixedFewWideCfg, mixedFewWideData, mixedFewWideSummary, 400,
 );
 /** 5 wide cols + pinned rows. #587 baseline (should look fine). */
 export const Mixed_FewWide_WithPinned: Story = {

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -158,6 +158,7 @@ function genConfig(
     col_name: `col_${i}`,
     header_name: headers[i % headers.length],
     displayer_args: displayer_args(),
+    ...(withPinned ? { ag_grid_specs: { minWidth: 120 } } : {}),
   }));
 
   const pinned_rows: PinnedRowConfig[] = withPinned

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -306,16 +306,24 @@ export const ManyCols_LongHdr_LongData: Story = {
   render: () => <ManyLongLongInner />,
 };
 
-const ManyLongYearInner = makeStoryComponent(
-  genConfig(25, "long", "long"),
-  genData(25, "long"),
-  [],
-  400,
+// #595 repro: force narrow columns so data values show "..."
+const narrowColConfig: DFViewerConfig = {
+  column_config: Array.from({ length: 15 }, (_, i) => ({
+    col_name: `col_${i}`,
+    header_name: LONG_HEADER_NAMES[i],
+    displayer_args: { displayer: "integer" as const, min_digits: 1, max_digits: 7 },
+    ag_grid_specs: { maxWidth: 50 },
+  })),
+  left_col_configs: [INDEX_COL],
+  pinned_rows: [],
+};
+const NarrowColInner = makeStoryComponent(
+  narrowColConfig,
+  genData(15, "long"),
 );
-/** 25 cols, long headers, 6-7 digit values in 400px. #595 repro —
- *  fitCellContents crushes columns, data values show "...". */
+/** 15 cols capped at 50px with 7-digit data. #595 repro — values show "...". */
 export const ManyCols_LongHdr_YearData: Story = {
-  render: () => <ManyLongYearInner />,
+  render: () => <NarrowColInner />,
 };
 
 // ── Section B: Large numbers / compact (#597, #602) ─────────────────────────

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -360,29 +360,29 @@ export const ClusteredBillions_Compact: Story = {
 
 // ── Section C: Pinned row / index (#587) ────────────────────────────────────
 
-const pinnedFewCfg = genConfig(5, "short", "short", true);
-const pinnedFewData = genData(5, "short");
-const pinnedFewSummary = genSummary(5, "short");
+const pinnedFewCfg = genConfig(10, "long", "short", true);
+const pinnedFewData = genData(10, "short");
+const pinnedFewSummary = genSummary(10, "short");
 
 const PinnedIndexFewInner = makeStoryComponent(pinnedFewCfg, pinnedFewData, pinnedFewSummary);
-/** 5 numeric cols + pinned summary stats + left index. Tests #587 alignment. */
+/** 10 long-header cols + pinned summary stats + left index. Tests #587 alignment. */
 export const PinnedIndex_FewCols: Story = {
   render: () => <PinnedIndexFewInner />,
 };
 
-const pinnedManyCfg = genConfig(15, "short", "short", true);
-const pinnedManyData = genData(15, "short");
-const pinnedManySummary = genSummary(15, "short");
+const pinnedManyCfg = genConfig(20, "long", "short", true);
+const pinnedManyData = genData(20, "short");
+const pinnedManySummary = genSummary(20, "short");
 
 const PinnedIndexManyInner = makeStoryComponent(pinnedManyCfg, pinnedManyData, pinnedManySummary);
-/** 15 numeric cols + pinned summary stats. #587 alignment under width contention. */
+/** 20 long-header cols + pinned summary stats. #587 alignment under width contention. */
 export const PinnedIndex_ManyCols: Story = {
   render: () => <PinnedIndexManyInner />,
 };
 
 // ── Section D: Mixed scenarios ───────────────────────────────────────────────
 
-const mixedManyNarrowCfg = genConfig(20, "short", "short", true);
+const mixedManyNarrowCfg = genConfig(20, "long", "short", true);
 const mixedManyNarrowData = genData(20, "short");
 const mixedManyNarrowSummary = genSummary(20, "short");
 

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -306,11 +306,11 @@ export const ManyCols_LongHdr_LongData: Story = {
   render: () => <ManyLongLongInner />,
 };
 
-// #595 repro: fitGridWidth with 15 cols in 800px → ~53px each → "..."
+// #595 repro: fitGridWidth with 25 cols in 800px → ~32px each → "..."
 // Without defaultColDef.minWidth (baseline) → columns crushed → "..."
 // With defaultColDef.minWidth: 80 (fix) → columns at 80px → scrollbar + readable values
 const narrowColConfig: DFViewerConfig = {
-  column_config: Array.from({ length: 15 }, (_, i) => ({
+  column_config: Array.from({ length: 25 }, (_, i) => ({
     col_name: `col_${i}`,
     header_name: LONG_HEADER_NAMES[i],
     displayer_args: { displayer: "integer" as const, min_digits: 1, max_digits: 4 },
@@ -321,9 +321,9 @@ const narrowColConfig: DFViewerConfig = {
 };
 const NarrowColInner = makeStoryComponent(
   narrowColConfig,
-  genData(15, "year"),
+  genData(25, "year"),
 );
-/** 15 cols with fitGridWidth. #595 repro — values show "..." without minWidth fix. */
+/** 25 cols with fitGridWidth in 800px. #595 repro — values show "..." without minWidth fix. */
 export const ManyCols_LongHdr_YearData: Story = {
   render: () => <NarrowColInner />,
 };

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -552,14 +552,11 @@ const histNarrowSummary: DFRow[] = (() => {
   return [
     row("dtype", () => "int64"),
     row("histogram", (i) => {
-      // Fake histogram bins — 10 values per column
-      return Array.from({ length: 10 }, (_, j) => ((i * 7 + j * 3) % 20) + 1);
-    }),
-    row("histogram_bins", (i) => {
-      return Array.from({ length: 10 }, (_, j) => j * 10 + i);
-    }),
-    row("histogram_log_bins", (i) => {
-      return Array.from({ length: 10 }, (_, j) => j * 10 + i);
+      // HistogramBar[] — must have {name, population} for the renderer
+      return Array.from({ length: 8 }, (_, j) => ({
+        name: `${j * 12 + i}-${(j + 1) * 12 + i}`,
+        population: ((i * 7 + j * 3) % 20) + 2,
+      }));
     }),
   ];
 })();

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -307,21 +307,24 @@ export const ManyCols_LongHdr_LongData: Story = {
 };
 
 // #595 repro: force narrow columns so data values show "..."
+// width: 40 + suppressAutoSize prevents fitCellContents from expanding.
+// Without defaultColDef.minWidth (baseline) → columns stay 40px → "..."
+// With defaultColDef.minWidth: 80 (fix) → columns forced to 80px → values visible
 const narrowColConfig: DFViewerConfig = {
   column_config: Array.from({ length: 15 }, (_, i) => ({
     col_name: `col_${i}`,
     header_name: LONG_HEADER_NAMES[i],
-    displayer_args: { displayer: "integer" as const, min_digits: 1, max_digits: 7 },
-    ag_grid_specs: { maxWidth: 50 },
+    displayer_args: { displayer: "integer" as const, min_digits: 1, max_digits: 4 },
+    ag_grid_specs: { width: 40, suppressAutoSize: true },
   })),
   left_col_configs: [INDEX_COL],
   pinned_rows: [],
 };
 const NarrowColInner = makeStoryComponent(
   narrowColConfig,
-  genData(15, "long"),
+  genData(15, "year"),
 );
-/** 15 cols capped at 50px with 7-digit data. #595 repro — values show "...". */
+/** 15 cols with initial 40px width + suppressAutoSize. #595 repro — "..." without minWidth fix. */
 export const ManyCols_LongHdr_YearData: Story = {
   render: () => <NarrowColInner />,
 };

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -1,0 +1,407 @@
+/**
+ * Stories to reproduce styling / column-width issues:
+ *   #587 – pinned-row index alignment
+ *   #595 / #596 / #599 / #600 – column width contention (few vs many, short vs long headers/data)
+ *   #597 – compact_number displayer for large values
+ *   #602 – compact_number precision loss on clustered billion-scale values
+ *
+ * Full 2×2×2 combinatorial matrix for width stories, plus large-number and pinned-row scenarios.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
+import { ShadowDomWrapper } from "./StoryUtils";
+import {
+  DFViewerConfig,
+  NormalColumnConfig,
+  PinnedRowConfig,
+} from "../components/DFViewerParts/DFWhole";
+
+type DFRow = Record<string, any>;
+
+// ── Column header name pools ────────────────────────────────────────────────
+
+const SHORT_HEADER_NAMES = [
+  "a","b","c","d","e","f","g","h","i","j","k","l","m",
+  "n","o","p","q","r","s","t","u","v","w","x","y",
+];
+
+const LONG_HEADER_NAMES = [
+  "revenue_total","customer_count","margin_pct_adj","transaction_vol",
+  "active_users_n","retention_rate","avg_order_val","monthly_recur_r",
+  "churn_pct_adj","lifetime_value","gross_margin_rt","net_promoter_sc",
+  "conv_rate_pct","acq_cost_avg","rev_per_user_q","visits_monthly",
+  "bounce_rate_pc","avg_session_s","page_views_tot","email_open_rt",
+  "click_thru_pct","refund_rate_pc","support_tkts","upsell_rev_q",
+  "referral_cnt",
+];
+
+const INDEX_COL: NormalColumnConfig = {
+  col_name: "index",
+  header_name: "index",
+  displayer_args: { displayer: "obj" },
+};
+
+// ── Data generators ─────────────────────────────────────────────────────────
+
+const ROW_COUNT = 20;
+
+type DataStyle = "short" | "long" | "large" | "clustered";
+type HeaderStyle = "short" | "long";
+
+function makeShortVal(row: number, col: number): number {
+  return ((row * 7 + col * 3 + 1) % 99) + 1; // 1–99
+}
+
+function makeLongVal(row: number, col: number): number {
+  return 100_000 + ((row * 1_234_567 + col * 234_567) % 9_900_000); // 100k–9.9M
+}
+
+function makeLargeVal(row: number, col: number): number {
+  // 3M – 5.7B spread
+  return 3_000_000 + ((row * 987_654_321 + col * 123_456_789) % 5_697_000_000);
+}
+
+function makeClusteredVal(row: number, col: number): number {
+  // 5.60B – 5.68B (tight cluster to expose compact_number precision loss)
+  return 5_600_000_000 + ((row * 12_345 + col * 5_678) % 80_000_000);
+}
+
+function genData(count: number, dataStyle: DataStyle): DFRow[] {
+  const valFn =
+    dataStyle === "short" ? makeShortVal :
+    dataStyle === "long"  ? makeLongVal  :
+    dataStyle === "large" ? makeLargeVal :
+                            makeClusteredVal;
+
+  return Array.from({ length: ROW_COUNT }, (_, row) => {
+    const r: DFRow = { index: row };
+    for (let col = 0; col < count; col++) {
+      r[`col_${col}`] = valFn(row, col);
+    }
+    return r;
+  });
+}
+
+function genSummary(count: number, dataStyle: DataStyle): DFRow[] {
+  const colKeys = Array.from({ length: count }, (_, i) => `col_${i}`);
+  const isFloat = dataStyle === "large" || dataStyle === "clustered";
+  const dtype = isFloat ? "float64" : "int64";
+
+  const row = (key: string, valFn: (i: number) => number | string): DFRow => {
+    const r: DFRow = { index: key };
+    colKeys.forEach((k, i) => { r[k] = valFn(i); });
+    return r;
+  };
+
+  if (dataStyle === "short") {
+    return [
+      row("dtype",         () => dtype),
+      row("non_null_count",() => ROW_COUNT),
+      row("mean",          (i) => 40 + i * 3),
+      row("std",           (i) => 20 + i),
+      row("min",           (i) => 1 + i),
+      row("max",           (i) => 90 + i),
+    ];
+  } else if (dataStyle === "long") {
+    return [
+      row("dtype",         () => dtype),
+      row("non_null_count",() => ROW_COUNT),
+      row("mean",          (i) => 5_000_000 + i * 100_000),
+      row("std",           (i) => 2_000_000 + i * 50_000),
+      row("min",           (i) => 100_000  + i * 10_000),
+      row("max",           (i) => 9_800_000 + i * 10_000),
+    ];
+  } else if (dataStyle === "large") {
+    return [
+      row("dtype",         () => dtype),
+      row("non_null_count",() => ROW_COUNT),
+      row("mean",          (i) => 2_000_000_000 + i * 100_000_000),
+      row("std",           ()  => 1_000_000_000),
+      row("min",           (i) => 3_000_000 + i * 1_000_000),
+      row("max",           ()  => 5_700_000_000),
+    ];
+  } else {
+    return [
+      row("dtype",         () => dtype),
+      row("non_null_count",() => ROW_COUNT),
+      row("mean",          () => 5_640_000_000),
+      row("std",           () => 20_000_000),
+      row("min",           () => 5_600_000_000),
+      row("max",           () => 5_680_000_000),
+    ];
+  }
+}
+
+// ── Config builders ─────────────────────────────────────────────────────────
+
+function genConfig(
+  count: number,
+  headerStyle: HeaderStyle,
+  dataStyle: DataStyle,
+  withPinned = false,
+): DFViewerConfig {
+  const headers =
+    headerStyle === "short" ? SHORT_HEADER_NAMES : LONG_HEADER_NAMES;
+
+  const displayer_args = (): NormalColumnConfig["displayer_args"] => {
+    if (dataStyle === "large" || dataStyle === "clustered") {
+      return { displayer: "float", min_fraction_digits: 2, max_fraction_digits: 2 };
+    }
+    return {
+      displayer: "integer",
+      min_digits: 1,
+      max_digits: dataStyle === "short" ? 2 : 7,
+    };
+  };
+
+  const column_config: NormalColumnConfig[] = Array.from({ length: count }, (_, i) => ({
+    col_name: `col_${i}`,
+    header_name: headers[i % headers.length],
+    displayer_args: displayer_args(),
+  }));
+
+  const pinned_rows: PinnedRowConfig[] = withPinned
+    ? [
+        { primary_key_val: "dtype",         displayer_args: { displayer: "obj" } },
+        { primary_key_val: "non_null_count", displayer_args: { displayer: "inherit" } },
+        { primary_key_val: "mean",           displayer_args: { displayer: "inherit" } },
+        { primary_key_val: "std",            displayer_args: { displayer: "inherit" } },
+        { primary_key_val: "min",            displayer_args: { displayer: "inherit" } },
+        { primary_key_val: "max",            displayer_args: { displayer: "inherit" } },
+      ]
+    : [];
+
+  return { column_config, left_col_configs: [INDEX_COL], pinned_rows };
+}
+
+// ── Story factory ───────────────────────────────────────────────────────────
+
+function makeStoryComponent(
+  config: DFViewerConfig,
+  data: DFRow[],
+  summary: DFRow[] = [],
+) {
+  const data_wrapper = { data_type: "Raw" as const, data, length: data.length };
+  return function StoryInner() {
+    return (
+      <ShadowDomWrapper>
+        <div style={{ height: 500, width: 800 }}>
+          <DFViewerInfinite
+            data_wrapper={data_wrapper}
+            df_viewer_config={config}
+            summary_stats_data={summary}
+            activeCol={["col_0", "col_0"]}
+            setActiveCol={() => {}}
+            outside_df_params={{}}
+          />
+        </div>
+      </ShadowDomWrapper>
+    );
+  };
+}
+
+// ── Meta ────────────────────────────────────────────────────────────────────
+
+// Placeholder component; all stories use render() below
+const _Placeholder = () => null;
+
+const meta = {
+  title: "Buckaroo/DFViewer/StylingIssues",
+  component: _Placeholder,
+  parameters: { layout: "centered" },
+} satisfies Meta<typeof _Placeholder>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// ── Section A: Width / contention (#595, #596, #599, #600) ─────────────────
+// Full 2×2×2 = 8 combinations of: col count × header length × data length
+
+const FewShortShortInner = makeStoryComponent(
+  genConfig(5, "short", "short"),
+  genData(5, "short"),
+);
+/** Baseline – 5 cols, 1-char headers, 1-2 digit values. Should look fine. (#599) */
+export const FewCols_ShortHdr_ShortData: Story = {
+  render: () => <FewShortShortInner />,
+};
+
+const FewShortLongInner = makeStoryComponent(
+  genConfig(5, "short", "long"),
+  genData(5, "long"),
+);
+/** 5 cols, 1-char headers, 6-7 digit values. Data drives width, no contention. */
+export const FewCols_ShortHdr_LongData: Story = {
+  render: () => <FewShortLongInner />,
+};
+
+const FewLongShortInner = makeStoryComponent(
+  genConfig(5, "long", "short"),
+  genData(5, "short"),
+);
+/** 5 cols, 12-18 char headers, 1-2 digit values. Header wider than data. */
+export const FewCols_LongHdr_ShortData: Story = {
+  render: () => <FewLongShortInner />,
+};
+
+const FewLongLongInner = makeStoryComponent(
+  genConfig(5, "long", "long"),
+  genData(5, "long"),
+);
+/** 5 cols, long headers, long data. Both are wide; no contention at 5 cols. */
+export const FewCols_LongHdr_LongData: Story = {
+  render: () => <FewLongLongInner />,
+};
+
+const ManyShortShortInner = makeStoryComponent(
+  genConfig(25, "short", "short"),
+  genData(25, "short"),
+);
+/** 25 cols, 1-char headers, 1-2 digit values. Primary bug case (#595/#599). */
+export const ManyCols_ShortHdr_ShortData: Story = {
+  render: () => <ManyShortShortInner />,
+};
+
+const ManyShortLongInner = makeStoryComponent(
+  genConfig(25, "short", "long"),
+  genData(25, "long"),
+);
+/** 25 cols, 1-char headers, 6-7 digit values. Data wants space (#596). */
+export const ManyCols_ShortHdr_LongData: Story = {
+  render: () => <ManyShortLongInner />,
+};
+
+const ManyLongShortInner = makeStoryComponent(
+  genConfig(25, "long", "short"),
+  genData(25, "short"),
+);
+/** 25 cols, 12-18 char headers, 1-2 digit values. Headers want space (#596). */
+export const ManyCols_LongHdr_ShortData: Story = {
+  render: () => <ManyLongShortInner />,
+};
+
+const ManyLongLongInner = makeStoryComponent(
+  genConfig(25, "long", "long"),
+  genData(25, "long"),
+);
+/** 25 cols, long headers, long data. Worst-case contention (#596). */
+export const ManyCols_LongHdr_LongData: Story = {
+  render: () => <ManyLongLongInner />,
+};
+
+// ── Section B: Large numbers / compact (#597, #602) ─────────────────────────
+
+const largeFloatConfig: DFViewerConfig = {
+  column_config: Array.from({ length: 5 }, (_, i) => ({
+    col_name: `col_${i}`,
+    header_name: SHORT_HEADER_NAMES[i],
+    displayer_args: { displayer: "float" as const, min_fraction_digits: 2, max_fraction_digits: 2 },
+  })),
+  left_col_configs: [INDEX_COL],
+  pinned_rows: [],
+};
+const largeData = genData(5, "large");
+
+const LargeNumbersFloatInner = makeStoryComponent(largeFloatConfig, largeData);
+/** 5 cols, values 3M–5.7B, float displayer. Shows why compact is needed (#597). */
+export const LargeNumbers_Float: Story = {
+  render: () => <LargeNumbersFloatInner />,
+};
+
+const largeCompactConfig: DFViewerConfig = {
+  column_config: Array.from({ length: 5 }, (_, i) => ({
+    col_name: `col_${i}`,
+    header_name: SHORT_HEADER_NAMES[i],
+    displayer_args: { displayer: "compact_number" as const },
+  })),
+  left_col_configs: [INDEX_COL],
+  pinned_rows: [],
+};
+
+const LargeNumbersCompactInner = makeStoryComponent(largeCompactConfig, largeData);
+/** Same data as LargeNumbers_Float but using compact_number displayer (#597 fix). */
+export const LargeNumbers_Compact: Story = {
+  render: () => <LargeNumbersCompactInner />,
+};
+
+const clusteredData = genData(5, "clustered");
+
+const clusteredFloatConfig: DFViewerConfig = {
+  column_config: Array.from({ length: 5 }, (_, i) => ({
+    col_name: `col_${i}`,
+    header_name: SHORT_HEADER_NAMES[i],
+    displayer_args: { displayer: "float" as const, min_fraction_digits: 2, max_fraction_digits: 2 },
+  })),
+  left_col_configs: [INDEX_COL],
+  pinned_rows: [],
+};
+
+const ClusteredBillionsFloatInner = makeStoryComponent(clusteredFloatConfig, clusteredData);
+/** 5 cols, values tightly clustered 5.60B–5.68B, float displayer (#602 baseline). */
+export const ClusteredBillions_Float: Story = {
+  render: () => <ClusteredBillionsFloatInner />,
+};
+
+const clusteredCompactConfig: DFViewerConfig = {
+  column_config: Array.from({ length: 5 }, (_, i) => ({
+    col_name: `col_${i}`,
+    header_name: SHORT_HEADER_NAMES[i],
+    displayer_args: { displayer: "compact_number" as const },
+  })),
+  left_col_configs: [INDEX_COL],
+  pinned_rows: [],
+};
+
+const ClusteredBillionsCompactInner = makeStoryComponent(clusteredCompactConfig, clusteredData);
+/** Same clustered data with compact_number – exposes precision loss (#602). */
+export const ClusteredBillions_Compact: Story = {
+  render: () => <ClusteredBillionsCompactInner />,
+};
+
+// ── Section C: Pinned row / index (#587) ────────────────────────────────────
+
+const pinnedFewCfg = genConfig(5, "short", "short", true);
+const pinnedFewData = genData(5, "short");
+const pinnedFewSummary = genSummary(5, "short");
+
+const PinnedIndexFewInner = makeStoryComponent(pinnedFewCfg, pinnedFewData, pinnedFewSummary);
+/** 5 numeric cols + pinned summary stats + left index. Tests #587 alignment. */
+export const PinnedIndex_FewCols: Story = {
+  render: () => <PinnedIndexFewInner />,
+};
+
+const pinnedManyCfg = genConfig(15, "short", "short", true);
+const pinnedManyData = genData(15, "short");
+const pinnedManySummary = genSummary(15, "short");
+
+const PinnedIndexManyInner = makeStoryComponent(pinnedManyCfg, pinnedManyData, pinnedManySummary);
+/** 15 numeric cols + pinned summary stats. #587 alignment under width contention. */
+export const PinnedIndex_ManyCols: Story = {
+  render: () => <PinnedIndexManyInner />,
+};
+
+// ── Section D: Mixed scenarios ───────────────────────────────────────────────
+
+const mixedManyNarrowCfg = genConfig(20, "short", "short", true);
+const mixedManyNarrowData = genData(20, "short");
+const mixedManyNarrowSummary = genSummary(20, "short");
+
+const MixedManyNarrowInner = makeStoryComponent(
+  mixedManyNarrowCfg, mixedManyNarrowData, mixedManyNarrowSummary,
+);
+/** 20 narrow cols + pinned rows. Cross-issue: #595 + #587 + #599. */
+export const Mixed_ManyNarrow_WithPinned: Story = {
+  render: () => <MixedManyNarrowInner />,
+};
+
+const mixedFewWideCfg = genConfig(5, "long", "long", true);
+const mixedFewWideData = genData(5, "long");
+const mixedFewWideSummary = genSummary(5, "long");
+
+const MixedFewWideInner = makeStoryComponent(
+  mixedFewWideCfg, mixedFewWideData, mixedFewWideSummary,
+);
+/** 5 wide cols + pinned rows. #587 baseline (should look fine). */
+export const Mixed_FewWide_WithPinned: Story = {
+  render: () => <MixedFewWideInner />,
+};

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -307,11 +307,13 @@ export const ManyCols_LongHdr_LongData: Story = {
 };
 
 const ManyLongYearInner = makeStoryComponent(
-  genConfig(15, "long", "year"),
-  genData(15, "year"),
+  genConfig(25, "long", "long"),
+  genData(25, "long"),
+  [],
+  400,
 );
-/** 15 cols, long headers, 4-digit year values. #595 primary repro — narrow
- *  content causes fitCellContents to crush columns, truncating headers. */
+/** 25 cols, long headers, 6-7 digit values in 400px. #595 repro —
+ *  fitCellContents crushes columns, data values show "...". */
 export const ManyCols_LongHdr_YearData: Story = {
   render: () => <ManyLongYearInner />,
 };

--- a/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StylingIssues.stories.tsx
@@ -306,25 +306,24 @@ export const ManyCols_LongHdr_LongData: Story = {
   render: () => <ManyLongLongInner />,
 };
 
-// #595 repro: force narrow columns so data values show "..."
-// width: 40 + suppressAutoSize prevents fitCellContents from expanding.
-// Without defaultColDef.minWidth (baseline) → columns stay 40px → "..."
-// With defaultColDef.minWidth: 80 (fix) → columns forced to 80px → values visible
+// #595 repro: fitGridWidth with 15 cols in 800px → ~53px each → "..."
+// Without defaultColDef.minWidth (baseline) → columns crushed → "..."
+// With defaultColDef.minWidth: 80 (fix) → columns at 80px → scrollbar + readable values
 const narrowColConfig: DFViewerConfig = {
   column_config: Array.from({ length: 15 }, (_, i) => ({
     col_name: `col_${i}`,
     header_name: LONG_HEADER_NAMES[i],
     displayer_args: { displayer: "integer" as const, min_digits: 1, max_digits: 4 },
-    ag_grid_specs: { width: 40, suppressAutoSize: true },
   })),
   left_col_configs: [INDEX_COL],
   pinned_rows: [],
+  extra_grid_config: { autoSizeStrategy: { type: "fitGridWidth" as const } },
 };
 const NarrowColInner = makeStoryComponent(
   narrowColConfig,
   genData(15, "year"),
 );
-/** 15 cols with initial 40px width + suppressAutoSize. #595 repro — "..." without minWidth fix. */
+/** 15 cols with fitGridWidth. #595 repro — values show "..." without minWidth fix. */
 export const ManyCols_LongHdr_YearData: Story = {
   render: () => <NarrowColInner />,
 };

--- a/scripts/download_styling_screenshots.sh
+++ b/scripts/download_styling_screenshots.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Download before/after styling screenshots from a CI run.
+#
+# Usage:
+#   ./scripts/download_styling_screenshots.sh [run-id]
+#
+# If run-id is omitted, uses the latest successful run of checks.yml
+# on the current branch.
+
+set -e
+
+REPO=$(gh repo view --json nameWithOwner -q '.nameWithOwner')
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+RUN_ID=${1:-}
+
+if [ -z "$RUN_ID" ]; then
+  echo "Looking up latest successful run on branch '$BRANCH'..."
+  RUN_ID=$(gh run list \
+    --repo "$REPO" \
+    --branch "$BRANCH" \
+    --workflow checks.yml \
+    --status success \
+    --limit 1 \
+    --json databaseId \
+    -q '.[0].databaseId')
+
+  if [ -z "$RUN_ID" ]; then
+    echo "No successful run found for branch '$BRANCH'. Try passing a run-id directly."
+    exit 1
+  fi
+fi
+
+echo "Downloading screenshots from run $RUN_ID (repo: $REPO)"
+
+OUT_DIR="packages/buckaroo-js-core/screenshots"
+mkdir -p "$OUT_DIR"
+
+gh run download "$RUN_ID" \
+  --repo "$REPO" \
+  --name styling-screenshots-before \
+  --dir "$OUT_DIR/before"
+
+gh run download "$RUN_ID" \
+  --repo "$REPO" \
+  --name styling-screenshots-after \
+  --dir "$OUT_DIR/after"
+
+BEFORE=$(ls -1 "$OUT_DIR/before"/*.png 2>/dev/null | wc -l | tr -d ' ')
+AFTER=$(ls -1 "$OUT_DIR/after"/*.png 2>/dev/null | wc -l | tr -d ' ')
+echo "Downloaded: $BEFORE before screenshots, $AFTER after screenshots"
+echo ""
+echo "Next step:"
+echo "  python scripts/gen_screenshot_compare.py && open packages/buckaroo-js-core/screenshots/compare.html"

--- a/scripts/gen_screenshot_compare.py
+++ b/scripts/gen_screenshot_compare.py
@@ -180,12 +180,12 @@ document.addEventListener('keydown', (e) => {{ if (e.key === 'Escape') closeLigh
 if __name__ == "__main__":
     if not BEFORE_DIR.exists() and not AFTER_DIR.exists():
         print(
-            f"No screenshots found.\n"
-            f"Run:\n"
-            f"  ./scripts/download_styling_screenshots.sh\n"
-            f"or capture locally with:\n"
-            f"  cd packages/buckaroo-js-core && "
-            f"SCREENSHOT_DIR=screenshots/after npx playwright test pw-tests/styling-issues-screenshots.spec.ts",
+            "No screenshots found.\n"
+            "Run:\n"
+            "  ./scripts/download_styling_screenshots.sh\n"
+            "or capture locally with:\n"
+            "  cd packages/buckaroo-js-core && "
+            "SCREENSHOT_DIR=screenshots/after npx playwright test pw-tests/styling-issues-screenshots.spec.ts",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/scripts/gen_screenshot_compare.py
+++ b/scripts/gen_screenshot_compare.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Generate a self-contained before/after screenshot comparison HTML page.
+
+Usage:
+    python scripts/gen_screenshot_compare.py
+
+Reads screenshots from:
+    packages/buckaroo-js-core/screenshots/before/*.png
+    packages/buckaroo-js-core/screenshots/after/*.png
+
+Writes:
+    packages/buckaroo-js-core/screenshots/compare.html
+"""
+import base64
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).parent
+REPO_ROOT = SCRIPT_DIR.parent
+SCREENSHOTS_DIR = REPO_ROOT / "packages" / "buckaroo-js-core" / "screenshots"
+BEFORE_DIR = SCREENSHOTS_DIR / "before"
+AFTER_DIR = SCREENSHOTS_DIR / "after"
+OUTPUT = SCREENSHOTS_DIR / "compare.html"
+
+# Stories in display order, with section headings and issue labels
+STORIES = [
+    # Section A
+    ("A – Width / Contention  (#595, #596, #599, #600)", [
+        ("A1_FewCols_ShortHdr_ShortData",  "#599 baseline"),
+        ("A2_FewCols_ShortHdr_LongData",   "few cols, long data"),
+        ("A3_FewCols_LongHdr_ShortData",   "few cols, long headers"),
+        ("A4_FewCols_LongHdr_LongData",    "few cols, both wide"),
+        ("A5_ManyCols_ShortHdr_ShortData", "#595 #599 primary bug"),
+        ("A6_ManyCols_ShortHdr_LongData",  "#596 data contention"),
+        ("A7_ManyCols_LongHdr_ShortData",  "#596 header contention"),
+        ("A8_ManyCols_LongHdr_LongData",   "#596 worst case"),
+    ]),
+    # Section B
+    ("B – Large Numbers / compact_number  (#597, #602)", [
+        ("B9_LargeNumbers_Float",         "#597 – float displayer (before)"),
+        ("B10_LargeNumbers_Compact",      "#597 – compact_number (after)"),
+        ("B11_ClusteredBillions_Float",   "#602 – clustered, float"),
+        ("B12_ClusteredBillions_Compact", "#602 – clustered, compact (precision loss)"),
+    ]),
+    # Section C
+    ("C – Pinned Row / Index Alignment  (#587)", [
+        ("C13_PinnedIndex_FewCols",  "#587 – 5 cols"),
+        ("C14_PinnedIndex_ManyCols", "#587 – 15 cols"),
+    ]),
+    # Section D
+    ("D – Mixed Scenarios", [
+        ("D15_Mixed_ManyNarrow_WithPinned", "#595 #587 #599"),
+        ("D16_Mixed_FewWide_WithPinned",    "#587 baseline"),
+    ]),
+]
+
+
+def img_data_uri(path: Path) -> str | None:
+    if not path.exists():
+        return None
+    b64 = base64.b64encode(path.read_bytes()).decode()
+    return f"data:image/png;base64,{b64}"
+
+
+def build_html() -> str:
+    sections_html = []
+
+    for section_title, stories in STORIES:
+        cards_html = []
+        for name, label in stories:
+            before_uri = img_data_uri(BEFORE_DIR / f"{name}.png")
+            after_uri = img_data_uri(AFTER_DIR / f"{name}.png")
+
+            def img_block(uri: str | None, slot: str) -> str:
+                if uri is None:
+                    return f'<div class="missing">{slot}: screenshot not found</div>'
+                return (
+                    f'<div class="slot-label">{slot}</div>'
+                    f'<img src="{uri}" alt="{slot} – {name}"'
+                    f' onclick="openLightbox(this.src, \'{name} [{slot}]\')" />'
+                )
+
+            cards_html.append(f"""
+<div class="card">
+  <h3>{name}</h3>
+  <div class="label">{label}</div>
+  {img_block(before_uri, "before")}
+  {img_block(after_uri, "after")}
+</div>""")
+
+        sections_html.append(f"""
+<section>
+  <h2>{section_title}</h2>
+  <div class="grid">{''.join(cards_html)}</div>
+</section>""")
+
+    sections = "\n".join(sections_html)
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Styling Issues: Before / After Screenshots</title>
+<style>
+  * {{ box-sizing: border-box; margin: 0; padding: 0; }}
+  body {{ font-family: system-ui, sans-serif; background: #f0f0f0; color: #222; padding: 24px; }}
+  h1   {{ font-size: 1.5rem; margin-bottom: 24px; }}
+  h2   {{ font-size: 1.1rem; color: #444; margin: 32px 0 12px; border-bottom: 2px solid #ccc; padding-bottom: 6px; }}
+  h3   {{ font-size: 0.85rem; font-weight: 600; margin-bottom: 4px; word-break: break-all; }}
+  .label {{ font-size: 0.75rem; color: #666; margin-bottom: 8px; }}
+
+  .grid {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(380px, 1fr)); gap: 16px; }}
+
+  .card {{
+    background: #fff;
+    border-radius: 8px;
+    padding: 12px;
+    box-shadow: 0 1px 4px rgba(0,0,0,.15);
+  }}
+  .card img {{
+    width: 100%;
+    height: auto;
+    display: block;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    cursor: zoom-in;
+    margin-bottom: 8px;
+  }}
+  .slot-label {{ font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
+                 color: #888; margin: 6px 0 2px; letter-spacing: .05em; }}
+  .missing {{ font-size: 0.8rem; color: #b00; background: #fff0f0;
+              padding: 8px; border-radius: 4px; margin-bottom: 8px; }}
+
+  /* Lightbox */
+  #lightbox {{
+    display: none; position: fixed; inset: 0;
+    background: rgba(0,0,0,.85); z-index: 9999;
+    flex-direction: column; align-items: center; justify-content: center;
+  }}
+  #lightbox.open {{ display: flex; }}
+  #lightbox img {{ max-width: 95vw; max-height: 88vh; object-fit: contain;
+                   border-radius: 4px; box-shadow: 0 4px 32px rgba(0,0,0,.6); }}
+  #lightbox-caption {{ color: #fff; margin-top: 12px; font-size: 0.9rem; }}
+  #lightbox-close {{
+    position: absolute; top: 16px; right: 20px;
+    font-size: 2rem; color: #fff; cursor: pointer; line-height: 1;
+    background: none; border: none;
+  }}
+</style>
+</head>
+<body>
+<h1>Styling Issues: Before / After Screenshots</h1>
+{sections}
+
+<!-- Lightbox overlay -->
+<div id="lightbox" onclick="closeLightbox()">
+  <button id="lightbox-close" onclick="closeLightbox()">&times;</button>
+  <img id="lightbox-img" src="" alt="" />
+  <div id="lightbox-caption"></div>
+</div>
+
+<script>
+function openLightbox(src, caption) {{
+  document.getElementById('lightbox-img').src = src;
+  document.getElementById('lightbox-caption').textContent = caption;
+  document.getElementById('lightbox').classList.add('open');
+  document.body.style.overflow = 'hidden';
+}}
+function closeLightbox() {{
+  document.getElementById('lightbox').classList.remove('open');
+  document.body.style.overflow = '';
+}}
+document.addEventListener('keydown', (e) => {{ if (e.key === 'Escape') closeLightbox(); }});
+</script>
+</body>
+</html>"""
+
+
+if __name__ == "__main__":
+    if not BEFORE_DIR.exists() and not AFTER_DIR.exists():
+        print(
+            f"No screenshots found.\n"
+            f"Run:\n"
+            f"  ./scripts/download_styling_screenshots.sh\n"
+            f"or capture locally with:\n"
+            f"  cd packages/buckaroo-js-core && "
+            f"SCREENSHOT_DIR=screenshots/after npx playwright test pw-tests/styling-issues-screenshots.spec.ts",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    html = build_html()
+    OUTPUT.write_text(html, encoding="utf-8")
+    print(f"Written: {OUTPUT}")
+
+    # Count available screenshots
+    before_count = len(list(BEFORE_DIR.glob("*.png"))) if BEFORE_DIR.exists() else 0
+    after_count  = len(list(AFTER_DIR.glob("*.png")))  if AFTER_DIR.exists()  else 0
+    print(f"  before: {before_count} screenshots")
+    print(f"  after:  {after_count} screenshots")

--- a/scripts/gen_screenshot_compare.py
+++ b/scripts/gen_screenshot_compare.py
@@ -38,7 +38,7 @@ STORIES = [
         ("A6_ManyCols_ShortHdr_LongData",  "#596 data contention","no-diff"),
         ("A7_ManyCols_LongHdr_ShortData",  "#596 hdr contention", "no-diff"),
         ("A8_ManyCols_LongHdr_LongData",   "#596 worst case",     "no-diff"),
-        ("A9_ManyCols_LongHdr_YearData",  "#595 primary repro",  "wip"),
+        ("A9_ManyCols_LongHdr_YearData",  "#595 primary repro",  "diff"),
     ]),
     # Section B — compact_number displayer shows clear before/after difference
     ("B – Large Numbers / compact_number  (#597, #602)", [
@@ -452,12 +452,17 @@ const zoomVal = document.getElementById('zoom-val');
 const panxVal = document.getElementById('panx-val');
 const panyVal = document.getElementById('pany-val');
 
-function loadStory(idx) {{
+function loadStory(idx, pushHash) {{
   currentIdx = idx;
   const s = STORIES[idx];
 
   storyName.textContent  = s.name;
   storyLabel.textContent = s.label;
+
+  // Update URL hash (default: push)
+  if (pushHash !== false) {{
+    history.replaceState(null, '', '#' + s.name);
+  }}
 
   // before image
   if (s.before) {{
@@ -557,8 +562,20 @@ imgAfter.addEventListener('load', applyTransform);
 // Re-apply on window resize
 window.addEventListener('resize', applyTransform);
 
+// Hash routing: load story from URL hash
+function loadFromHash() {{
+  const hash = location.hash.slice(1);
+  if (hash) {{
+    const idx = STORIES.findIndex(s => s.name === hash);
+    if (idx >= 0) {{ loadStory(idx, false); return; }}
+  }}
+  loadStory(0, false);
+}}
+
+window.addEventListener('hashchange', loadFromHash);
+
 // Init
-loadStory(0);
+loadFromHash();
 </script>
 </body>
 </html>"""

--- a/scripts/gen_screenshot_compare.py
+++ b/scripts/gen_screenshot_compare.py
@@ -57,6 +57,17 @@ STORIES = [
         ("D15_Mixed_ManyNarrow_WithPinned", "#595 #587 #599", "diff"),
         ("D16_Mixed_FewWide_WithPinned",    "#587 baseline",  "diff"),
     ]),
+    # Section E — Python-computed ag_grid_specs.minWidth
+    ("E – Python-Computed minWidth", [
+        ("E17_PythonMinWidth_NarrowInts",  "minWidth lever",  "wip"),
+        ("E18_PythonMinWidth_LongHeaders", "minWidth lever",  "wip"),
+        ("E19_PythonMinWidth_MixedTypes",  "minWidth lever",  "wip"),
+    ]),
+    # Section F — Histogram + narrow columns
+    ("F – Histogram + Narrow Columns", [
+        ("F20_Histogram_NarrowCols",           "histogram 100px min", "wip"),
+        ("F21_Histogram_NarrowCols_NoHistMin", "histogram crushed",   "wip"),
+    ]),
 ]
 
 

--- a/tests/unit/dataflow/customizable_dataflow_test.py
+++ b/tests/unit/dataflow/customizable_dataflow_test.py
@@ -348,9 +348,10 @@ def test_column_config_override_widget():
             {'displayer_args': { 'displayer': 'integer', 'min_digits': 3, 'max_digits': 5 }}})
         
     float_col_config = bw2.df_display_args['main']['df_viewer_config']['column_config'][1]
-    assert float_col_config == {'col_name': 'b', 'header_name':'float_col', 'displayer_args': { 'displayer': 'integer', 'min_digits': 3, 'max_digits': 5 },
-    #'tooltip_config': {'tooltip_type': 'simple', 'val_column': 'c'}
-    }
+    assert float_col_config['col_name'] == 'b'
+    assert float_col_config['header_name'] == 'float_col'
+    assert float_col_config['displayer_args'] == { 'displayer': 'integer', 'min_digits': 3, 'max_digits': 5 }
+    assert float_col_config['ag_grid_specs']['minWidth'] > 0
 
 def test_column_config_override_rewrite():
     ROWS = 200
@@ -366,12 +367,12 @@ def test_column_config_override_rewrite():
             
         
     float_col_config = bw2.df_display_args['main']['df_viewer_config']['column_config'][1]
-    expected = {'col_name': 'b', 'header_name':'float_col', 
-                'displayer_args': {'displayer': 'float',
-                                   'max_fraction_digits': 3,
-                                   'min_fraction_digits': 3},
-                'tooltip_config': {'tooltip_type': 'simple', 'val_column': 'c'}}
-    assert expected == float_col_config
+    assert float_col_config['col_name'] == 'b'
+    assert float_col_config['header_name'] == 'float_col'
+    assert float_col_config['displayer_args'] == {
+        'displayer': 'float', 'max_fraction_digits': 3, 'min_fraction_digits': 3}
+    assert float_col_config['tooltip_config'] == {'tooltip_type': 'simple', 'val_column': 'c'}
+    assert float_col_config['ag_grid_specs']['minWidth'] > 0
     
 
 

--- a/tests/unit/dataflow/styling_core_test.py
+++ b/tests/unit/dataflow/styling_core_test.py
@@ -1,6 +1,12 @@
 from typing import Dict, List
 import pandas as pd
 from buckaroo.dataflow.styling_core import ColumnConfig, DFViewerConfig, NormalColumnConfig, PartialColConfig, StylingAnalysis, merge_sd_overrides, rewrite_override_col_references
+from buckaroo.customizations.styling import (
+    _formatted_char_count,
+    estimate_min_width_px,
+    _HISTOGRAM_MIN_PX,
+    _MIN_COL_PX,
+)
 from buckaroo.ddd_library import get_basic_df2, get_multiindex_index_df, get_multiindex_index_multiindex_with_names_cols_df, get_multiindex_index_with_names_multiindex_cols_df, get_multiindex_with_names_both, get_multiindex_with_names_index_df, get_multiindex_cols_df, get_multiindex_with_names_cols_df, get_tuple_cols_df
 from buckaroo.df_util import ColIdentifier
 from buckaroo.pluggable_analysis_framework.col_analysis import SDType
@@ -253,4 +259,151 @@ def test_merge_sd_overrides2():
     assert len(merged) == 1
 
 
-    
+# ── Tests for estimate_min_width_px and _formatted_char_count ────────────────
+
+
+class TestFormattedCharCount:
+    def test_float_small_values(self):
+        # max=9, min=0 → 1 int digit, 0 commas, 3 frac digits, decimal, no sign
+        disp = {'displayer': 'float', 'max_fraction_digits': 3}
+        meta = {'max': 9, 'min': 0}
+        assert _formatted_char_count(disp, meta) == 1 + 0 + 1 + 3 + 0  # 5
+
+    def test_float_large_values(self):
+        # max=5_700_000_000 → 10 int digits, 3 commas, 2 frac digits, decimal
+        disp = {'displayer': 'float', 'max_fraction_digits': 2}
+        meta = {'max': 5_700_000_000, 'min': 0}
+        assert _formatted_char_count(disp, meta) == 10 + 3 + 1 + 2 + 0  # 16
+
+    def test_float_negative(self):
+        # min=-100 → sign char added
+        disp = {'displayer': 'float', 'max_fraction_digits': 2}
+        meta = {'max': 50, 'min': -100}
+        # max_abs = 100 → 3 int digits, 0 commas, decimal, 2 frac, 1 sign
+        assert _formatted_char_count(disp, meta) == 3 + 0 + 1 + 2 + 1  # 7
+
+    def test_float_zero_frac(self):
+        # max_fraction_digits=0 → no decimal point
+        disp = {'displayer': 'float', 'max_fraction_digits': 0}
+        meta = {'max': 999, 'min': 0}
+        assert _formatted_char_count(disp, meta) == 3 + 0 + 0 + 0 + 0  # 3
+
+    def test_float_nan_guard(self):
+        # NaN max → int_digits defaults to 1
+        disp = {'displayer': 'float', 'max_fraction_digits': 2}
+        meta = {'max': float('nan'), 'min': 0}
+        assert _formatted_char_count(disp, meta) == 1 + 0 + 1 + 2 + 0  # 4
+
+    def test_float_none_metadata(self):
+        # None values in metadata → treated as 0
+        disp = {'displayer': 'float', 'max_fraction_digits': 3}
+        meta = {'max': None, 'min': None}
+        assert _formatted_char_count(disp, meta) == 1 + 0 + 1 + 3 + 0  # 5
+
+    def test_integer(self):
+        disp = {'displayer': 'integer', 'max_digits': 7}
+        # 7 digits + 2 commas = 9
+        assert _formatted_char_count(disp, {}) == 7 + 2  # 9
+
+    def test_integer_default(self):
+        # no max_digits → default 4
+        disp = {'displayer': 'integer'}
+        assert _formatted_char_count(disp, {}) == 4 + 1  # 5
+
+    def test_compact_number(self):
+        disp = {'displayer': 'compact_number'}
+        assert _formatted_char_count(disp, {}) == 5
+
+    def test_string(self):
+        disp = {'displayer': 'string', 'max_length': 35}
+        # capped at 20
+        assert _formatted_char_count(disp, {}) == 20
+
+    def test_string_short(self):
+        disp = {'displayer': 'string', 'max_length': 10}
+        assert _formatted_char_count(disp, {}) == 10
+
+    def test_datetime(self):
+        disp = {'displayer': 'datetimeLocaleString'}
+        assert _formatted_char_count(disp, {}) == 18
+
+    def test_datetime_default(self):
+        disp = {'displayer': 'datetimeDefault'}
+        assert _formatted_char_count(disp, {}) == 18
+
+    def test_obj_fallback(self):
+        disp = {'displayer': 'obj'}
+        assert _formatted_char_count(disp, {}) == 8
+
+    def test_unknown_displayer(self):
+        disp = {'displayer': 'something_new'}
+        assert _formatted_char_count(disp, {}) == 8
+
+
+class TestEstimateMinWidthPx:
+    def test_data_wider_than_header(self):
+        # float with large values, short header "a"
+        disp = {'displayer': 'float', 'max_fraction_digits': 3}
+        meta = {'max': 999_999, 'min': 0}
+        # data: 6 int + 1 comma + 1 decimal + 3 frac = 11 chars → 11*7 + 16 = 93
+        # header "a": 1*8 + 14 + 16 = 38
+        result = estimate_min_width_px(disp, 'a', meta)
+        assert result == 93
+
+    def test_header_wider_than_data(self):
+        # short data, long header
+        disp = {'displayer': 'integer', 'max_digits': 2}
+        meta = {}
+        # data: 2 digits + 0 commas = 2 chars → 2*7 + 16 = 30
+        # header "customer_lifetime_value": 23 chars → 23*8 + 14 + 16 = 214
+        result = estimate_min_width_px(disp, 'customer_lifetime_value', meta)
+        assert result == 214
+
+    def test_histogram_enforces_minimum(self):
+        # tiny data + short header → would be small, but histogram enforces 100px
+        disp = {'displayer': 'integer', 'max_digits': 1}
+        meta = {}
+        # data: 1*7 + 16 = 23; header "x": 1*8 + 14 + 16 = 38; max = 38
+        # but histogram: max(38, 100) = 100
+        result = estimate_min_width_px(disp, 'x', meta, has_histogram=True)
+        assert result == _HISTOGRAM_MIN_PX
+
+    def test_histogram_doesnt_shrink(self):
+        # wide column should not be shrunk by histogram
+        disp = {'displayer': 'float', 'max_fraction_digits': 3}
+        meta = {'max': 999_999_999, 'min': -999_999_999}
+        result_with = estimate_min_width_px(disp, 'a', meta, has_histogram=True)
+        result_without = estimate_min_width_px(disp, 'a', meta, has_histogram=False)
+        assert result_with >= result_without
+
+    def test_minimum_floor(self):
+        # even with nothing, should return _MIN_COL_PX
+        disp = {'displayer': 'obj'}
+        meta = {}
+        result = estimate_min_width_px(disp, '', meta)
+        assert result >= _MIN_COL_PX
+
+    def test_none_header(self):
+        # None header should not crash
+        disp = {'displayer': 'obj'}
+        meta = {}
+        result = estimate_min_width_px(disp, None, meta)
+        assert result >= _MIN_COL_PX
+
+    def test_compact_number_narrow(self):
+        # compact_number is always ~5 chars regardless of data magnitude
+        disp = {'displayer': 'compact_number'}
+        meta = {'max': 5_700_000_000, 'min': 0}
+        result = estimate_min_width_px(disp, 'a', meta)
+        # data: 5*7 + 16 = 51; header "a": 1*8 + 14 + 16 = 38 → 51
+        assert result == 51
+
+    def test_float_vs_compact_savings(self):
+        # compact_number should produce a narrower column than float for large values
+        meta = {'max': 5_700_000_000, 'min': 0}
+        float_disp = {'displayer': 'float', 'max_fraction_digits': 2}
+        compact_disp = {'displayer': 'compact_number'}
+        float_w = estimate_min_width_px(float_disp, 'a', meta)
+        compact_w = estimate_min_width_px(compact_disp, 'a', meta)
+        assert compact_w < float_w
+


### PR DESCRIPTION
## Summary

- **Content-aware per-column `minWidth`**: Python's `estimate_min_width_px()` computes pixel width from displayer type, data range, header name, and histogram presence — replaces the blanket `defaultColDef.minWidth: 80` that wasted space on narrow columns
- **Screenshot comparison infrastructure**: CI captures before/after screenshots at baseline vs current branch, with download script and self-contained HTML comparison viewer
- **Comprehensive test coverage**: 23 unit tests for width estimation, 22 Storybook stories covering width contention, large numbers, pinned rows, Python-computed minWidth, and histogram + narrow columns
- **Design doc**: `docs/column-width-design.md` documents all width levers (per-column `ag_grid_specs`, grid-level `autoSizeStrategy`, displayer choice, theme params) and four valid sizing approaches (readable, compact, balanced, data-priority)

## Key changes

**Python (`buckaroo/customizations/styling.py`)**
- `_formatted_char_count()` estimates character width per displayer type (float, integer, compact_number, string, datetime)
- `estimate_min_width_px()` computes pixel width from max(data width, header width), with 100px histogram floor
- `DefaultMainStyling.style_column()` sets `ag_grid_specs.minWidth` per column

**JS (`DFViewerInfinite.tsx`, `gridUtils.ts`)**
- Removed blanket `minWidth: 80` from `defaultColDef`
- Per-column `ag_grid_specs` flows through `...f.ag_grid_specs` spread in `baseColToColDef()`
- `extra_grid_config.autoSizeStrategy` override supported

**Stories (22 total across 6 sections)**
- A: Width contention matrix (9 stories — few/many cols × short/long headers × short/long data)
- B: Large numbers / compact_number (4 stories)
- C: Pinned row / index alignment (2 stories)
- D: Mixed scenarios (2 stories)
- E: Python-computed `ag_grid_specs.minWidth` (3 stories — narrow ints, long headers, mixed types)
- F: Histogram + narrow columns (2 stories — with/without histogram minimum)

**CI (`.github/workflows/checks.yml`)**
- `StylingScreenshots` job captures before screenshots at baseline `b7956f8`, after at current branch
- Uploads as separate artifacts for download and comparison

## Test plan

- [x] 23 Python unit tests for `estimate_min_width_px()` and `_formatted_char_count()` pass
- [x] 81 JS tests pass
- [x] 546 Python tests pass
- [x] Storybook Playwright screenshots capture all 22 stories
- [x] Histogram pinned rows render correctly in F20/F21 stories
- [x] CI green (all jobs except infra flake on uv install)

🤖 Generated with [Claude Code](https://claude.com/claude-code)