### PR TITLE
perf: upgrade AG Grid v32 → v33 (unified packages)

### DIFF
--- a/packages/buckaroo-js-core/package.json
+++ b/packages/buckaroo-js-core/package.json
@@ -30,12 +30,8 @@
     "/dist"
   ],
   "dependencies": {
-    "@ag-grid-community/client-side-row-model": "^32.3.3",
-    "@ag-grid-community/core": "^32.3.3",
-    "@ag-grid-community/infinite-row-model": "^32.3.3",
-    "@ag-grid-community/react": "^32.3.3",
-    "@ag-grid-community/styles": "^32.3.3",
-    "@ag-grid-community/theming": "^32.3.3",
+    "ag-grid-community": "^33.3.2",
+    "ag-grid-react": "^33.3.2",
     "hyparquet": "^1.8.2",
     "lodash-es": "^4.17.21",
     "recharts": "^2.13.1"

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -16,7 +16,7 @@ import {
     IDisplayArgs
 } from "./DFViewerParts/gridUtils";
 import { DatasourceOrRaw, DFViewerInfinite } from "./DFViewerParts/DFViewerInfinite";
-import { IDatasource } from "@ag-grid-community/core";
+import { IDatasource } from "ag-grid-community";
 import { KeyAwareSmartRowCache, PayloadArgs, PayloadResponse, RequestFN } from "./DFViewerParts/SmartRowCache";
 import { parquetRead, parquetMetadata } from 'hyparquet'
 import { MessageBox } from "./MessageBox";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerDataHelper.ts
@@ -1,4 +1,4 @@
-import { IDatasource, IGetRowsParams } from "@ag-grid-community/core";
+import { IDatasource, IGetRowsParams } from "ag-grid-community";
 import * as _ from "lodash-es";
 
 export type RawDataWrapper = {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.test.tsx
@@ -5,7 +5,7 @@ import { DFViewerConfig } from "./DFWhole";
 const setGridOptionMock = jest.fn();
 let latestAgGridProps: any = null;
 
-jest.mock("@ag-grid-community/react", () => {
+jest.mock("ag-grid-react", () => {
   const React = require("react");
   return {
     AgGridReact: React.forwardRef((props: any, ref: any) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -15,6 +15,15 @@ import {
     GridApi,
     GridOptions,
     IDatasource,
+    ModuleRegistry,
+    ClientSideRowModelModule,
+    InfiniteRowModelModule,
+    CellStyleModule,
+    ColumnAutoSizeModule,
+    PinnedRowModule,
+    RowSelectionModule,
+    TooltipModule,
+    TextFilterModule,
     SortChangedEvent,
     CellClassParams,
     RefreshCellsParams,
@@ -28,6 +37,16 @@ import {
 import { getThemeForScheme } from './gridUtils';
 import { useColorScheme } from '../useColorScheme';
 
+ModuleRegistry.registerModules([
+    ClientSideRowModelModule,
+    InfiniteRowModelModule,
+    CellStyleModule,
+    ColumnAutoSizeModule,
+    PinnedRowModule,
+    RowSelectionModule,
+    TooltipModule,
+    TextFilterModule,
+]);
 
 const AccentColor = "#2196F3"
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -9,21 +9,16 @@ import { DFData, DFDataRow, DFViewerConfig, SDFT } from "./DFWhole";
 
 import { getCellRendererSelector, dfToAgrid, extractPinnedRows, extractSDFT } from "./gridUtils";
 
-import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
+import { AgGridReact } from "ag-grid-react"; // the AG Grid React Component
 import {
     GetRowIdParams,
     GridApi,
     GridOptions,
     IDatasource,
-    ModuleRegistry,
     SortChangedEvent,
     CellClassParams,
     RefreshCellsParams,
-    //ColDef,
-} from "@ag-grid-community/core";
-import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
-import { InfiniteRowModelModule } from "@ag-grid-community/infinite-row-model";
-
+} from "ag-grid-community";
 import {
     getAutoSize,
     getHeightStyle2,
@@ -32,9 +27,6 @@ import {
 } from "./gridUtils";
 import { getThemeForScheme } from './gridUtils';
 import { useColorScheme } from '../useColorScheme';
-
-ModuleRegistry.registerModules([ClientSideRowModelModule]);
-ModuleRegistry.registerModules([InfiniteRowModelModule]);
 
 
 const AccentColor = "#2196F3"

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -1,6 +1,6 @@
 // I'm not sure about adding underlying types too
 
-import { ColDef, ColGroupDef, GridOptions } from "@ag-grid-community/core";
+import { ColDef, ColGroupDef, GridOptions } from "ag-grid-community";
 import * as _ from "lodash-es";
 
 type AGGrid_ColDef = ColDef;

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Displayer.ts
@@ -1,4 +1,4 @@
-import { ValueFormatterFunc, ValueFormatterParams } from "@ag-grid-community/core";
+import { ValueFormatterFunc, ValueFormatterParams } from "ag-grid-community";
 import {
     DisplayerArgs,
     cellRendererDisplayers,

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -4,7 +4,7 @@ import { createPortal } from "react-dom";
 
 import { Bar, BarChart, Tooltip } from "recharts";
 import { getChartColors } from "./ChartCell";
-import { ColDef, Column, Context, GridApi } from "@ag-grid-community/core";
+import { ColDef, Column, Context, GridApi } from "ag-grid-community";
 import { useColorScheme } from "../useColorScheme";
 
 export interface HistogramNode {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
@@ -1,5 +1,5 @@
 import * as _ from "lodash-es";
-import { ValueFormatterFunc } from "@ag-grid-community/core";
+import { ValueFormatterFunc } from "ag-grid-community";
 
 export const getTextCellRenderer = (formatter: ValueFormatterFunc<any>) => {
     const TextCellRenderer = (props: any) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SeriesSummaryTooltip.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SeriesSummaryTooltip.tsx
@@ -1,6 +1,6 @@
 import { DFViewer } from "./DFViewerInfinite";
 import { DFWhole, TooltipConfig } from "./DFWhole";
-import { ITooltipParams } from "@ag-grid-community/core";
+import { ITooltipParams } from "ag-grid-community";
 
 export function getBakedDFViewer(seriesDf: DFWhole) {
     const retFunc = (_props: ITooltipParams) => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Styler.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Styler.tsx
@@ -1,6 +1,6 @@
 import {
     CellClassParams,
-} from "@ag-grid-community/core";
+} from "ag-grid-community";
 
 import { BLUE_TO_YELLOW, DIVERGING_RED_WHITE_BLUE } from "../../baked_data/colorMap";
 import {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -14,7 +14,7 @@ import {
 import * as _ from "lodash-es";
 import { DFData, DFViewerConfig, NormalColumnConfig, MultiIndexColumnConfig, PinnedRowConfig, ColumnConfig } from "./DFWhole";
 import { getFloatFormatter, getCompactNumberFormatter } from './Displayer';
-import { ColDef, ValueFormatterParams } from '@ag-grid-community/core';
+import { ColDef, ValueFormatterParams } from 'ag-grid-community';
 
 describe("testing utility functions in gridUtils ", () => {
   // mostly sanity checks to help develop gridUtils

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -8,7 +8,11 @@ import {
     IGetRowsParams,
     SizeColumnsToContentStrategy,
     SizeColumnsToFitProvidedWidthStrategy,
-} from "@ag-grid-community/core";
+    colorSchemeDark,
+    colorSchemeLight,
+    themeAlpine,
+    Theme,
+} from "ag-grid-community";
 
 import {
     DFWhole,
@@ -34,7 +38,6 @@ import { getFormatterFromArgs, getCellRenderer, objFormatter, getFormatter } fro
 import { CSSProperties, Dispatch, SetStateAction } from "react";
 import { CommandConfigT } from "../CommandUtils";
 import { KeyAwareSmartRowCache, PayloadArgs } from "./SmartRowCache";
-import { colorSchemeDark, colorSchemeLight, themeAlpine, Theme } from "@ag-grid-community/theming";
 
 
 // for now colDef stuff with less than 3 implementantions should stay in this file

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -1,20 +1,18 @@
 // https://plnkr.co/edit/QTNwBb2VEn81lf4t?open=index.tsx
 import React, { useRef, useCallback, useState, memo, useEffect, useMemo } from "react";
 import * as _ from "lodash-es";
-import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
-import { ColDef, GridApi, GridOptions, ModuleRegistry } from "@ag-grid-community/core";
+import { AgGridReact } from "ag-grid-react"; // the AG Grid React Component
+import { ColDef, GridApi, GridOptions } from "ag-grid-community";
 import { basicIntFormatter } from "./DFViewerParts/Displayer";
 import { DFMeta } from "./WidgetTypes";
 import { BuckarooOptions } from "./WidgetTypes";
 import { BuckarooState, BKeys } from "./WidgetTypes";
-import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
-import { CustomCellEditorProps } from '@ag-grid-community/react';
+import { CustomCellEditorProps } from 'ag-grid-react';
 import { getThemeForScheme } from "./DFViewerParts/gridUtils";
-import { Theme } from "@ag-grid-community/theming";
+import { Theme } from "ag-grid-community";
 import { useColorScheme } from "./useColorScheme";
 
 export type setColumFunc = (newCol: string) => void;
-ModuleRegistry.registerModules([ClientSideRowModelModule]);
 const helpCell = function (_params: any) {
     return (
         <a

--- a/packages/buckaroo-js-core/src/components/utils.ts
+++ b/packages/buckaroo-js-core/src/components/utils.ts
@@ -1,6 +1,6 @@
 import * as _ from "lodash-es";
 import { DFWhole } from "./DFViewerParts/DFWhole";
-import { ColDef } from "@ag-grid-community/core";
+import { ColDef } from "ag-grid-community";
 
 export type setDFFunc = (newDf: DFWhole) => void;
 

--- a/packages/buckaroo-js-core/src/stories/OutsideParamsInconsistency.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/OutsideParamsInconsistency.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import React, { useMemo, useState } from "react";
 import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
 import { DFViewerConfig } from "../components/DFViewerParts/DFWhole";
-import { IDatasource, IGetRowsParams } from "@ag-grid-community/core";
+import { IDatasource, IGetRowsParams } from "ag-grid-community";
 
 const makeContextualDatasource = (dataA: any[], dataB: any[], delayMs = 0): IDatasource => {
   const total = Math.max(dataA.length, dataB.length);

--- a/packages/buckaroo-js-core/src/stories/RawAGGrid.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/RawAGGrid.stories.tsx
@@ -4,23 +4,14 @@ import { DFData } from "../components/DFViewerParts/DFWhole";
 import { createDatasourceWrapper, DatasourceWrapper } from "../components/DFViewerParts/DFViewerDataHelper";
 
 import {SelectBox } from './StoryUtils'
-import { AgGridReact } from "@ag-grid-community/react"; // the AG Grid React Component
+import { AgGridReact } from "ag-grid-react"; // the AG Grid React Component
 import {
     GridOptions,
-    //IDatasource,
-    ModuleRegistry,
     ColDef,
-    CellClassParams
-} from "@ag-grid-community/core";
-
-import { themeAlpine} from '@ag-grid-community/theming';
-import { colorSchemeDark } from '@ag-grid-community/theming';
-
-import { ClientSideRowModelModule } from "@ag-grid-community/client-side-row-model";
-import { InfiniteRowModelModule } from "@ag-grid-community/infinite-row-model";
-
-ModuleRegistry.registerModules([ClientSideRowModelModule]);
-ModuleRegistry.registerModules([InfiniteRowModelModule]);
+    CellClassParams,
+    themeAlpine,
+    colorSchemeDark,
+} from "ag-grid-community";
 
 const myTheme = themeAlpine.withPart(colorSchemeDark).withParams({
     spacing:5,

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -14,24 +14,12 @@ importers:
 
   buckaroo-js-core:
     dependencies:
-      '@ag-grid-community/client-side-row-model':
-        specifier: ^32.3.3
-        version: 32.3.5
-      '@ag-grid-community/core':
-        specifier: ^32.3.3
-        version: 32.3.5
-      '@ag-grid-community/infinite-row-model':
-        specifier: ^32.3.3
-        version: 32.3.5
-      '@ag-grid-community/react':
-        specifier: ^32.3.3
-        version: 32.3.5(@ag-grid-community/core@32.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@ag-grid-community/styles':
-        specifier: ^32.3.3
-        version: 32.3.5
-      '@ag-grid-community/theming':
-        specifier: ^32.3.3
-        version: 32.3.9
+      ag-grid-community:
+        specifier: ^33.3.2
+        version: 33.3.2
+      ag-grid-react:
+        specifier: ^33.3.2
+        version: 33.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       hyparquet:
         specifier: ^1.8.2
         version: 1.23.3
@@ -189,31 +177,6 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
-
-  '@ag-grid-community/client-side-row-model@32.3.5':
-    resolution: {integrity: sha512-dTAko9W0E914BMVfDBcresQfDZZPiVVmkbS2iRwDPX0erqYT2/nkuXXVh5If1LFnAqM1q5EQTZDZaLXDv2GO7Q==}
-
-  '@ag-grid-community/core@32.3.5':
-    resolution: {integrity: sha512-RGL3RyPCKC4R2fcG1gXdk7rs+CXig23wufTFJfbE46aQDxg941ww07G0cDS5Z5u/6btM9GJkxlwcR0JVEI003A==}
-
-  '@ag-grid-community/core@32.3.9':
-    resolution: {integrity: sha512-oZeAEPgaJVMzfKqbAPCyadcN5+iy+tjvhRLqEYJdBxtLgW/s2s0qXcXQvnrz7eUMD3Z7h3BQRVt2h/p0T6Ox/w==}
-
-  '@ag-grid-community/infinite-row-model@32.3.5':
-    resolution: {integrity: sha512-XdFwyeZfIOGc69H1OAJGiP2iTFIlUrC7ANIvxWtuAuy77lqjE1IYRxBv9Lfc+qM4pJRqYFVLmc9aOLJbmrr6DQ==}
-
-  '@ag-grid-community/react@32.3.5':
-    resolution: {integrity: sha512-GW2Alqo+U2eSXKZFVE+1F9THBSrHbbe4crAvjL4NOSaqimLtKyYJ8TCHgsn5PX/PPeOxfCVK5SMHD4oziSHidA==}
-    peerDependencies:
-      '@ag-grid-community/core': 32.3.5
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
-  '@ag-grid-community/styles@32.3.5':
-    resolution: {integrity: sha512-gr4orZTYDqx3r+P+F8SSaL4BFzSTopjqaua5wXcOHfUm7OGENcgogMo2DiaMnxzcc33T/TbOIiL8RCDP7X0efw==}
-
-  '@ag-grid-community/theming@32.3.9':
-    resolution: {integrity: sha512-NRqeoISBJncWDYDATc+cxG7D5CgVuOkJRpz3hWnEBY/CjEHCM/HBIDJnv1ALsNsro/6iwALrpHrPaScJbDF9vw==}
 
   '@anywidget/react@0.0.8':
     resolution: {integrity: sha512-obr4EasXgWra485u+G4V3Msn7A1EOnowarvR62FRjpv2Rz6AyOoLMz2B03Z9j3DrWdD0634fMGu5ZAeRyjuV4w==}
@@ -1680,11 +1643,17 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ag-charts-types@10.3.5:
-    resolution: {integrity: sha512-DtvV+IS4RlocGV2IcaQOe/eM6eBGGCvkLnwxGkDxKa8ddxivv90fwlfPxK0O5XnVectiKtWFfOw35Cm0k+4vMw==}
+  ag-charts-types@11.3.2:
+    resolution: {integrity: sha512-trPGqgGYiTeLgtf9nLuztDYOPOFOLbqHn1g2D99phf7QowcwdX0TPx0wfWG8Hm90LjB8IH+G2s3AZe2vrdAtMQ==}
 
-  ag-charts-types@10.3.9:
-    resolution: {integrity: sha512-drcRiJVencliC8LnRwk4MmeQDNNBg5GzmOoLFihO3/k0CUK0VF/N+2nc7iFozwaNG0btSB9vAhYuJLjqHMtRrQ==}
+  ag-grid-community@33.3.2:
+    resolution: {integrity: sha512-9bx0e/+ykOyLvUxHqmdy0cRVANH6JAtv0yZdnBZEXYYqBAwN+G5a4NY+2I1KvoOCYzbk8SnStG7y4hCdVAAWOQ==}
+
+  ag-grid-react@33.3.2:
+    resolution: {integrity: sha512-5bv4JIJvGov23sduIUIyQTqpa/qhoQrRkQm5pFOQb7RMwusfx6xBPrkLwIIlCJiQ8g0OOinxWzZ2kQ2Zml6tLw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -3812,40 +3781,6 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ag-grid-community/client-side-row-model@32.3.5':
-    dependencies:
-      '@ag-grid-community/core': 32.3.5
-      tslib: 2.8.1
-
-  '@ag-grid-community/core@32.3.5':
-    dependencies:
-      ag-charts-types: 10.3.5
-      tslib: 2.8.1
-
-  '@ag-grid-community/core@32.3.9':
-    dependencies:
-      ag-charts-types: 10.3.9
-      tslib: 2.8.1
-
-  '@ag-grid-community/infinite-row-model@32.3.5':
-    dependencies:
-      '@ag-grid-community/core': 32.3.5
-      tslib: 2.8.1
-
-  '@ag-grid-community/react@32.3.5(@ag-grid-community/core@32.3.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      '@ag-grid-community/core': 32.3.5
-      prop-types: 15.8.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@ag-grid-community/styles@32.3.5': {}
-
-  '@ag-grid-community/theming@32.3.9':
-    dependencies:
-      '@ag-grid-community/core': 32.3.9
-      tslib: 2.8.1
-
   '@anywidget/react@0.0.8(@types/react-dom@18.3.7(@types/react@18.3.21))(@types/react@18.3.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@anywidget/types': 0.2.0
@@ -5406,9 +5341,18 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  ag-charts-types@10.3.5: {}
+  ag-charts-types@11.3.2: {}
 
-  ag-charts-types@10.3.9: {}
+  ag-grid-community@33.3.2:
+    dependencies:
+      ag-charts-types: 11.3.2
+
+  ag-grid-react@33.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      ag-grid-community: 33.3.2
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   agent-base@6.0.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Consolidate 6 `@ag-grid-community/*` packages into 2 unified packages (`ag-grid-community` + `ag-grid-react`)
- Register specific v33 modules (`ClientSideRowModelModule`, `InfiniteRowModelModule`, `CellStyleModule`, `ColumnAutoSizeModule`, `PinnedRowModule`, `RowSelectionModule`, `TooltipModule`, `TextFilterModule`)
- Remove old `ModuleRegistry.registerModules()` per-file calls
- Rewrite all imports across 17 source files
- Update test mock path to `ag-grid-react`

**Stacked on #624** — merge that first.

## Bundle sizes (cumulative, both PRs combined vs main)

| Artifact | main | After #624 | After this PR | Total reduction |
|----------|------|-----------|--------------|-----------------|
| widget.js (raw) | 3,433 KB | 1,781 KB | **1,506 KB** | **-56%** |
| widget.js (gzip) | 690 KB | 456 KB | **410 KB** | **-41%** |
| ESM (raw) | 2,342 KB | 2,309 KB | **1,907 KB** | **-19%** |
| ESM (gzip) | 534 KB | 513 KB | **442 KB** | **-17%** |

## Test plan
- [x] `tsc -b` — 0 errors
- [x] `pnpm test` — 81/81 pass (same as main, no test regression)
- [x] `pnpm run build` — success
- [x] widget.js build — 1.5 MB
- [ ] CI checks pass

Supersedes #555 (closed) — same goals, but without unrelated deletions (release.yml, session eviction, compare handler, etc.), broken `is_numeric()` calls, or silently dropped test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)