### PR TITLE
docs: clean up README, extract CONTRIBUTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,5 @@ Runs on push to main and PRs. Key jobs: LintPython, TestJS, BuildWheel, TestPyth
 ## Release Process
 
 1. Update CHANGELOG.md
-2. Tag (no 'v' prefix): `git tag 0.12.13`
-3. Push tag: `git push origin tag 0.12.13`
-4. Release workflow generates notes and publishes to PyPI
+2. Trigger the **Release** workflow via GitHub Actions (`workflow_dispatch`), choosing `patch`, `minor`, or `major`
+3. The workflow bumps the version in `pyproject.toml`, creates the tag, builds, publishes to PyPI, and creates a GitHub release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,7 @@ pnpm storybook
 
 Build a static Storybook site:
 ```bash
+cd packages/buckaroo-js-core
 pnpm build-storybook
 ```
 
@@ -93,9 +94,8 @@ uv add --group <group> <package>              # extras group
 ## Release process
 
 1. Update `CHANGELOG.md`
-2. Tag (no `v` prefix): `git tag 0.12.13`
-3. Push tag: `git push origin tag 0.12.13`
-4. The release workflow automatically generates notes and publishes to PyPI
+2. Trigger the **Release** workflow via GitHub Actions (`workflow_dispatch`), choosing `patch`, `minor`, or `major`
+3. The workflow bumps the version in `pyproject.toml`, creates the tag, builds, publishes to PyPI, and creates a GitHub release
 
 
 ## Reporting issues

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to Buckaroo
+
+We love contributions! This guide covers development setup, building, testing, and releasing.
+
+## Development setup
+
+### Prerequisites
+- [uv](https://docs.astral.sh/uv/) for Python dependency management
+- [pnpm](https://pnpm.io/) for JavaScript dependency management
+- Node.js >= 18
+- Python >= 3.11
+
+### Python
+
+```bash
+git clone https://github.com/buckaroo-data/buckaroo.git
+cd buckaroo
+uv sync --dev --all-extras
+```
+
+### JavaScript
+
+```bash
+cd packages/buckaroo-js-core
+pnpm install
+```
+
+### Full build (JS + Python wheel)
+
+```bash
+./scripts/full_build.sh
+```
+
+
+## Running tests
+
+### Python
+
+```bash
+uv run pytest tests/unit/ -v
+uv run ruff check --fix
+```
+
+### JavaScript
+
+```bash
+cd packages/buckaroo-js-core
+pnpm test
+```
+
+### Storybook (component development)
+
+```bash
+cd packages/buckaroo-js-core
+pnpm storybook
+# open http://localhost:6006
+```
+
+Build a static Storybook site:
+```bash
+pnpm build-storybook
+```
+
+### Playwright (UI tests against Storybook)
+
+Install browsers:
+```bash
+cd packages/buckaroo-js-core
+pnpm exec playwright install
+```
+
+Run tests:
+```bash
+pnpm test:pw --reporter=line
+```
+
+Useful variants:
+```bash
+pnpm test:pw:headed   # visible browser
+pnpm test:pw:ui       # Playwright UI
+pnpm test:pw:report   # open HTML report
+```
+
+
+## Adding dependencies
+
+```bash
+uv add <package>                              # main dependency
+uv add --group <group> <package>              # extras group
+```
+
+
+## Release process
+
+1. Update `CHANGELOG.md`
+2. Tag (no `v` prefix): `git tag 0.12.13`
+3. Push tag: `git push origin tag 0.12.13`
+4. The release workflow automatically generates notes and publishes to PyPI
+
+
+## Reporting issues
+
+We welcome [issue reports](https://github.com/buckaroo-data/buckaroo/issues). Please choose the proper issue template so we get the necessary information.

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Buckaroo - The Data Table for Jupyter
 
-Buckaroo is a modern data table for Jupyter that expedites the most common exploratory data analysis tasks. The most basic data analysis task - looking at the raw data, is cumbersome with the existing pandas tooling.  Buckaroo starts with a modern performant data table, is sortable, has value formatting, and scrolls infinitely.  On top of the core table experience extra features like summary stats, histograms, smart sampling, auto-cleaning, and a low code UI are added.  All of the functionality has sensible defaults that can be overridden to customize the experience for your workflow.
+[![PyPI version](https://img.shields.io/pypi/v/buckaroo.svg)](https://pypi.org/project/buckaroo/)
+[![CI](https://github.com/buckaroo-data/buckaroo/actions/workflows/checks.yml/badge.svg)](https://github.com/buckaroo-data/buckaroo/actions/workflows/checks.yml)
+[![License](https://img.shields.io/pypi/l/buckaroo.svg)](https://github.com/buckaroo-data/buckaroo/blob/main/LICENSE.txt)
+
+Buckaroo is a modern data table for Jupyter that expedites the most common exploratory data analysis tasks. The most basic data analysis task - looking at the raw data, is cumbersome with the existing pandas tooling. Buckaroo starts with a modern performant data table that is sortable, has value formatting, and scrolls infinitely. On top of the core table experience, extra features like summary stats, histograms, smart sampling, auto-cleaning, and a low code UI are added. All of the functionality has sensible defaults that can be overridden to customize the experience for your workflow.
 
 <img width="947" alt="Screenshot 2025-05-12 at 3 54 33 PM" src="https://github.com/user-attachments/assets/9238c893-8dd4-47e4-8215-b5450c8c7b3a" />
-
-# Note buckaroo has moved to
-https://github.com/buckaroo-data/buckaroo
 
 ## Try it now with Marimo in your browser
 Play with Buckaroo without any installation.
@@ -14,18 +15,19 @@ Play with Buckaroo without any installation.
 
 ## Quick start
 
-run `pip install buckaroo` then restart your jupyter server
-
-The following code shows Buckaroo on a simple dataframe
-
+```bash
+pip install buckaroo
 ```
+
+Then in a Jupyter notebook:
+
+```python
 import pandas as pd
 import buckaroo
-pd.DataFrame({'a':[1, 2, 10, 30, 50, 60, 50], 'b': ['foo', 'foo', 'bar', pd.NA, pd.NA, pd.NA, pd. NA]})
-
+pd.DataFrame({'a': [1, 2, 10, 30, 50, 60, 50], 'b': ['foo', 'foo', 'bar', pd.NA, pd.NA, pd.NA, pd.NA]})
 ```
 
-When you run `import buckaroo` in a Jupyter notebook, Buckaroo becomes the default display method for Pandas and Polars DataFrames
+When you `import buckaroo`, it becomes the default display for Pandas and Polars DataFrames.
 
 ## Claude Code MCP Integration
 
@@ -50,36 +52,63 @@ Claude will call the `view_data` tool, which opens the file in Buckaroo's intera
 
 ## Compatibility
 
-Buckaroo works in the following notebook environments
+Buckaroo works in the following notebook environments:
 
 - `jupyter lab` (version >=3.6.0)
-- `jupyter notebook` (version >=7.0) 
+- `jupyter notebook` (version >=7.0)
 - [Marimo](https://marimo.io/p/@paddy-mullen/buckaroo-full-tour)
 - `VS Code notebooks` (with extra install)
 - [Jupyter Lite](https://paddymul.github.io/buckaroo-examples/lab/index.html)
-- `Google colab` 
-- `Claude Code`
+- `Google Colab`
+- `Claude Code` (via MCP)
+
+Buckaroo works with the following DataFrame libraries:
+- **pandas** (version >=1.3.5)
+- **polars** (optional, `pip install buckaroo[polars]`)
 
 
-Buckaroo works with the following DataFrame libraries
-- `pandas` (version >=1.3.5)
-- `polars` optional
-- `geopandas` optional (deprecated, if you are interested in geopandas, please get in touch)
+# Features
+
+## High performance table
+The core data grid is based on [AG-Grid](https://www.ag-grid.com/). It loads thousands of cells in under a second, with highly customizable display, formatting and scrolling. Data is loaded lazily into the browser as you scroll, and serialized with parquet. You no longer have to use `df.head()` to poke at portions of your data.
+
+## Fixed width formatting by default
+By default numeric columns are formatted to use a fixed width font and commas are added. This allows quick visual confirmation of magnitudes in a column.
+
+## Histograms
+[Histograms](https://buckaroo-data.readthedocs.io/en/latest/articles/histograms.html) for every column give you a very quick overview of the distribution of values, including uniques and N/A.
+
+## Summary stats
+The summary stats view can be toggled by clicking on the `0` below the `Σ` icon. Summary stats are similar to `df.describe` and extensible.
+
+## Sorting
+All visible data is sortable by clicking on a column name; further clicks change sort direction then disable sort for that column. Because extreme values are included with sample rows, you can see outlier values too.
+
+## Search
+Search is built into Buckaroo so you can quickly find the rows you are looking for.
+
+## Lowcode UI
+Buckaroo has a simple low code UI with Python code gen. This view can be toggled by clicking the checkbox below the `λ` (lambda) icon.
+
+## Autocleaning
+Select a cleaning method from the status bar. The autocleaning system inspects each column and runs statistics to decide if cleaning should be applied (parsing dates, stripping non-integer characters, parsing implied booleans like "yes"/"no"), then adds those operations to the low code UI. Different cleaning methods can be tried because dirty data isn't deterministic. Access it with `BuckarooWidget(df, auto_clean=True)`.
+
+Read more: [Autocleaning docs](https://buckaroo-data.readthedocs.io/en/latest/articles/auto_clean.html)
+
+## Extensibility at the core
+Summary stats are built on the [Pluggable Analysis Framework](https://buckaroo-data.readthedocs.io/en/latest/articles/pluggable.html) that allows individual summary stats to be overridden, and new summary stats to be built in terms of existing ones. Care is taken to prevent errors in summary stats from preventing display of a dataframe.
 
 
 # Learn More
 
-Buckaroo has extensive docs and tests, the best way to learn about the system is from feature example videos on youtube
-
 ## Interactive Styling Gallery
+The interactive [styling gallery](https://py.cafe/app/paddymul/buckaroo-gallery) lets you see different styling configurations. You can live edit code and play with different configs.
 
-The interactive [styling gallery](https://py.cafe/app/paddymul/buckaroo-gallery) lets you see different styling configurations.  You can live edit code and play with different configs.
-
-## Videos 
-- [Buckaroo Full Tour](https://youtu.be/t-wk24F1G3s) 6m50s A broad introduction to Buckaroo
-- [The Column's the limit - PyData Boston 2025 (conference)](https://www.youtube.com/watch?v=JUCvHnpmx-Y) 43m Explanation of how LazyBuckaroo reliably process laptop large data
+## Videos
+- [Buckaroo Full Tour](https://youtu.be/t-wk24F1G3s) 6m50s - A broad introduction to Buckaroo
+- [The Column's the limit - PyData Boston 2025](https://www.youtube.com/watch?v=JUCvHnpmx-Y) 43m - How LazyBuckaroo reliably processes laptop-large data
 - [19 Million row scrolling and stats demo](https://www.youtube.com/shorts/x1UnW4Y_tOk) 58s
-- [Buckaroo PyData Boston 2025](https://www.youtube.com/watch?v=HtahDDEnBwE) 49m A tour of Buckaroo at PyData Boston.  Includes questions from the audience.
+- [Buckaroo PyData Boston 2025](https://www.youtube.com/watch?v=HtahDDEnBwE) 49m - Full tour with audience Q&A
 - [Using Buckaroo and pandas to investigate large CSVs](https://www.youtube.com/watch?v=_ZmYy8uvZN8) 9m
 - [Autocleaning quick demo](https://youtube.com/shorts/4Jz-Wgf3YDc) 2m38s
 - [Writing your own autocleaning functions](https://youtu.be/A-GKVsqTLMI) 10m10s
@@ -95,183 +124,25 @@ The interactive [styling gallery](https://py.cafe/app/paddymul/buckaroo-gallery)
 
 ## Example Notebooks
 
-The following examples are loaded into a jupyter lite environment with Buckaroo installed.
-- [Full Tour Marimo Pyodide](https://marimo.io/p/@paddy-mullen/buckaroo-full-tour)   Start here. This gives a broad overview of Buckaroo's features. [Jupyterlite (old)](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Full-tour.ipynb) [Google Colab](https://colab.research.google.com/github/paddymul/buckaroo/blob/main/docs/example-notebooks/Full-tour-colab.ipynb)
-- [Notebook on Github](https://github.com/paddymul/buckaroo/blob/main/docs/example-notebooks/Full-tour.ipynb)
+- [Full Tour (Marimo)](https://marimo.io/p/@paddy-mullen/buckaroo-full-tour) - Start here. Broad overview of Buckaroo's features. Also available on [Google Colab](https://colab.research.google.com/github/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Full-tour-colab.ipynb) and [JupyterLite](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Full-tour.ipynb)
+- [Notebook on GitHub](https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Full-tour.ipynb)
+- [Live Styling Gallery](https://marimo.io/p/@paddy-mullen/buckaroo-styling-gallery) - Examples of all the formatters and styling available
+- [Live Autocleaning](https://marimo.io/p/@paddy-mullen/buckaroo-auto-cleaning) - How autocleaning works and how to implement your own
+- [Live Histogram Demo](https://marimo.io/p/@paddy-mullen/buckaroo-histogram-demo) - Explanation of the embedded histograms
+- [Live JLisp overview](https://marimo.io/p/@paddy-mullen/jlisp-in-buckaroo) - The small lisp interpreter powering the lowcode UI
+- [Extending Buckaroo](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Extending.ipynb) - Adding post processing methods and custom styling
+- [Styling Howto](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=styling-howto.ipynb) - In depth custom styling guide
+- [Pluggable Analysis Framework](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Pluggable-Analysis-Framework.ipynb) - Adding new summary stats
+- [Solara Buckaroo](https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Solara-Buckaroo.ipynb) - Using Buckaroo with Solara
+- [GeoPandas with Buckaroo](https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/GeoPandas.ipynb)
 
-- [Live Styling Gallery](https://marimo.io/p/@paddy-mullen/buckaroo-styling-gallery)  [ipynb](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=styling-gallery.ipynb) Examples of all of the different formatters and styling available for the table
-- [Live Autocleaning](https://marimo.io/p/@paddy-mullen/buckaroo-auto-cleaning) Marimo notebook explaining how autocleaning works and showing how to implement your own cleaning commands and heuristic strategies.
-- [Live Histogram Demo](https://marimo.io/p/@paddy-mullen/buckaroo-histogram-demo) [ipynb](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Histograms-demo.ipynb) Explanation of the embedded histograms of Buckaroo.
-- [Live JLisp overview](https://marimo.io/p/@paddy-mullen/jlisp-in-buckaroo) Buckaroo embeds a small lisp interpreter to power the lowcode UI. You don't have to understand lisp to use buckaroo, but if you want to geek out on programming language UI, check this out.
-- [Extending Buckaroo](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Extending.ipynb) Broad overview of how to add post processing methods and custom styling methods to Buckaroo
-- [Styling Howto](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=styling-howto.ipynb) In depth explanation of how to write custom styling methods
-- [Pluggable Analysis Framework](https://paddymul.github.io/buckaroo-examples/lab/index.html?path=Pluggable-Analysis-Framework.ipynb) How to add new summary stats to Buckaroo
-- [Solara Buckaroo](https://github.com/paddymul/buckaroo/blob/main/docs/example-notebooks/Solara-Buckaroo.ipynb) Using Buckaroo with Solara
-- [GeoPandas with Bucakroo](https://github.com/paddymul/buckaroo/blob/main/docs/example-notebooks/GeoPandas.ipynb)
-
-
-## Example apps built on buckaroo
-More full featured integrations that can be built on a table UI
-- [Buckaroo Compare](https://marimo.io/p/@paddy-mullen/buckaroo-compare-preview) Join two dataframes and highlight visual differences between them
-- [Buckaroo Pandera](https://marimo.io/p/@paddy-mullen/buckaroo-pandera) Example showing validating a dataframe with Pandera, then visually highlighting where it fails the schema.
-
-# Features
-
-## High performance table
-The core data grid of buckaroo is based on [AG-Grid](https://www.ag-grid.com/). This loads 1000s of cells in less than a second, with highly customizable display, formatting and scrolling. Data is loaded lazily into the browser as you scroll, and serialized with parquet. You no longer have to use `df.head()` to poke at portions of your data.
-
-## Fixed width formatting by default
-
-By default numeric columns are formatted to use a fixed width font and commas are added.  This allows quick visual confirmation of magnitudes in a column.
-
-## Histograms
-
-[Histograms](https://buckaroo-data.readthedocs.io/en/latest/articles/histograms.html) for every column give you a very quick overview of the distribution of values, including uniques and N/A.
-
-## Summary stats
-The summary stats view can be toggled by clicking on the `0` below the `Σ` icon.  Summary stats are similar to `df.describe` and extensible.
-
-## Sorting
-
-All of the data visible in the table (rows shown), is sortable by clicking on a column name, further clicks change sort direction then disable sort for that column.  Because extreme values are included with sample rows, you can see outlier values too.
-
-## Search
-Search is built into Buckaroo so you can quickly find the rwos you are looking for.
-
-## Lowcode UI
-
-Buckaroo has a simple low code UI with python code gen. This view can be toggled by clicking the checkbox below the ` λ `(lambda) icon.
-
-## Autocleaning
-
-Select a cleaning method from the status bar. Buckaroo has heuristic autocleaning. The autocleaning system inspects each column and runs statistics to decide if a cleaning methods should be applied to the column (parsing as dates, stripping non integer characters and treating as an integer, parsing implied booleans "yes" "no" to booleans), then adds those cleaning operations to the low code UI.  Different cleaning methods can be tried because dirty data isn't deterministic and there are multiple approaches that could properly apply to any situation.
-
-## Extensibility at the core
-
-Buckaroo summary stats are built on the [Pluggable Analysis Framework](https://buckaroo-data.readthedocs.io/en/latest/articles/pluggable.html) that allows individual summary stats to be overridden, and new summary stats to be built in terms of existing summary stats.  Care is taken to prevent errors in summary stats from preventing display of a dataframe.
+## Example apps built on Buckaroo
+- [Buckaroo Compare](https://marimo.io/p/@paddy-mullen/buckaroo-compare-preview) - Join two dataframes and highlight visual differences
+- [Buckaroo Pandera](https://marimo.io/p/@paddy-mullen/buckaroo-pandera) - Validate a dataframe with Pandera, then visually highlight where it fails
 
 
-## Auto cleaning (beta)
+# Contributing
 
-Buckaroo can [automatically clean](https://buckaroo-data.readthedocs.io/en/latest/articles/auto_clean.html) dataframes to remove common data errors (a single string in a column of ints, recognizing date times...).  This feature is in beta.  You can access it by invoking buckaroo as `BuckarooWidget(df, auto_clean=True)`
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, build instructions, and release process.
 
-## Development installation
-
-For a development installation:
-
-```bash
-git clone https://github.com/paddymul/buckaroo.git
-cd buckaroo
-#we need to build against 3.6.5, jupyterlab 4.0 has different JS typing that conflicts
-# the installable still works in JL4
-pip install build twine pytest sphinx polars mypy jupyterlab==3.6.5 pandas-stubs geopolars pyarrow
-pip install -ve .
-```
-
-Enabling development install for Jupyter notebook:
-
-
-Enabling development install for JupyterLab:
-
-```bash
-jupyter labextension develop . --overwrite
-```
-
-Note for developers: the `--symlink` argument on Linux or OS X allows one to modify the JavaScript code in-place. This feature is not available with Windows.
-`
-### Developing the JS side
-
-There are a series of examples of the components in [examples/ex](./examples/ex).
-
-
-
-Instructions
-```bash
-npm install
-npm run dev
-```
-
-### Storybook (JS core components)
-
-Run Storybook locally:
-```bash
-cd packages/buckaroo-js-core
-pnpm install
-pnpm storybook
-# open http://localhost:6006
-```
-
-Build a static Storybook site:
-```bash
-cd packages/buckaroo-js-core
-pnpm install
-pnpm build-storybook
-# output: packages/buckaroo-js-core/dist/storybook
-```
-
-### Playwright (UI tests against Storybook)
-
-Install browsers:
-```bash
-cd packages/buckaroo-js-core
-pnpm install
-pnpm exec playwright install
-```
-
-Run tests (auto-starts Storybook via Playwright webServer, or reuses an existing one):
-```bash
-pnpm test:pw --reporter=line
-```
-
-Useful variants:
-```bash
-pnpm test:pw:headed   # visible browser
-pnpm test:pw:ui       # Playwright UI
-pnpm test:pw:report   # open HTML report
-```
-
-
-### UV Instructions
-```sh
-cd buckaroo
-uv venv
-source ~/buckaroo/.venv/bin/activate
-uv sync -q
-
-```
-
-### adding a package
-```sh
-cd ~/buckaroo
-uv add $PACKAGE_NAME
-```
-
-#### adding a package to a subgroup 
-```sh
-cd ~/buckaroo
-uv add --group $GROUP_NAME --quiet $PACKAGE_NAME
-```
-
-### Release instructions
-[github release instructions](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository)
-
-```bash
-update CHANGELOG.md
-git commit -m "updated changelog for release $VERSION_NUMBER"
-git tag $VERSION_NUMBER # no leading v in the version number
-git push origin tag $VERSION_NUMBER
-```
-navigate to [create new buckaroo release](https://github.com/paddymul/buckaroo/releases/new)
-Follow instructions
-
-
-
-
-## Contributions
-
-We :heart: contributions.
-
-Have you had a good experience with this project? Why not share some love and contribute code, or just let us know about any issues you had with it?
-
-We welcome [issue reports](../../issues); be sure to choose the proper issue template for your issue, so that we can be sure you're providing the necessary information.
-
+We welcome [issue reports](https://github.com/buckaroo-data/buckaroo/issues); be sure to choose the proper issue template so we get the necessary information.


### PR DESCRIPTION
## Summary
- Remove stale "buckaroo has moved to" notice (we're already here)
- Fix ~10 links from `paddymul/buckaroo` to `buckaroo-data/buckaroo`
- Add PyPI, CI, and license badges
- Fix typos: "rwos" -> "rows", "Bucakroo" -> "Buckaroo", dangling backtick
- Consolidate duplicate autocleaning sections into one
- Promote Polars from "optional" footnote to first-class `pip install buckaroo[polars]`
- Move dev setup, Storybook, Playwright, UV, and release instructions to new `CONTRIBUTING.md` (~120 lines out of README)
- Drop outdated dev instructions (pip install with manual deps, jupyterlab 3.6.5, npm instead of pnpm)

## Test plan
- [ ] Verify badge links render correctly on GitHub
- [ ] Spot-check notebook/video links still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)