### PR TITLE
fix: skip polars cell in WASM ddd_tour notebook

### DIFF
--- a/docs/example-notebooks/marimo-wasm/buckaroo_ddd_tour.py
+++ b/docs/example-notebooks/marimo-wasm/buckaroo_ddd_tour.py
@@ -293,13 +293,16 @@ def _(ddd):
 
 
 @app.cell(hide_code=True)
-def _(ddd):
+def _():
+    import pandas as pd
 
-    _df = ddd.pl_df_with_weird_types_as_pandas()
+    _df = pd.DataFrame()
 
     _explain_md = """
     ##  pl_df_with_weird_types (polars→pandas)
-     Exercises Duration (#622), Time, Categorical, Decimal, and Binary dtypes (converted to pandas for widget compat)
+     **Not available in WASM/Pyodide.** Polars does not provide WebAssembly wheels,
+     so this dataset cannot be generated in the browser. Run the notebook locally
+     with `marimo run` to see Duration (#622), Time, Categorical, Decimal, and Binary dtypes.
     """
     pl_df_with_weird_types_config = (_df, _explain_md)
     return (pl_df_with_weird_types_config,)


### PR DESCRIPTION
## Summary

- Replace the `pl_df_with_weird_types` cell in the WASM ddd_tour notebook with an empty DataFrame and explanation text
- Polars has no WASM wheels, so that cell crashed pyodide and broke the entire notebook via marimo's dependency chain

Fixes #644

## Test plan

- [ ] Verify RTD preview build at `/example_notebooks/buckaroo_ddd_tour/` loads and renders
- [ ] Verify selecting "pl_df_with_weird_types" in the dropdown shows the explanation instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)