### PR TITLE
Fix CI mp_timeout: increase from 1s to 3s

### DIFF
--- a/tests/unit/file_cache/mp_test_utils.py
+++ b/tests/unit/file_cache/mp_test_utils.py
@@ -12,7 +12,7 @@ multiprocessing  an behave differently when a function is defined in an imported
 
 
 LOCAL_TIMEOUT = 0.8
-CI_TIMEOUT = 1.0
+CI_TIMEOUT = 3.0
 # spawn context on Windows is much slower than forkserver (full process startup)
 WINDOWS_CI_TIMEOUT = 10.0
 


### PR DESCRIPTION
## Summary
- Increase `CI_TIMEOUT` from 1.0s to 3.0s in mp_timeout tests
- 1s is too tight for subprocess spawn + execution on GitHub-hosted or slower runners

## Test plan
- [ ] mp_timeout tests pass on all Python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)