### PR TITLE
Publish release screenshots to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-ghpage.yml
+++ b/.github/workflows/deploy-ghpage.yml
@@ -61,7 +61,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main' || github.head_ref == 'feat/release-screenshots-ghpages'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/deploy-ghpage.yml
+++ b/.github/workflows/deploy-ghpage.yml
@@ -61,7 +61,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' || github.head_ref == 'feat/release-screenshots-ghpages'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/deploy-ghpage.yml
+++ b/.github/workflows/deploy-ghpage.yml
@@ -15,7 +15,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
         with:
           run_install: true
@@ -42,6 +43,16 @@ jobs:
       #   run: |
       #     cd docs
       #     jupyter lite build --contents ./example-notebooks --output-dir ./_output
+
+      - name: Merge screenshots into Storybook output
+        run: |
+          git fetch origin gh-pages || true
+          if git rev-parse origin/gh-pages &>/dev/null; then
+            git checkout origin/gh-pages -- screenshots/ 2>/dev/null || true
+            if [ -d screenshots ]; then
+              cp -r screenshots/ ./packages/buckaroo-js-core/dist/storybook/screenshots/
+            fi
+          fi
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./packages/buckaroo-js-core/dist/storybook
+          keep_files: true
       # - name: Setup Pages
       #   uses: actions/configure-pages@v3
       # - name: Upload Artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,26 +135,6 @@ jobs:
           ./scripts/full_build.sh
           uv build --sdist
 
-      - name: Upload release assets
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ steps.versions.outputs.new }}" dist/*.whl dist/*.tar.gz
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-
-      - name: Upload changelog entry artifact
-        # Download this artifact and apply it in your next dev PR:
-        #   python scripts/update_changelog.py changelog_entry.md
-        #   sed -i 's/^version = ".*"/version = "NEW"/' pyproject.toml
-        #   uv lock
-        uses: actions/upload-artifact@v4
-        with:
-          name: changelog-${{ steps.versions.outputs.new }}
-          path: /tmp/changelog_entry.md
-          if-no-files-found: ignore
-
       - name: Capture release screenshots
         run: |
           cd packages/buckaroo-js-core
@@ -183,3 +163,31 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "screenshots: add release $VERSION screenshots"
           git push origin gh-pages
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.versions.outputs.new }}" \
+            --title "${{ steps.versions.outputs.new }}" \
+            --notes-file /tmp/release_notes.md
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.versions.outputs.new }}" dist/*.whl dist/*.tar.gz
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Upload changelog entry artifact
+        # Download this artifact and apply it in your next dev PR:
+        #   python scripts/update_changelog.py changelog_entry.md
+        #   sed -i 's/^version = ".*"/version = "NEW"/' pyproject.toml
+        #   uv lock
+        uses: actions/upload-artifact@v4
+        with:
+          name: changelog-${{ steps.versions.outputs.new }}
+          path: /tmp/changelog_entry.md
+          if-no-files-found: ignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,3 +154,32 @@ jobs:
           name: changelog-${{ steps.versions.outputs.new }}
           path: /tmp/changelog_entry.md
           if-no-files-found: ignore
+
+      - name: Capture release screenshots
+        run: |
+          cd packages/buckaroo-js-core
+          npx playwright install chromium
+          npx playwright test pw-tests/theme-screenshots.spec.ts --reporter=line || true
+          VERSION="${{ steps.versions.outputs.new }}"
+          mkdir -p /tmp/screenshots-staging/"$VERSION"
+          for f in screenshots/*.png; do
+            [ -f "$f" ] || continue
+            base=$(basename "$f" .png)
+            cp "$f" /tmp/screenshots-staging/"$VERSION"/"${base}--${VERSION}.png"
+          done
+
+      - name: Publish screenshots to GitHub Pages
+        run: |
+          VERSION="${{ steps.versions.outputs.new }}"
+          git fetch origin gh-pages
+          git worktree add /tmp/gh-pages gh-pages
+          mkdir -p /tmp/gh-pages/screenshots/"$VERSION"
+          cp /tmp/screenshots-staging/"$VERSION"/*.png /tmp/gh-pages/screenshots/"$VERSION"/
+          python scripts/generate_screenshots_index.py /tmp/gh-pages/screenshots
+          cd /tmp/gh-pages
+          git add screenshots/
+          git diff --cached --quiet && echo "No screenshot changes" && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "screenshots: add release $VERSION screenshots"
+          git push origin gh-pages

--- a/scripts/generate_screenshots_index.py
+++ b/scripts/generate_screenshots_index.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate an index.html for the screenshots gallery on gh-pages.
+
+Reads the screenshots/ directory structure and produces a browsable page
+listing all releases with their screenshots.
+
+Usage:
+    python scripts/generate_screenshots_index.py <screenshots_dir>
+
+The screenshots_dir should contain subdirectories named by version
+(e.g. screenshots/0.13.3/) each containing .png files.
+"""
+import sys
+from pathlib import Path
+
+HTML_TEMPLATE = """\
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Buckaroo Screenshots</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; background: #111; color: #eee; padding: 2rem; }
+  h1 { margin-bottom: 1rem; }
+  h2 { margin: 2rem 0 1rem; border-bottom: 1px solid #333; padding-bottom: 0.5rem; }
+  .release { margin-bottom: 2rem; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(400px, 1fr)); gap: 1rem; }
+  .card { background: #1a1a1a; border-radius: 8px; overflow: hidden; }
+  .card img { width: 100%%; display: block; cursor: pointer; }
+  .card .label { padding: 0.5rem; font-size: 0.85rem; color: #aaa; }
+  a { color: #58a6ff; text-decoration: none; }
+  a:hover { text-decoration: underline; }
+  .nav { margin-bottom: 2rem; }
+  .nav a { margin-right: 1rem; }
+</style>
+</head>
+<body>
+<h1>Buckaroo Screenshots</h1>
+<div class="nav">%(nav)s</div>
+%(releases)s
+</body>
+</html>
+"""
+
+RELEASE_TEMPLATE = """\
+<div class="release" id="%(version)s">
+<h2>%(version)s</h2>
+<div class="grid">
+%(cards)s
+</div>
+</div>
+"""
+
+CARD_TEMPLATE = """\
+<div class="card">
+<a href="%(url)s" target="_blank"><img src="%(url)s" alt="%(name)s" loading="lazy"></a>
+<div class="label">%(name)s</div>
+</div>
+"""
+
+
+def main():
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <screenshots_dir>", file=sys.stderr)
+        sys.exit(1)
+
+    screenshots_dir = Path(sys.argv[1])
+    if not screenshots_dir.is_dir():
+        print(f"Not a directory: {screenshots_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Collect versions (sorted newest first by semver)
+    versions = sorted(
+        [d.name for d in screenshots_dir.iterdir() if d.is_dir() and not d.name.startswith('.')],
+        key=lambda v: [int(x) for x in v.split('.')],
+        reverse=True,
+    )
+
+    nav_links = []
+    release_blocks = []
+
+    for version in versions:
+        version_dir = screenshots_dir / version
+        pngs = sorted(p.name for p in version_dir.iterdir() if p.suffix == '.png')
+        if not pngs:
+            continue
+
+        nav_links.append(f'<a href="#{version}">{version}</a>')
+
+        cards = []
+        for png in pngs:
+            name = png.replace('.png', '')
+            url = f"{version}/{png}"
+            cards.append(CARD_TEMPLATE % {'url': url, 'name': name})
+
+        release_blocks.append(RELEASE_TEMPLATE % {
+            'version': version,
+            'cards': '\n'.join(cards),
+        })
+
+    html = HTML_TEMPLATE % {
+        'nav': ' '.join(nav_links),
+        'releases': '\n'.join(release_blocks),
+    }
+
+    output = screenshots_dir / 'index.html'
+    output.write_text(html)
+    print(f"Wrote {output} ({len(versions)} releases)")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- On each release, captures theme screenshots (light + dark) via Playwright
- Pushes to `gh-pages` under `screenshots/<version>/`
- Files named `<test-name>--<version>.png` for predictable URLs
- Auto-generates `index.html` gallery listing all releases
- Screenshots stored only in `gh-pages`, not checked into the repo

## URL pattern
```
https://buckaroo-data.github.io/buckaroo/screenshots/<version>/<name>.png
```

Gallery: `https://buckaroo-data.github.io/buckaroo/screenshots/`

## Test plan
- [ ] `scripts/generate_screenshots_index.py` generates valid HTML (tested locally)
- [ ] Release workflow runs screenshot capture after publish
- [ ] Screenshots appear on gh-pages after next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)