### PR TITLE
fix: force 500px height in small iframes (nteract)

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -516,9 +516,9 @@ export const heightStyle = (hArgs: HeightStyleArgs): HeightStyleI => {
     //console.log("maxRowsWithoutScrolling", maxRowsWithoutScrolling, belowMinRows, numRows, dfvHeight, rowHeight);
     const shortMode = compC?.shortMode || (belowMinRows && rowHeight === undefined);
     console.log("shortMode", shortMode, compC?.shortMode, belowMinRows, rowHeight);
-    const inIframeClass = inIframe ? "inIframe" : "";
+    const inIframeClass = inIframe ? "in-iframe" : "";
     //console.log("gridUtils 350 heightstyle", dfvHeight)
-    if (isGoogleColab || inVSCcode() ) {
+    if (isGoogleColab || inVSCcode() || (inIframe && window.innerHeight < 300)) {
         return {
             classMode: "regular-mode",
             domLayout: "normal",


### PR DESCRIPTION
## Summary
- When rendered inside a small iframe (e.g. nteract's isolated output frames), `window.innerHeight` is tiny (~115px), so `dfvHeight = innerHeight/2 ≈ 57px` — only the header row is visible
- Now detects iframe + small viewport (`< 300px`) and forces a fixed 500px height, same pattern used for Google Colab and VSCode
- Also fixes a CSS class name mismatch: JS was emitting `inIframe` but the CSS selectors target `.in-iframe` — so the iframe-specific min-height rules never applied

## Test plan
- [ ] Install from this branch in nteract and verify the widget renders at ~500px height
- [ ] Verify Jupyter/JupyterLab rendering is unaffected (not in an iframe, so no change)
- [ ] Verify Colab/VSCode still work (separate code path, unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)