### PR TITLE
fix: remove duplicate "Create GitHub release" step in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,14 +122,6 @@ jobs:
           # Pin hatch-vcs to the exact release version for the build step
           echo "SETUPTOOLS_SCM_PRETEND_VERSION=${{ steps.versions.outputs.new }}" >> "$GITHUB_ENV"
 
-      - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release create "${{ steps.versions.outputs.new }}" \
-            --title "${{ steps.versions.outputs.new }}" \
-            --notes-file /tmp/release_notes.md
-
       - name: Build wheel + sdist
         run: |
           ./scripts/full_build.sh


### PR DESCRIPTION
The screenshots PR (#656) introduced a second `gh release create` call. The first one ran before the build, creating the release early; the second one then failed with HTTP 422 (tag already exists). This also broke retry logic — each retry saw a release existed and bumped to the next version, producing three orphan releases (0.13.3, 0.13.4, 0.14.0).