### PR TITLE
lint(paddy-format): pipefail-safe CI find + add pre-commit hook

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Run ruff
         run: uv run ruff check
       - name: Run paddy-format check
-        run: uv run python scripts/paddy_format.py --check $(find buckaroo tests scripts -type f -name "*.py" -not -path "buckaroo/jlisp/lispy.py")
+        run: find buckaroo tests scripts -type f -name "*.py" -not -path "buckaroo/jlisp/lispy.py" -print0 | xargs -0 uv run python scripts/paddy_format.py --check
 
   TestJS:
     name: JS / Build + Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,12 @@ repos:
     rev: v1.7.11
     hooks:
       - id: actionlint
+  - repo: local
+    hooks:
+      - id: paddy-format
+        name: paddy-format
+        entry: uv run python scripts/paddy_format.py
+        language: system
+        types: [python]
+        files: ^(buckaroo|tests|scripts)/.*\.py$
+        exclude: ^buckaroo/jlisp/lispy\.py$


### PR DESCRIPTION
## Summary
Two follow-ups to #690 that didn't make it into the squash:

- **`458b3218` — surface find failures in the CI step.** The `$(find ...)` substitution swallowed find's exit code, so a missing/renamed search root (e.g., `buckaroo/`, `tests/`, or `scripts/`) would print an error but still let the step pass — silently shrinking lint coverage. Switched to `find -print0 | xargs -0` so find's exit propagates through GHA's default `bash -o pipefail`. Addresses Codex feedback on #690.
- **`f89647f1` — add a `paddy-format` pre-commit hook.** Mirrors the CI scope exactly (`^(buckaroo|tests|scripts)/.*\.py$`, excluding `buckaroo/jlisp/lispy.py`) so violations are caught locally before reaching CI.

## Test plan
- [x] `find buckaroo tests scripts -type f -name "*.py" -not -path "buckaroo/jlisp/lispy.py" -print0 | xargs -0 uv run python scripts/paddy_format.py --check` exits 0 locally.
- [x] `pre-commit run paddy-format --all-files` passes locally.
- [ ] CI `Python / Lint` step (`Run paddy-format check`) passes on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)