### PR TITLE
test: pre-warm mp_timeout context once per session (CI flake fix)

### DIFF
--- a/tests/unit/file_cache/conftest.py
+++ b/tests/unit/file_cache/conftest.py
@@ -1,0 +1,34 @@
+"""Session-scoped warm-up for the mp_timeout multiprocessing context.
+
+The first call to ``ctx.Process().start()`` (forkserver on POSIX, spawn on
+Windows) pays a one-time bootstrap cost — starting the forkserver helper or
+spinning up a fresh interpreter. On a slow CI runner that bootstrap can
+exceed the 1-second ``CI_TIMEOUT`` used by these tests, so the *first* test
+that calls a normal ``@mp_timeout``-wrapped function (``test_mp_timeout_pass``
+in particular) intermittently flakes with ``TimeoutException``. Subsequent
+calls reuse the warm pool and finish in milliseconds.
+
+This fixture forces one no-op invocation per session before any test runs,
+amortising the bootstrap cost so per-test timeouts only need to cover the
+work itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from buckaroo.file_cache.mp_timeout_decorator import mp_timeout
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_mp_context():
+    @mp_timeout(30.0)
+    def _noop():
+        return None
+
+    try:
+        _noop()
+    except Exception:
+        # Never block the test session if warm-up itself can't run — the
+        # individual tests will surface any real defect.
+        pass


### PR DESCRIPTION
## Summary
Fixes the chronic ``mp_timeout_decorator_test.py::test_mp_timeout_pass`` + ``test_mp_fail_then_normal`` flake on Python 3.11/3.12/Max-Versions CI legs. Adds a session-scoped autouse fixture in ``tests/unit/file_cache/conftest.py`` that pre-warms the multiprocessing context once before any test runs.

## Diagnosis
``buckaroo/file_cache/mp_timeout_decorator.py`` uses ``multiprocessing.get_context("forkserver")`` on POSIX and ``"spawn"`` on Windows. The **first** ``ctx.Process().start()`` of the session pays a one-time bootstrap cost (starting the forkserver helper or spinning up a fresh interpreter). On a slow ``depot-ubuntu-latest`` runner under load that bootstrap can exceed the 1-second ``CI_TIMEOUT`` defined in ``mp_test_utils.py``, so whichever test runs first eats the cold-start penalty and flakes with ``TimeoutException: Timeout fail``. Subsequent tests reuse the warm pool and finish in milliseconds — that's why the failure pattern is *always* the same two tests at session start, never the deeper ones.

## Fix
One file, 34 lines: a session-scoped ``autouse=True`` fixture that issues a single no-op ``@mp_timeout(30.0)`` call before any test runs. 30s is generous enough to cover pathological cold-starts; the fixture swallows exceptions so warm-up failures never block the session (real defects still surface in the individual tests).

## Test plan
- [x] ``pytest tests/unit/file_cache/`` — 72 passed locally
- [x] ``pytest tests/unit/file_cache/mp_timeout_decorator_test.py -v`` — 10 passed, 5 skipped (the skipped ones are diagnostic-only, pre-existing)
- [x] ``ruff check`` clean
- [x] ``paddy_format --check tests/unit/file_cache/conftest.py`` clean
- [ ] CI green on Python 3.11 + 3.12 + Max-Versions legs (the legs that currently flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)