### PR TITLE
docs(xorq-stats notebook): three custom stats with a real dependency

### DIFF
--- a/docs/example-notebooks/Xorq-Stats.ipynb
+++ b/docs/example-notebooks/Xorq-Stats.ipynb
@@ -28,7 +28,14 @@
     "\n",
     "from buckaroo.pluggable_analysis_framework.xorq_stat_pipeline import XorqStatPipeline, XorqDfStatsV2\n",
     "from buckaroo.pluggable_analysis_framework.stat_func import stat, XorqColumn\n",
-    "from buckaroo.customizations.xorq_stats_v2 import XORQ_STATS_V2"
+    "from buckaroo.customizations.xorq_stats_v2 import XORQ_STATS_V2\n",
+    "import pandas as pd\n",
+    "expr = xo.memtable({\n",
+    "    'price': [12.5, 18.9, 7.4, 22.1, None, 14.0, 9.9, 31.2, 11.5, 19.8],\n",
+    "    'qty': [1, 2, 1, 3, 1, 2, 4, 1, 2, 5],\n",
+    "    'category': ['a', 'b', 'a', 'c', 'a', 'b', 'b', 'c', 'a', 'b'],\n",
+    "    'is_promo': [True, False, False, True, False, False, True, True, False, True],\n",
+    "})"
    ]
   },
   {
@@ -52,13 +59,70 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "expr = xo.memtable({\n",
-    "    'price': [12.5, 18.9, 7.4, 22.1, None, 14.0, 9.9, 31.2, 11.5, 19.8],\n",
-    "    'qty': [1, 2, 1, 3, 1, 2, 4, 1, 2, 5],\n",
-    "    'category': ['a', 'b', 'a', 'c', 'a', 'b', 'b', 'c', 'a', 'b'],\n",
-    "    'is_promo': [True, False, False, True, False, False, True, True, False, True],\n",
-    "})\n",
+    "\n",
     "expr.execute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8d353ad3-4353-43fc-8b77-8e7a96c3c5cd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import buckaroo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c4ac8b7-9fad-4b0c-9800-e7762433ee59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "buckaroo.buckaroo_widget.BuckarooInfiniteWidget(expr.execute())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11029e2f-d887-40b7-8099-fcfa0db772a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "buckaroo.buckaroo_widget.XorqBuckarooInfiniteWidget(expr) \n",
+    "#we can make it such that this calls to_record_batches\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "beae0355-3e5c-4a1e-bca6-dc3bc5184367",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "next(expr.to_pyarrow_batches())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4b5d8f3-8498-4b6a-99a1-cc62797ba517",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "next(expr.head(50).to_pyarrow_batches())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5089507-5a9a-407e-ba8e-c603d81bc7b5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expr"
    ]
   },
   {
@@ -95,7 +159,6 @@
    "outputs": [],
    "source": [
     "# Convenience: cross-column summary as a DataFrame for readability.\n",
-    "import pandas as pd\n",
     "pd.DataFrame.from_dict(summary, orient='index')[\n",
     "    ['_type', 'length', 'null_count', 'distinct_count', 'min', 'max', 'mean', 'std']\n",
     "]"
@@ -244,12 +307,22 @@
    "id": "2f7a3604",
    "metadata": {},
    "source": [
-    "## 6. Adding a custom stat\n",
+    "## 6. Three custom stats from scratch — with a dependency\n",
     "\n",
-    "Any `@stat`-decorated function with an `XorqColumn` parameter\n",
-    "joins the batch aggregate. Return an ibis expression; the pipeline\n",
-    "compiles, runs, and writes the scalar result into the per-column\n",
-    "accumulator under the function's name."
+    "`@stat`-decorated functions come in two flavours:\n",
+    "\n",
+    "- **Batched aggregate** — parameter `col: XorqColumn`, returns an ibis\n",
+    "  expression. The pipeline folds it into the single `expr.aggregate(...)`\n",
+    "  call alongside every other batched stat, so it costs nothing extra.\n",
+    "- **Computed** — parameters are scalar stats from *other* `@stat`\n",
+    "  functions (declared via type-annotated argument names that match\n",
+    "  another stat's name). Runs after the batch resolves, in the typed\n",
+    "  DAG order; no SQL emitted.\n",
+    "\n",
+    "Below: `q1` and `q3` are batched (one quartile expression each, both\n",
+    "folded into the same backend round-trip); `iqr` is computed and\n",
+    "declares both as inputs, so the DAG runs `q1` and `q3` first and\n",
+    "hands the resolved floats to `iqr`."
    ]
   },
   {
@@ -259,20 +332,83 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "@stat(column_filter=lambda dt: dt.is_numeric())\n",
-    "def col_range(col: XorqColumn) -> float:\n",
-    "    return (col.max() - col.min()).cast('float64')\n",
+    "# Two batched stats — quartiles. Each returns an ibis expression that\n",
+    "# the pipeline folds into the single `expr.aggregate(...)` call.\n",
+    "@stat(column_filter=lambda dt: dt.is_numeric() and not dt.is_boolean())\n",
+    "def q1(col: XorqColumn) -> float:\n",
+    "    return col.quantile(0.25).cast('float64')\n",
     "\n",
     "@stat(column_filter=lambda dt: dt.is_numeric() and not dt.is_boolean())\n",
-    "def cv(mean: float, std: float) -> float:\n",
-    "    if mean is None or std is None or mean == 0:\n",
-    "        return None\n",
-    "    return std / mean\n",
+    "def q3(col: XorqColumn) -> float:\n",
+    "    return col.quantile(0.75).cast('float64')\n",
     "\n",
-    "extended = [*XORQ_STATS_V2, col_range, cv]\n",
-    "summary, _ = XorqStatPipeline(extended).process_table(expr)\n",
-    "summary\n",
-    "#pd.DataFrame.from_dict(summary, orient='index')[['_type', 'min', 'max', 'col_range', 'mean', 'std', 'cv']]"
+    "# Computed stat — depends on q1 and q3 by parameter name.\n",
+    "# No XorqColumn here; the pipeline resolves q1/q3 first and passes\n",
+    "# their scalar values in. Same column_filter so the dependency\n",
+    "# survives DAG filtering on non-numeric columns.\n",
+    "@stat(column_filter=lambda dt: dt.is_numeric() and not dt.is_boolean())\n",
+    "def iqr(q1: float, q3: float) -> float:\n",
+    "    if q1 is None or q3 is None:\n",
+    "        return None\n",
+    "    return q3 - q1\n",
+    "\n",
+    "# Run with just these three — no XORQ_STATS_V2 needed. The pipeline\n",
+    "# pre-populates `dtype`/`length`; everything else is what we defined.\n",
+    "summary, _ = XorqStatPipeline([q1, q3, iqr]).process_table(expr)\n",
+    "summary\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0d414a28-0d23-4f5a-9d81-b109f0729516",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame.from_dict(summary, orient='index')[['dtype', 'q1', 'q3', 'iqr']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31ddabb4-a244-4827-89c5-6499ac40808a",
+   "metadata": {},
+   "source": [
+    "## 7. The same IQR as a raw xorq expression\n",
+    "\n",
+    "The pipeline gives us DAG ordering, column filtering, and a place\n",
+    "for the result in each column's accumulator — but the underlying\n",
+    "work is just an `expr.aggregate(...)` call. Here's the same IQR\n",
+    "computation written by hand for two columns: `q1`, `q3`, and the\n",
+    "difference all live in a single aggregate, one round-trip to the\n",
+    "backend.\n",
+    "\n",
+    "Note that `iqr` doesn't need a separate computed phase here —\n",
+    "because we're inlining everything in one expression, the engine\n",
+    "computes `quantile(.75) - quantile(.25)` in SQL. The pipeline's\n",
+    "two-phase design (batch then computed) is what lets you reuse\n",
+    "`q1` and `q3` as inputs to *other* stats without reissuing the\n",
+    "quantile work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2119b2d0-a5fb-406d-97d2-d08384c88267",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Same answer, no decorators — `q1`, `q3`, and `iqr` all live in\n",
+    "# a single aggregate call. One backend round-trip for two columns.\n",
+    "agg = expr.aggregate(\n",
+    "    price_q1=expr.price.quantile(0.25).cast('float64'),\n",
+    "    price_q3=expr.price.quantile(0.75).cast('float64'),\n",
+    "    price_iqr=(expr.price.quantile(0.75) - expr.price.quantile(0.25)).cast('float64'),\n",
+    "    qty_q1=expr.qty.quantile(0.25).cast('float64'),\n",
+    "    qty_q3=expr.qty.quantile(0.75).cast('float64'),\n",
+    "    qty_iqr=(expr.qty.quantile(0.75) - expr.qty.quantile(0.25)).cast('float64'),\n",
+    ")\n",
+    "print(xo.to_sql(agg))\n",
+    "agg.execute()"
    ]
   },
   {
@@ -280,7 +416,7 @@
    "id": "ea3e9c41",
    "metadata": {},
    "source": [
-    "## 7. Bring your own backend\n",
+    "## 8. Bring your own backend\n",
     "\n",
     "Pass `backend=` to route every query (batched aggregate **and**\n",
     "per-column histograms) through a specific xorq backend. Useful\n",


### PR DESCRIPTION
## Summary

- Reframes section 6 around `q1` / `q3` / `iqr` — the third stat takes the first two as parameters, so it actually exercises the typed-DAG dependency that `@stat`-from-scratch enables (the previous `cv` example reused `mean`/`std` from `XORQ_STATS_V2`).
- Pipeline runs with just `[q1, q3, iqr]` — no `XORQ_STATS_V2` — to keep the minimal-construction path obvious.
- Adds section 7 showing the same IQR written by hand as a single `expr.aggregate(...)`. Clarifies what the pipeline buys you over a raw xorq expression: DAG ordering and column-filter cascade for stats that *consume* other stats — not the SQL itself.

## Test plan

- [x] `jupyter nbconvert --to notebook --execute` succeeds end-to-end
- [x] section 6 produces non-NaN `q1`/`q3`/`iqr` for numeric columns and NaN for non-numeric
- [x] section 7 emits the expected `PERCENTILE_CONT` SQL via `xo.to_sql(...)` and the executed values match section 6

🤖 Generated with [Claude Code](https://claude.com/claude-code)