### PR TITLE
TDD demo: xorq↔polars isolation test (red→green)

### DIFF
--- a/buckaroo/buckaroo_widget.py
+++ b/buckaroo/buckaroo_widget.py
@@ -124,7 +124,7 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
         self.record_transcript = record_transcript
         self.exception = None
         kls = self.__class__
-        class InnerDataFlow(CustomizableDataflow):
+        class InnerDataFlow(kls.dataflow_klass):
             sampling_klass = kls.sampling_klass
             autocleaning_klass = kls.autocleaning_klass
             DFStatsClass = kls.DFStatsClass
@@ -166,6 +166,7 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
     autocleaning_klass = PandasAutocleaning #override the base CustomizableDataFlow klass
     DFStatsClass = DfStatsV2 # Pandas Specific
     autoclean_conf = tuple([CleaningConf, NoCleaningConf]) #override the base CustomizableDataFlow conf
+    dataflow_klass = CustomizableDataflow
 
 
     df_data_dict = Dict({}).tag(sync=True)

--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -1,0 +1,193 @@
+"""XorqBuckarooWidget — buckaroo against a xorq/ibis expression.
+
+Stats compile to a single batched ``expr.aggregate(...)`` query plus
+per-column histogram queries; the only thing pulled into Python is a
+display-sized sample (via ``expr.limit(N).execute()``). Postprocessing
+is expression-to-expression: registered functions take the underlying
+xorq expr and return a new expr (or pandas DataFrame).
+
+Optional dependency: ``pip install 'buckaroo[xorq]'``.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pandas as pd
+
+from .buckaroo_widget import BuckarooWidget
+from .customizations.pl_autocleaning_conf import NoCleaningConfPl
+from .customizations.styling import DefaultMainStyling, DefaultSummaryStatsStyling
+from .customizations.xorq_stats_v2 import XORQ_STATS_V2
+from .dataflow.autocleaning import PandasAutocleaning
+from .dataflow.dataflow import CustomizableDataflow
+from .dataflow.dataflow_extras import Sampling
+from .df_util import old_col_new_col
+from .pluggable_analysis_framework.col_analysis import ColAnalysis
+from .pluggable_analysis_framework.xorq_stat_pipeline import XorqDfStatsV2
+from .serialization_utils import pd_to_obj
+
+logger = logging.getLogger(__name__)
+
+
+def _is_pandas(obj: Any) -> bool:
+    return isinstance(obj, pd.DataFrame)
+
+
+def _expr_count(expr_or_df: Any) -> int:
+    if _is_pandas(expr_or_df):
+        return len(expr_or_df)
+    try:
+        return int(expr_or_df.count().execute())
+    except Exception:
+        return 0
+
+
+class XorqSampling(Sampling):
+    """Push-down sampling.
+
+    Stats run against the full expression on the backend — there's no
+    pre-stats pandas sample. For display, ``serialize_sample`` materialises
+    ``expr.limit(serialize_limit).execute()`` (or returns a pandas
+    DataFrame as-is, e.g. an error frame from the post-processing path).
+    """
+
+    pre_limit = False
+
+    @classmethod
+    def pre_stats_sample(cls, expr):
+        return expr
+
+    @classmethod
+    def serialize_sample(cls, df_or_expr):
+        if _is_pandas(df_or_expr):
+            if cls.serialize_limit and len(df_or_expr) > cls.serialize_limit:
+                return df_or_expr.sample(cls.serialize_limit).sort_index()
+            return df_or_expr
+        if cls.serialize_limit:
+            return df_or_expr.limit(cls.serialize_limit).execute()
+        return df_or_expr.execute()
+
+
+class XorqAutocleaning(PandasAutocleaning):
+    """Pass-through autocleaning.
+
+    Cleaning operations run a lisp interpreter over a pandas DataFrame —
+    that surface doesn't apply to ibis exprs. Skip cleaning entirely so
+    the expr flows through to ``_compute_processed_result`` unchanged.
+    """
+
+    def handle_ops_and_clean(self, df, cleaning_method, quick_command_args, existing_operations):
+        if df is None:
+            return None
+        return [df, {}, "", []]
+
+
+class XorqDataflow(CustomizableDataflow):
+    """Dataflow specialised for ibis/xorq expression inputs.
+
+    Two pieces of behaviour differ from the pandas dataflow:
+
+    1. ``populate_df_meta`` can't ``len(expr)`` — it issues an
+       ``expr.count().execute()`` for the row count.
+    2. ``_get_summary_sd`` re-keys the summary dict from original column
+       names (what ``XorqStatPipeline`` produces) to the rewritten
+       ``a, b, c`` names that ``pd_to_obj`` and the styling layer expect.
+    """
+
+    def populate_df_meta(self) -> None:
+        if self.processed_df is None:
+            self.df_meta = {
+                'columns': 0, 'filtered_rows': 0,
+                'rows_shown': 0, 'total_rows': 0}
+            return
+        rows = _expr_count(self.processed_df)
+        limit = self.sampling_klass.serialize_limit
+        rows_shown = min(rows, limit) if limit else rows
+        self.df_meta = {
+            'columns': len(self.processed_df.columns),
+            'filtered_rows': rows,
+            'rows_shown': rows_shown,
+            'total_rows': _expr_count(self.orig_df)}
+
+    def _get_summary_sd(self, processed_df):
+        if _is_pandas(processed_df):
+            # The error path (and any postprocessor that returns a pandas
+            # DataFrame) doesn't go through XorqStatPipeline. Return a
+            # minimal SD so the main grid still renders.
+            empty: dict = {}
+            for orig_col, rewritten_col in old_col_new_col(processed_df):
+                empty[rewritten_col] = {
+                    'orig_col_name': orig_col,
+                    'rewritten_col_name': rewritten_col}
+            return empty, {}
+        sdf, errs = super()._get_summary_sd(processed_df)
+        rewritten = {}
+        for orig_col, rewritten_col in old_col_new_col(processed_df):
+            col_meta = dict(sdf.get(orig_col, {}))
+            col_meta['orig_col_name'] = orig_col
+            col_meta['rewritten_col_name'] = rewritten_col
+            rewritten[rewritten_col] = col_meta
+        return rewritten, errs
+
+
+_XORQ_ANALYSIS_KLASSES = list(XORQ_STATS_V2) + [DefaultSummaryStatsStyling, DefaultMainStyling]
+
+
+class XorqBuckarooWidget(BuckarooWidget):
+    """Buckaroo widget over a xorq/ibis expression.
+
+    Usage::
+
+        import xorq.api as xo
+        from buckaroo.xorq_buckaroo import XorqBuckarooWidget
+
+        expr = xo.memtable({'price': [...], 'qty': [...]})
+        XorqBuckarooWidget(expr)
+
+    Postprocessing functions take and return a xorq expression::
+
+        def top_categories(expr):
+            return expr.filter(expr.qty > 1)
+
+        widget = XorqBuckarooWidget(expr)
+        widget.add_processing(top_categories)  # also selects it
+    """
+
+    analysis_klasses = _XORQ_ANALYSIS_KLASSES
+    autocleaning_klass = XorqAutocleaning
+    autoclean_conf = tuple([NoCleaningConfPl])
+    DFStatsClass = XorqDfStatsV2
+    sampling_klass = XorqSampling
+    dataflow_klass = XorqDataflow
+
+    def _df_to_obj(self, df):
+        return pd_to_obj(self.sampling_klass.serialize_sample(df))
+
+    def _build_error_dataframe(self, e):
+        return pd.DataFrame({'err': [str(e)]})
+
+    def add_processing(self, expr_processing_func):
+        """Register a postprocessing function and switch to it.
+
+        ``expr_processing_func`` takes the current expression and returns
+        either a new expression or a pandas DataFrame. The returned object
+        replaces ``processed_df`` for display and stats; if it's still an
+        expression, stats continue to push down.
+        """
+        proc_func_name = expr_processing_func.__name__
+
+        class DecoratedXorqProcessing(ColAnalysis):
+            provides_defaults = {}
+
+            @classmethod
+            def post_process_df(kls, expr):
+                return [expr_processing_func(expr), {}]
+
+            post_processing_method = proc_func_name
+
+        DecoratedXorqProcessing.__name__ = f"DecoratedXorqProcessing_{proc_func_name}"
+        self.add_analysis(DecoratedXorqProcessing)
+        temp_state = self.buckaroo_state.copy()
+        temp_state['post_processing'] = proc_func_name
+        self.buckaroo_state = temp_state

--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -16,10 +16,9 @@ from typing import Any
 import pandas as pd
 
 from .buckaroo_widget import BuckarooWidget
-from .customizations.pl_autocleaning_conf import NoCleaningConfPl
 from .customizations.styling import DefaultMainStyling, DefaultSummaryStatsStyling
 from .customizations.xorq_stats_v2 import XORQ_STATS_V2
-from .dataflow.autocleaning import PandasAutocleaning
+from .dataflow.autocleaning import AutocleaningConfig, PandasAutocleaning
 from .dataflow.dataflow import CustomizableDataflow
 from .dataflow.dataflow_extras import Sampling
 from .df_util import old_col_new_col
@@ -67,6 +66,17 @@ class XorqSampling(Sampling):
         if cls.serialize_limit:
             return df_or_expr.limit(cls.serialize_limit).execute()
         return df_or_expr.execute()
+
+
+class NoCleaningConfXorq(AutocleaningConfig):
+    """No-cleaning config local to the xorq path — avoids importing
+    ``NoCleaningConfPl`` (which would transitively load polars and break
+    a polars-less ``buckaroo[xorq]`` install)."""
+
+    autocleaning_analysis_klasses = []
+    command_klasses = []
+    quick_command_klasses = []
+    name = ""
 
 
 class XorqAutocleaning(PandasAutocleaning):
@@ -156,7 +166,7 @@ class XorqBuckarooWidget(BuckarooWidget):
 
     analysis_klasses = _XORQ_ANALYSIS_KLASSES
     autocleaning_klass = XorqAutocleaning
-    autoclean_conf = tuple([NoCleaningConfPl])
+    autoclean_conf = tuple([NoCleaningConfXorq])
     DFStatsClass = XorqDfStatsV2
     sampling_klass = XorqSampling
     dataflow_klass = XorqDataflow

--- a/tests/unit/test_xorq_buckaroo_widget.py
+++ b/tests/unit/test_xorq_buckaroo_widget.py
@@ -1,0 +1,106 @@
+"""End-to-end tests for XorqBuckarooWidget.
+
+Cover the bits the widget owns on top of XorqStatPipeline /
+XorqDfStatsV2: column-name rewriting for the frontend, df_meta from
+``expr.count()``, postprocessing registration, and the error fallback
+when a postprocessor raises.
+"""
+
+import pytest
+
+xo = pytest.importorskip("xorq.api")
+
+from buckaroo.xorq_buckaroo import XorqBuckarooWidget  # noqa: E402
+
+
+def _expr():
+    return xo.memtable(
+        {"price": [12.5, 18.9, 7.4, 22.1, 14.0, 9.9, 31.2, 11.5, 19.8, 50.0], "qty": [1, 2, 1, 3, 2, 4, 1, 2, 5, 9],
+         "category": ["a", "b", "a", "c", "b", "b", "c", "a", "b", "c"]})
+
+
+class TestInstantiation:
+    def test_smoke(self):
+        XorqBuckarooWidget(_expr())
+
+    def test_df_meta_from_count(self):
+        w = XorqBuckarooWidget(_expr())
+        assert w.df_meta["columns"] == 3
+        assert w.df_meta["filtered_rows"] == 10
+        assert w.df_meta["total_rows"] == 10
+
+    def test_columns_rewritten_for_frontend(self):
+        """Frontend works in 'a, b, c' space; orig names land in header_name."""
+        w = XorqBuckarooWidget(_expr())
+        cc = w.df_display_args["main"]["df_viewer_config"]["column_config"]
+        rewritten = [(c.get("col_name"), c.get("header_name")) for c in cc]
+        assert ("a", "price") in rewritten
+        assert ("b", "qty") in rewritten
+        assert ("c", "category") in rewritten
+
+    def test_main_data_serialized(self):
+        w = XorqBuckarooWidget(_expr())
+        rows = w.df_data_dict["main"]
+        assert len(rows) == 10
+        assert "a" in rows[0]  # rewritten 'price'
+
+    def test_summary_sd_keyed_by_rewritten_name(self):
+        w = XorqBuckarooWidget(_expr())
+        merged = w.dataflow.merged_sd
+        assert "a" in merged
+        assert merged["a"]["orig_col_name"] == "price"
+        assert merged["a"]["length"] == 10
+        assert merged["a"]["min"] == 7.4
+        assert merged["a"]["max"] == 50.0
+
+
+class TestPostProcessing:
+    def test_add_processing_registers_and_selects(self):
+        w = XorqBuckarooWidget(_expr())
+
+        def big_qty(expr):
+            return expr.filter(expr.qty > 2)
+
+        w.add_processing(big_qty)
+        assert "big_qty" in w.buckaroo_options["post_processing"]
+        assert w.buckaroo_state["post_processing"] == "big_qty"
+
+    def test_filter_pushes_down(self):
+        """Stats run on the filtered expr — length and min reflect the filter."""
+        w = XorqBuckarooWidget(_expr())
+
+        def big_qty(expr):
+            return expr.filter(expr.qty > 2)
+
+        w.add_processing(big_qty)
+        merged = w.dataflow.merged_sd
+        assert merged["a"]["length"] == 4  # 4 rows have qty > 2
+        # min price among rows with qty > 2 is 9.9 (qty=4)
+        assert merged["a"]["min"] == 9.9
+        assert w.df_meta["filtered_rows"] == 4
+
+    def test_switch_back_to_no_processing(self):
+        w = XorqBuckarooWidget(_expr())
+
+        def big_qty(expr):
+            return expr.filter(expr.qty > 2)
+
+        w.add_processing(big_qty)
+        state = w.buckaroo_state.copy()
+        state["post_processing"] = ""
+        w.buckaroo_state = state
+        assert w.df_meta["filtered_rows"] == 10
+
+    def test_processing_error_renders_error_frame(self):
+        w = XorqBuckarooWidget(_expr())
+
+        def bad(expr):
+            raise RuntimeError("boom")
+
+        w.add_processing(bad)
+        rows = w.df_data_dict["main"]
+        assert len(rows) == 1
+        # error frame is one column 'err' (rewritten to 'a') with the message
+        assert rows[0].get("a") == "boom"
+        assert w.df_meta["columns"] == 1
+        assert w.df_meta["filtered_rows"] == 1

--- a/tests/unit/test_xorq_polars_isolation.py
+++ b/tests/unit/test_xorq_polars_isolation.py
@@ -1,0 +1,65 @@
+"""Architectural test: ``buckaroo.xorq_buckaroo`` must import without
+polars, and ``buckaroo.polars_buckaroo`` must import without xorq.
+
+Both ``polars`` and ``xorq`` are optional extras; pulling one in
+through the other turns ``pip install 'buckaroo[xorq]'`` into a
+broken install. Run each import in a fresh subprocess with a
+meta-path blocker so a regression shows up as a clear ImportError.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def _run_with_blocked(blocked_packages: list[str], target_module: str) -> None:
+    blocked_repr = repr(tuple(blocked_packages))
+    script = textwrap.dedent(
+        f"""
+        import sys
+        import importlib.abc
+
+        BLOCKED = {blocked_repr}
+
+        class Blocker(importlib.abc.MetaPathFinder):
+            def find_spec(self, name, path, target=None):
+                if name in BLOCKED or any(name.startswith(b + '.') for b in BLOCKED):
+                    raise ImportError(f'BLOCKED: {{name}}')
+
+        sys.meta_path.insert(0, Blocker())
+        __import__({target_module!r})
+        """)
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        pytest.fail(
+            f"Importing {target_module} pulled in a blocked package "
+            f"({blocked_packages}):\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}")
+
+
+def test_xorq_buckaroo_imports_without_polars():
+    """``buckaroo[xorq]`` must not transitively require ``polars``."""
+    pytest.importorskip("xorq.api")
+    _run_with_blocked(
+        blocked_packages=["polars", "buckaroo.customizations.pl_autocleaning_conf",
+            "buckaroo.customizations.polars_commands", "buckaroo.customizations.polars_analysis",
+            "buckaroo.customizations.pl_stats_v2", "buckaroo.polars_buckaroo", "buckaroo.lazy_infinite_polars_widget",
+            "buckaroo.pluggable_analysis_framework.polars_analysis_management",
+            "buckaroo.pluggable_analysis_framework.polars_utils"],
+        target_module="buckaroo.xorq_buckaroo")
+
+
+def test_polars_buckaroo_imports_without_xorq():
+    """``buckaroo[polars]`` must not transitively require ``xorq``."""
+    pytest.importorskip("polars")
+    _run_with_blocked(
+        blocked_packages=["xorq", "buckaroo.xorq_buckaroo", "buckaroo.customizations.xorq_stats_v2",
+            "buckaroo.pluggable_analysis_framework.xorq_stat_pipeline"],
+        target_module="buckaroo.polars_buckaroo")


### PR DESCRIPTION
## Purpose

Demonstration PR for the TDD discipline in CLAUDE.md — *the test must be seen failing on CI before the fix lands.* Two commits, intended to be viewed in order:

1. **RED — `a5feb3ff`** adds `tests/unit/test_xorq_polars_isolation.py` plus the original `XorqBuckarooWidget` from PR #703's first commit, which still reuses `NoCleaningConfPl` from polars-land. The isolation test (`test_xorq_buckaroo_imports_without_polars`) fails: importing `buckaroo.xorq_buckaroo` in a subprocess with polars-side modules blocked surfaces an `ImportError: BLOCKED: buckaroo.customizations.pl_autocleaning_conf`.

2. **GREEN — `e30136b2`** introduces a self-contained `NoCleaningConfXorq` in `xorq_buckaroo.py` and switches `autoclean_conf` to it. The cross-import is gone; the isolation test passes.

## What to look at

- The "Python / Test (3.13)" job on the RED commit shows the isolation test failing.
- The same job on the GREEN commit shows it passing.
- Other matrix entries (3.14, Max Versions 3.14) skip the test because xorq isn't installed there — `pytest.importorskip("xorq.api")` short-circuits.

This PR is **not for merge** — it's a demo so we can read CI output for both states. PR #703 already carries the same fix and the same regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)