### PR TITLE
fix(xorq): #709 cut SQL queries 51→9 on widget construction

### DIFF
--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -222,10 +222,23 @@ class DataFlow(ABCDataflow):
             ret_summary[col] = {}
         return ret_summary, {}
 
+    _summary_sd_cache_key = (None, None)
+
     @observe('processed_result', 'analysis_klasses')
     @exception_protect('summary_sd-protector')
     def _summary_sd(self, change):
-        result_summary_sd, errs  = self._get_summary_sd(self.processed_df)
+        # Dedupe: the autocleaning operations cascade re-fires
+        # _operation_result → cleaned → processed_result with a freshly-built
+        # tuple wrapper, which makes this observer fire twice per widget
+        # construction even when processed_df identity is unchanged.
+        # Skip when neither the dataframe nor analysis_klasses has actually
+        # changed since the last run. See issue #709.
+        df = self.processed_df
+        klasses = self.analysis_klasses
+        if (id(df), id(klasses)) == self._summary_sd_cache_key:
+            return
+        self._summary_sd_cache_key = (id(df), id(klasses))
+        result_summary_sd, errs  = self._get_summary_sd(df)
         self.summary_sd = result_summary_sd
         self.errs = errs
 

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -342,11 +342,17 @@ class XorqDfStatsV2:
 
     @classmethod
     def verify_analysis_objects(cls, objs):
-        XorqStatPipeline(objs)
+        # unit_test=False to skip the per-widget PERVERSE_DF pipeline run
+        # (issue #709). DAG validation still runs as part of __init__.
+        XorqStatPipeline(objs, unit_test=False)
 
     def __init__(self, table, col_analysis_objs, operating_df_name=None, debug=False):
         self.table = table
-        self.ap = XorqStatPipeline(col_analysis_objs)
+        # Skip the unit_test PERVERSE_DF run on each widget construction —
+        # it doubles the SQL query count (issue #709). The DAG-validation
+        # cost is already paid by verify_analysis_objects on first set up
+        # and by the test suite. Mirrors PlDfStatsV2.
+        self.ap = XorqStatPipeline(col_analysis_objs, unit_test=False)
         self.operating_df_name = operating_df_name
         self.debug = debug
         self.sdf, self.errs = self.ap.process_table_v1_compat(self.table)

--- a/docs/research/perf-polars-stats.md
+++ b/docs/research/perf-polars-stats.md
@@ -390,16 +390,27 @@ Infinite variant on the same data:
    number** in any of the harnesses — pandas DataFrame → duckdb table
    ingestion of a 376 MB string-heavy frame.
 
-### What's next for xorq perf
+### Update — #709 fix landed (PR #710)
 
-Not investigated here, but worth considering:
-- Profile `XorqStatPipeline.process_df` to see whether the cost is
-  per-query overhead (network/IPC) or actual SQL execution. If it's
-  the former, batching multiple stats into a single SQL query (one
-  SELECT with many aggregations) would collapse the round-trip count.
-- The `XorqDfStatsV2` likely benefits from the #706 traitlets fix
-  (it inherits the DataFlow traits), but the win is small there
-  because xorq exprs don't have an O(rows × cols) `__eq__`.
+Profiling confirmed it's per-query overhead, not SQL execution. Three
+fixes (`_summary_sd` dedupe, `XorqDfStatsV2` and
+`verify_analysis_objects` both pass `unit_test=False`) cut the query
+count by ~80% and the wall time by 2.3-3.9×:
+
+| dataset | xorq[df] PRE | xorq[df] POST | xorq[duckdb] PRE | xorq[duckdb] POST |
+| --- | --- | --- | --- | --- |
+| synth 100k × 8 | 320 ms | **81 ms** (3.9×) | 364 ms | **103 ms** (3.5×) |
+| synth 500k × 8 | 437 ms | **133 ms** (3.3×) | 396 ms | **118 ms** (3.4×) |
+| Fielding 174k × 18 | 555 ms | **209 ms** (2.7×) | 690 ms | **269 ms** (2.6×) |
+| Boston 883k × 26 | 793 ms | **318 ms** (2.5×) | 744 ms | **325 ms** (2.3×) |
+
+Post-fix query count: 4 (3-col fixture), 9 (8 cols), 27 (26 cols).
+Remaining is 1 batched aggregate + 1 histogram per column.
+
+Still TODO: fold histograms into the batched aggregate to drop the
+count to 1-2 regardless of column count. Numeric histograms can use
+the already-computed min/max via a 2-pass batch; categorical top-K
+is harder to batch in ibis.
 
 ## Updated picture of "polars feels slower"
 

--- a/tests/unit/test_xorq_buckaroo_widget.py
+++ b/tests/unit/test_xorq_buckaroo_widget.py
@@ -23,6 +23,43 @@ def _expr():
          "category": ["a", "b", "a", "c", "b", "b", "c", "a", "b", "c"]})
 
 
+class TestQueryCount:
+    """Regression for #709: XorqStatPipeline used to issue ~51 SQL queries
+    per widget construction on an 8-col input — a 4× redundant pipeline run
+    (per-column histograms × 2 _get_summary_sd × (real table + PERVERSE_DF
+    unit_test)). Cap query count to a small constant.
+    """
+
+    def test_widget_construction_query_count(self):
+        from buckaroo.pluggable_analysis_framework.xorq_stat_pipeline import XorqStatPipeline
+        # Patch _execute on the class so all pipelines (real + unit_test) count.
+        orig = XorqStatPipeline._execute
+        queries = []
+
+        def counting(self, q):
+            queries.append(q)
+            return orig(self, q)
+
+        XorqStatPipeline._execute = counting
+        try:
+            XorqBuckarooWidget(_expr())
+        finally:
+            XorqStatPipeline._execute = orig
+
+        # Pre-fix #709: 41 queries on the 3-col fixture (4× redundant
+        # pipeline runs + per-column histograms). Post-fix: 4 (one batched
+        # aggregate + one histogram per column). Cap at 6 for CI headroom.
+        # If this rises above 6, suspect either:
+        #  - _summary_sd dedupe broke (cascade re-firing)
+        #  - XorqStatPipeline(unit_test=True) coming back into a hot path
+        #  - new per-column query added somewhere
+        # If we ever batch histograms (#709 follow-up), this can drop to 1.
+        assert len(queries) <= 6, (
+            f"XorqBuckarooWidget(3-col) issued {len(queries)} SQL queries; "
+            f"expected ≤ 6 (#709 regression). Pre-fix baseline was 41."
+        )
+
+
 class TestInstantiation:
     def test_smoke(self):
         XorqBuckarooWidget(_expr())


### PR DESCRIPTION
## Summary

Closes #709. Three independent fixes that drop XorqBuckarooWidget construction SQL query count from 51 → 9 (8-col synthetic) and 87 → 27 (26-col Boston restaurants), with proportional perf wins (2.3-3.9× faster widget construction).

## What's wrong (today)

`XorqBuckarooWidget(expr)` issues 51 separate SQL queries during construction on an 8-column input. Three stacked causes:

1. **`_summary_sd` observer fires twice.** `DataFlow._operation_result` re-sets `self.operations = result[3]`, which triggers another `_operation_result` cascade because the observer also watches `operations`. Every cascade rebuilds `processed_result` as a fresh tuple wrapper, so `_summary_sd`'s observer fires again even though `processed_df` identity hasn't changed.
2. **`XorqDfStatsV2` constructs `XorqStatPipeline(unit_test=True)`** (the default) on every widget. The unit test runs the full pipeline against `PERVERSE_DF` — a SQL roundtrip per stat per col. `PlDfStatsV2` already passes `unit_test=False` for the same reason; xorq missed it.
3. **`verify_analysis_objects` also defaults to `unit_test=True`.** Called from `setup_options_from_analysis` on every widget.

## Fixes

`buckaroo/dataflow/dataflow.py:_summary_sd` — dedupe by `(id(processed_df), id(analysis_klasses))`:

```python
_summary_sd_cache_key = (None, None)

@observe('processed_result', 'analysis_klasses')
@exception_protect('summary_sd-protector')
def _summary_sd(self, change):
    df = self.processed_df
    klasses = self.analysis_klasses
    if (id(df), id(klasses)) == self._summary_sd_cache_key:
        return
    self._summary_sd_cache_key = (id(df), id(klasses))
    result_summary_sd, errs = self._get_summary_sd(df)
    self.summary_sd = result_summary_sd
    self.errs = errs
```

Identity comparison is right here — the `==` would be cheap in xorq (returns an expression) but using `is`/`id` is consistent with `DfTrait` (#706).

`buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py:XorqDfStatsV2.__init__` and `verify_analysis_objects` — pass `unit_test=False`. DAG validation (the part that actually catches misconfig) still runs in `XorqStatPipeline.__init__`; only the per-widget `PERVERSE_DF` SQL roundtrip is skipped.

## Numbers

Query count after fix:

| dataset | pre | post |
| --- | --- | --- |
| `_expr()` 3 cols | 41 | **4** |
| synth 50k × 8 | 51 | **9** |
| Boston 50k × 26 | 87 | **27** |

Widget construction time (warm best of 3, after `create_table`):

| dataset | xorq[df] PRE | xorq[df] POST | speedup |
| --- | --- | --- | --- |
| synth 100k × 8 | 320 ms | **81 ms** | **3.9×** |
| synth 500k × 8 | 437 ms | **133 ms** | 3.3× |
| Fielding 174k × 18 | 555 ms | **209 ms** | 2.7× |
| Boston 883k × 26 | 793 ms | **318 ms** | 2.5× |

| dataset | xorq[duckdb] PRE | xorq[duckdb] POST | speedup |
| --- | --- | --- | --- |
| synth 100k × 8 | 364 ms | **103 ms** | 3.5× |
| synth 500k × 8 | 396 ms | **118 ms** | 3.4× |
| Fielding 174k × 18 | 690 ms | **269 ms** | 2.6× |
| Boston 883k × 26 | 744 ms | **325 ms** | 2.3× |

xorq[datafusion] is now competitive with polars on small-N (synth 100k: 81 vs 99 ms) and beats pandas on large-N (Boston: 318 vs 758 ms post-#706 fix).

## What's still left

The remaining ~9 queries on 8 cols are 1 batched aggregate + 1 histogram per column. Folding histograms into the batched aggregate would drop the count to 1-2 regardless of column count — that's the polars-equivalent end state. Out of scope for this PR; deserves its own design (numeric histograms can use the already-computed min/max via a 2-pass batch; categorical top-K is harder to batch in ibis).

## Test plan

- [x] New `TestQueryCount.test_widget_construction_query_count` asserts ≤ 6 queries for the 3-col fixture (was 41).
- [x] Full unit suite stays green (956 passed).
- [x] Re-run `scripts/perf/perf_xorq.py` — numbers above match the report.

## Commits

1. **`test(xorq): failing query-count regression test for #709`** — pushed first; CI fails on this commit (assertion: 41 ≤ 6).
2. **(coming next push)** the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)