### PR TITLE
fix(pandas): #706 traitlets DataFrame equality on widget construction

### DIFF
--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -21,6 +21,32 @@ from .styling_core import (
 
 
 from .abc_dataflow import ABCDataflow
+
+
+class DfTrait(Any):
+    """Any-trait for values that may contain a pandas/polars DataFrame.
+
+    The default ``traitlets.TraitType.set`` decides whether to fire
+    ``@observe`` callbacks via ``bool(old_value == new_value)``. For a
+    DataFrame that triggers a full element-wise comparison
+    (O(rows × cols)) — and on widget construction with a moderately large
+    frame, those traitlets-internal comparisons dominate runtime
+    (~78% of construction time on a real 883k×26 CSV; see issue #706).
+
+    DfTrait uses identity comparison instead. Trades a possible
+    spurious notification (cheap) when the same DataFrame object is
+    re-assigned for skipping the expensive ``==``.
+    """
+
+    def set(self, obj, value):
+        new_value = self._validate(obj, value)
+        try:
+            old_value = obj._trait_values[self.name]
+        except KeyError:
+            old_value = self.default_value
+        obj._trait_values[self.name] = new_value
+        if old_value is not new_value:
+            obj._notify_trait(self.name, old_value, new_value)
     
 class DataFlow(ABCDataflow):
     """This class is meant to only represent the dataflow through
@@ -59,9 +85,9 @@ class DataFlow(ABCDataflow):
         'generated_py_code': ""})
 
 
-    raw_df = Any('')
+    raw_df = DfTrait('')
     sample_method = Unicode('default')
-    sampled_df = Any('')
+    sampled_df = DfTrait('')
 
     cleaning_method = Unicode('')
     quick_command_args = Dict({})
@@ -70,10 +96,10 @@ class DataFlow(ABCDataflow):
     # us that the interpeter is run through at least once
     operations = Any([]).tag(sync=True)
 
-    cleaned = Any().tag(default=None)
-    
+    cleaned = DfTrait().tag(default=None)
+
     post_processing_method = Unicode('').tag(default='')
-    processed_result = Any().tag(default=None)
+    processed_result = DfTrait().tag(default=None)
 
     analysis_klasses = None
     summary_sd = Any()
@@ -88,7 +114,7 @@ class DataFlow(ABCDataflow):
 
     merged_column_config = Any()
 
-    widget_args_tuple = Any()
+    widget_args_tuple = DfTrait()
 
 
     

--- a/tests/unit/perf_regression_test.py
+++ b/tests/unit/perf_regression_test.py
@@ -45,9 +45,52 @@ def test_basic_instantiation():
     bw_do_stuff(float_df(100_000,5))
     bw_end2 = time.time()
     bw_time_2 = bw_end2 - bw_start2
-    
+
     assert bw_time_2 < np_time * 60
 
 
+# ============================================================
+# Issue #706 — pandas widget construction must not perform full DataFrame
+# equality during traitlets change-detection. Cost is O(rows × cols) and
+# dominated 78% of construction time on a real 883k×26 CSV.
+# ============================================================
+
+def _best_of(fn, n=3):
+    fn()  # warmup
+    times = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return min(times)
 
 
+def test_pandas_infinite_widget_no_full_dataframe_eq():
+    """Regression for #706: traitlets _compare must use identity for DF traits.
+
+    Construction time on a 200k×10 object-dtype frame must not scale anywhere
+    near linearly with cells (the bug makes it scale exactly linearly).
+    """
+    from buckaroo.buckaroo_widget import BuckarooInfiniteWidget
+
+    big = pd.DataFrame({f'c{i}': ['xyz'] * 200_000 for i in range(10)})
+    small = pd.DataFrame({f'c{i}': ['xyz'] * 1_000 for i in range(10)})
+
+    # Warmup imports + first-DAG-build so the first measured call doesn't pay
+    # cold-start cost.
+    BuckarooInfiniteWidget(small)
+    BuckarooInfiniteWidget(big)
+
+    big_t = _best_of(lambda: BuckarooInfiniteWidget(big), n=3)
+    small_t = _best_of(lambda: BuckarooInfiniteWidget(small), n=3)
+    ratio = big_t / max(small_t, 1e-6)
+
+    # Bug today: ratio ~6-8x (DataFrame.__eq__ scales with cells).
+    # Fixed: ratio ~1.5-2x (just stat-pipeline overhead on more rows).
+    # 3.5x leaves CI headroom and still discriminates clearly.
+    assert ratio < 3.5, (
+        f"BuckarooInfiniteWidget on 200k×10 obj df is {big_t*1000:.0f}ms, "
+        f"{ratio:.1f}x the 1k×10 baseline ({small_t*1000:.0f}ms). "
+        "Construction is scaling with cells — likely traitlets DataFrame.__eq__ "
+        "regression (#706)."
+    )


### PR DESCRIPTION
Closes #706.

## Summary

`traitlets.TraitType.set` decides whether to fire `@observe` callbacks via `bool(old_value == new_value)`. For pandas DataFrames, that triggers a full element-wise comparison (O(rows × cols), pure Python). Profiling on the Boston restaurant inspections CSV (883k × 26) showed **~586 ms / 78%** of `BuckarooInfiniteWidget` construction time was in two such comparisons.

## Fix

Add a `DfTrait` subclass that uses identity (`is`) instead of `==`. Apply to the five `Any()` traits in `DataFlow` that may hold DataFrames or DataFrame-bearing tuples: `raw_df`, `sampled_df`, `cleaned`, `processed_result`, `widget_args_tuple`.

## Numbers (Boston 883k × 26, warm best of 3)

| | pre | post |
| --- | ---: | ---: |
| `BuckarooWidget` | 758 ms | **157 ms** (4.8×) |
| `BuckarooInfiniteWidget` | 715 ms | **112 ms** (6.4×) |

## Stack

Based on **#711** (perf monitoring infrastructure). Sibling PRs:
- **polars `_pl_vc_to_pd`** — separate PR
- **xorq SQL query reduction** — separate PR

## Test plan

- [x] `tests/unit/perf_regression_test.py::test_pandas_infinite_widget_no_full_dataframe_eq` asserts ratio < 3.5 (pre-fix: 6.6, post-fix: ~1.8).
- [x] Full unit suite stays green (one unrelated pre-existing flake in `test_mcp_uvx_install.py`).
- [ ] Failing test pushed alone first; fix in next commit per project TDD pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)