### PR TITLE
fix(polars): #707 _pl_vc_to_pd uses .to_numpy() instead of .to_list()

### DIFF
--- a/buckaroo/customizations/pl_stats_v2.py
+++ b/buckaroo/customizations/pl_stats_v2.py
@@ -67,8 +67,11 @@ def _pl_vc_to_pd(ser: pl.Series) -> pd.Series:
     which expect a pd.Series value_counts.
     """
     vc = ser.drop_nulls().value_counts(sort=True)
-    col_name = ser.name
-    return pd.Series(vc['count'].to_list(), index=vc[col_name].to_list())
+    # Cast count to int64 to match the previous .to_list() path's effective
+    # dtype. Keeps `categorical_dict`'s `full_long_tail - unique_count`
+    # subtraction signed (counts come back as uint32, which underflows on 0-N).
+    counts = vc['count'].to_numpy().astype(np.int64, copy=False)
+    return pd.Series(counts, index=vc[ser.name].to_numpy())
 
 
 @stat()

--- a/tests/unit/perf_regression_test.py
+++ b/tests/unit/perf_regression_test.py
@@ -94,3 +94,31 @@ def test_pandas_infinite_widget_no_full_dataframe_eq():
         "Construction is scaling with cells — likely traitlets DataFrame.__eq__ "
         "regression (#706)."
     )
+
+
+# ============================================================
+# Issue #707 — _pl_vc_to_pd must not regress to .to_list().
+# .to_list() is ~9x slower than .to_numpy() for value_counts conversion.
+# ============================================================
+
+def test_pl_vc_to_pd_not_using_to_list():
+    """Regression for #707: _pl_vc_to_pd must use .to_numpy(), not .to_list()."""
+    import polars as pl
+    from buckaroo.customizations.pl_stats_v2 import _pl_vc_to_pd
+
+    ser = pl.Series('a', list(range(50_000)))
+
+    def fast_baseline():
+        vc = ser.drop_nulls().value_counts(sort=True)
+        return pd.Series(vc['count'].to_numpy(), index=vc[ser.name].to_numpy())
+
+    impl_t = _best_of(lambda: _pl_vc_to_pd(ser), n=5)
+    fast_t = _best_of(fast_baseline, n=5)
+
+    # Current (.to_list) is ~9x slower than baseline; fixed (.to_numpy)
+    # should be within ~1x. 3x leaves comfortable CI headroom either way.
+    ratio = impl_t / max(fast_t, 1e-6)
+    assert ratio < 3.0, (
+        f"_pl_vc_to_pd is {impl_t*1000:.1f}ms vs to_numpy baseline {fast_t*1000:.1f}ms "
+        f"({ratio:.1f}x). Likely a .to_list() regression — see issue #707."
+    )


### PR DESCRIPTION
Closes #707.

## Summary

`_pl_vc_to_pd` in `pl_stats_v2` converts polars `value_counts` output to a pandas Series via `.to_list()`. Switching to `.to_numpy()` is **~9× faster** on numeric columns and **~3.5× faster** on strings.

`.to_list()` materializes N Python objects per call; `.to_numpy()` is a zero-copy numpy view (or single allocation for strings). pandas's `Series` constructor accepts both, so the swap is invisible at the call site.

## Caveat addressed

Counts come back as `uint32`. The `.to_list()` path lossily upcast via Python ints; `.to_numpy()` preserves `uint32`, which underflows in `categorical_dict`'s `full_long_tail - unique_count` when `full_long_tail = 0`. Fix casts the count column to `int64` to match the previous effective dtype.

## Numbers (50k unique ints, min of 5)

| step | ms |
| --- | ---: |
| `_pl_vc_to_pd` current (`.to_list()`) | 7.2 |
| same with `.to_numpy()` | 0.7 |
| ratio | **10×** |

## Stack

Based on **#711** (perf monitoring infrastructure). Sibling PRs:
- **pandas DfTrait** — separate PR
- **xorq SQL query reduction** — separate PR

## Test plan

- [x] `tests/unit/perf_regression_test.py::test_pl_vc_to_pd_not_using_to_list` asserts ratio < 3.0 (pre-fix: ~10×, post-fix: ~1×).
- [x] Existing pl_stats_v2 tests still pass (unchanged behavior).
- [ ] Failing test pushed alone first; fix in next commit per project TDD pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)