### PR TITLE
feat(row-cache): rowid-keyed RowStore + view layer (phases 1-7a of cache redesign)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,11 @@ repos:
         types: [python]
         files: ^(buckaroo|tests|scripts)/.*\.py$
         exclude: ^buckaroo/jlisp/lispy\.py$
+      - id: tsc-buckaroo-js-core
+        name: tsc buckaroo-js-core
+        # Type-check the whole project, not just staged files — TS needs
+        # to resolve imports across the project graph. ~0.65s warm.
+        entry: pnpm --filter buckaroo-js-core exec tsc -b
+        language: system
+        files: ^packages/buckaroo-js-core/.*\.(ts|tsx)$
+        pass_filenames: false

--- a/buckaroo/row_cache_payloads.py
+++ b/buckaroo/row_cache_payloads.py
@@ -11,10 +11,8 @@ parquet bytes:
 materialises the source (xorq lazy → pa.Table), appends a dense
 ``_buckaroo_rowid`` column starting at 0, and re-wraps as a memtable so
 the rest of the pipeline can keep operating on a stable in-memory
-expression.
-
-Phase 6 of the redesign — pure functions, no widget wiring (that's
-phase 7).
+expression. The rowid column is ``int32`` so it matches the JS
+``Int32Array`` view permutations on the wire.
 """
 
 from io import BytesIO
@@ -27,12 +25,14 @@ import xorq.api as xo
 _ROWID_COL = "_buckaroo_rowid"
 
 
-def tag_with_rowids(source):
+def tag_with_rowids(source: "xo.Expr") -> "xo.Expr":
     """Materialise ``source`` and append a stable rowid column.
 
     Returns an xorq Table backed by an in-memory pyarrow Table with a
-    new ``_buckaroo_rowid`` column 0..N-1. Repeated evaluations return
-    the same rowids in the same order.
+    new ``_buckaroo_rowid`` column 0..N-1 (int32). Repeated evaluations
+    return the same rowids in the same order. Raises ``ValueError`` if
+    ``source`` already exposes a ``_buckaroo_rowid`` column — callers
+    must not call ``tag_with_rowids`` twice.
     """
     table = source.to_pyarrow()
     rowids = pa.array(list(range(table.num_rows)), type=pa.int64())
@@ -69,10 +69,13 @@ def make_sort_payload(tagged, sort_col: str, ascending: bool = True) -> bytes:
 
 def make_filter_payload(filtered_expr) -> bytes:
     """Filter response: just the ``_buckaroo_rowid`` column of the rows
-    that satisfy the (already-applied) filter. Source order preserved.
+    that satisfy the (already-applied) filter.
 
     The caller composes the filter on the tagged expression and hands
-    the result here. Keeps this function predicate-agnostic.
+    the result here. Keeps this function predicate-agnostic. Result
+    order is whatever the backend produces — the client treats this as
+    a subset, so the client must not rely on source order being
+    preserved.
     """
     rowid_only = filtered_expr.select(_ROWID_COL)
     table = rowid_only.to_pyarrow()

--- a/buckaroo/row_cache_payloads.py
+++ b/buckaroo/row_cache_payloads.py
@@ -1,0 +1,81 @@
+"""Server-side response builders for the rowid-keyed row cache.
+
+See docs/smart-row-cache-redesign.md. Three response kinds, all
+parquet bytes:
+
+  - populate(tagged, start, end)               → rowids + data cols
+  - sort(tagged, sort_col, ascending)          → rowids only, in sort order
+  - filter(already_filtered_tagged_expression) → rowids only
+
+``tag_with_rowids(source)`` is a one-time call at widget init: it
+materialises the source (xorq lazy → pa.Table), appends a dense
+``_buckaroo_rowid`` column starting at 0, and re-wraps as a memtable so
+the rest of the pipeline can keep operating on a stable in-memory
+expression.
+
+Phase 6 of the redesign — pure functions, no widget wiring (that's
+phase 7).
+"""
+
+from io import BytesIO
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import xorq.api as xo
+
+
+_ROWID_COL = "_buckaroo_rowid"
+
+
+def tag_with_rowids(source):
+    """Materialise ``source`` and append a stable rowid column.
+
+    Returns an xorq Table backed by an in-memory pyarrow Table with a
+    new ``_buckaroo_rowid`` column 0..N-1. Repeated evaluations return
+    the same rowids in the same order.
+    """
+    table = source.to_pyarrow()
+    rowids = pa.array(list(range(table.num_rows)), type=pa.int64())
+    tagged = table.append_column(_ROWID_COL, rowids)
+    return xo.memtable(tagged)
+
+
+def make_populate_payload(tagged, start: int, end: int) -> bytes:
+    """Bounded-window populate response: ``[start, end)`` rows with all
+    columns including ``_buckaroo_rowid``. Parquet-encoded.
+    """
+    windowed = tagged.limit(end - start, offset=start)
+    table = windowed.to_pyarrow()
+    buf = BytesIO()
+    pq.write_table(table, buf, compression="none")
+    return buf.getvalue()
+
+
+def make_sort_payload(tagged, sort_col: str, ascending: bool = True) -> bytes:
+    """Sort response: just the ``_buckaroo_rowid`` column in sort order.
+
+    The client sees the full permutation (rowidOrder). Row contents
+    are not shipped — they're either already in the RowStore or fetched
+    on a follow-up ``populate`` call.
+    """
+    col = tagged[sort_col]
+    ordered = tagged.order_by(col.asc() if ascending else col.desc())
+    rowid_only = ordered.select(_ROWID_COL)
+    table = rowid_only.to_pyarrow()
+    buf = BytesIO()
+    pq.write_table(table, buf, compression="none")
+    return buf.getvalue()
+
+
+def make_filter_payload(filtered_expr) -> bytes:
+    """Filter response: just the ``_buckaroo_rowid`` column of the rows
+    that satisfy the (already-applied) filter. Source order preserved.
+
+    The caller composes the filter on the tagged expression and hands
+    the result here. Keeps this function predicate-agnostic.
+    """
+    rowid_only = filtered_expr.select(_ROWID_COL)
+    table = rowid_only.to_pyarrow()
+    buf = BytesIO()
+    pq.write_table(table, buf, compression="none")
+    return buf.getvalue()

--- a/buckaroo/row_cache_payloads.py
+++ b/buckaroo/row_cache_payloads.py
@@ -29,13 +29,19 @@ def tag_with_rowids(source: "xo.Expr") -> "xo.Expr":
     """Materialise ``source`` and append a stable rowid column.
 
     Returns an xorq Table backed by an in-memory pyarrow Table with a
-    new ``_buckaroo_rowid`` column 0..N-1 (int32). Repeated evaluations
+    new ``_buckaroo_rowid`` column 0..N-1 (int32, to match the JS
+    Int32Array view permutations on the wire). Repeated evaluations
     return the same rowids in the same order. Raises ``ValueError`` if
     ``source`` already exposes a ``_buckaroo_rowid`` column — callers
     must not call ``tag_with_rowids`` twice.
     """
     table = source.to_pyarrow()
-    rowids = pa.array(list(range(table.num_rows)), type=pa.int64())
+    if _ROWID_COL in table.schema.names:
+        raise ValueError(
+            f"source already has a {_ROWID_COL!r} column; "
+            "tag_with_rowids must be called exactly once per source"
+        )
+    rowids = pa.array(range(table.num_rows), type=pa.int32())
     tagged = table.append_column(_ROWID_COL, rowids)
     return xo.memtable(tagged)
 

--- a/buckaroo/row_cache_payloads.py
+++ b/buckaroo/row_cache_payloads.py
@@ -39,8 +39,7 @@ def tag_with_rowids(source: "xo.Expr") -> "xo.Expr":
     if _ROWID_COL in table.schema.names:
         raise ValueError(
             f"source already has a {_ROWID_COL!r} column; "
-            "tag_with_rowids must be called exactly once per source"
-        )
+            "tag_with_rowids must be called exactly once per source")
     rowids = pa.array(range(table.num_rows), type=pa.int32())
     tagged = table.append_column(_ROWID_COL, rowids)
     return xo.memtable(tagged)

--- a/docs/smart-row-cache-redesign.md
+++ b/docs/smart-row-cache-redesign.md
@@ -1,0 +1,129 @@
+# SmartRowCache redesign — rowid-keyed store + view permutations
+
+## Status
+DRAFT — design locked. Implementation pending. Strategy: build alongside, big-bang replace once tests pass.
+
+## Today's architecture (briefly)
+
+`KeyAwareSmartRowCache` routes requests by `${sourceName}-${sort}-${sort_direction}` to a per-sort `SmartRowCache`. Each `SmartRowCache` stores **full row dicts** indexed by absolute position `[start, end)` *under that sort*. GC trims around the most recent request window, LRU evicts whole sort caches across keys.
+
+Cost:
+
+- Sorting a column = fresh empty cache → re-fetch every visible row from the server.
+- N sorts × M rows = N copies of the same row in memory.
+- Every cache entry is full row data, even though `sort` is a *reorder* operation.
+- No way to ship "preview" first/last N rows when the user clicks sort.
+
+## Two-layer cache
+
+1. **`RowStore`** — only place row contents live. Keyed by stable `rowid`. Has its own GC.
+2. **View layer** — per-view permutations / subsets of rowids. Cheap (Int32Array).
+
+Renderer composes:
+```
+view V at position k  →  rowid r = V.rowidOrder[k]  →  RowStore[r]
+```
+
+The existing `KeyAwareSmartRowCache` machinery survives, but only for views that **change row contents** (mutate, group-by, join). Sort and filter share the source RowStore.
+
+## Decisions (all locked)
+
+### What is a rowid
+Server-assigned monotonic int from the order of the original DataFrame as delivered to the widget. Stable across the session. Decoupled from any user-visible column (not pandas index, not xorq's `index` column — they may exist as columns in their own right, but they are not rowids).
+
+### Default order
+"Unsorted" is the as-delivered order. View-position equals rowid. **No N-int permutation array is allocated** for the default view — it's a privileged identity case. SortViews allocate when a sort is actually selected.
+
+### Permutations are whole-dataset
+On sort, server ships the full `rowidOrder` for the new sort (one Int32Array of length N). At 4 bytes/row this is 4MB / 1M rows / 40MB / 10M rows. Soft cap on dataset size at ~10M.
+
+### What "changes the rows"
+Boundary baked into the lisp annotation:
+
+| Op | Changes rows | View kind |
+|---|---|---|
+| sort | no | `SortView` (rowid permutation) |
+| filter / search | no | `FilterView` (rowid subset) |
+| select (column subset) | no | shares RowStore with masked schema |
+| postprocessing func | yes | fresh DerivedRowStore |
+| most low-code (lisp) ops | yes | fresh DerivedRowStore |
+| low-code op annotated as filter-only | no | `FilterView` |
+
+The lisp return value carries an annotation flag. Search is the canonical "filter-only" op.
+
+### Server contract
+
+One request shape, one response shape:
+
+```
+populate({sourceName, viewKey?, start, end})
+  → {rowids: Int32Array, rows: Row[]}
+```
+
+`viewKey` identifies the active SortView / FilterView (absent = default order). The response always pairs rows with their rowids, so positional fetches inside any view re-hydrate the rowstore.
+
+Sort triggers a separate request:
+
+```
+sort({sourceName, sortKey, sortDirection})
+  → {rowidOrder: Int32Array}
+```
+
+No row payload in the sort response. After it lands, the client does its normal positional fetch for the visible window (and an eager fetch for the head/tail; see GC below) using `populate` against the new viewKey.
+
+Filter triggers:
+
+```
+filter({sourceName, filterKey})
+  → {rowidSubset: Int32Array}
+```
+
+No row payload — the subset is rowids, rows are already in the rowstore (or fetched on demand).
+
+A `getRowsByRowid([…])` endpoint is **not** in v1. Adding it later is cheap if scrolling patterns demand it.
+
+### RowStore GC
+Two policies, both active:
+
+1. **Visibility-aware.** Compute the union of `[start-pad, end+pad]` *positions* across all active views. Map each to rowids via the relevant `rowidOrder` (or identity for the default view). Keep that rowid set; drop the rest.
+2. **Pinned head/tail.** Always keep rowids for the first 20 + last 20 positions of every active SortView (and the default view). Falls out naturally: after a sort response lands, the client eagerly fetches `[0, 20)` and `[N-20, N)` under the new view, populating those rowids and they survive normal eviction.
+
+No pure LRU. (LRU evicts cells the user just visited — bad fit for scroll patterns where you visit a region once and don't return.)
+
+### View LRU
+LRU-4 on `SortView`s. Permutations are cheap (4MB/1M rows × 4 = 16MB worst case); keeping 4 alive means toggling between two columns is always instant. FilterViews follow the same LRU-4 cap.
+
+### Migration
+Big-bang replacement once the new code reaches feature parity and tests pass:
+
+1. Build `RowStore`, `SortView`, `FilterView` net-new in `RowStore.ts` / `Views.ts`. No changes to `SmartRowCache.ts`.
+2. Mirror the existing `SmartRowCache.test.ts` tests against the new shape (where they apply), plus new tests for sort-without-refetch, head/tail pinning, GC across views, mutate carve-out.
+3. Implement Python-side server contract changes (`populate` returns `{rowids, rows}`; `sort` / `filter` separate response shapes).
+4. Cut over `BuckarooWidgetInfinite.tsx` consumers.
+5. Delete `SmartRowCache.ts` + `KeyAwareSmartRowCache` once the existing test suite is rewritten or retired.
+
+### Where this lands
+Off `main`, on `feat/smart-row-cache-redesign`. Not stacked on `feat/xorq-buckaroo-widget`.
+
+## Build order (test-first)
+
+Each phase has its own commit pair (failing test → implementation), per repo TDD rule.
+
+| Phase | Test scope | Implementation |
+|---|---|---|
+| 1 | RowStore.test.ts: get/set/has, byte-aware GC | `RowStore.ts` |
+| 2 | Views.test.ts: SortView, FilterView, identity default view, position→rowid lookup | `Views.ts` |
+| 3 | Visibility-aware GC: keep union across views, drop rest | RowStore + Views interaction |
+| 4 | Pinned head/tail: eager fetch policy after sort lands | client-side fetch logic |
+| 5 | LRU-4 on SortViews/FilterViews | view registry |
+| 6 | Server contract: extend `populate` to return `{rowids, rows}`; add `sort` / `filter` shapes | Python `_handle_payload_args` |
+| 7 | Cut over `BuckarooWidgetInfinite.tsx` consumers; rewrite/retire `SmartRowCache.test.ts`; delete old types | net deletion |
+
+Phases 1-5 are pure TS, no Python touched. Phase 6 is the contract change. Phase 7 is the big-bang.
+
+## Out of scope for v1
+
+- `getRowsByRowid([…])` — only if scroll patterns prove it necessary.
+- Datasets >10M rows — hard cap on whole-dataset permutations. If we want to go bigger, we revisit windowed permutations.
+- Multi-sort (sort by A then B). Single sort key only, matching today's behavior.
+- Persisting RowStore across widget re-renders. Each widget instance starts fresh.

--- a/docs/smart-row-cache-redesign.md
+++ b/docs/smart-row-cache-redesign.md
@@ -1,7 +1,7 @@
 # SmartRowCache redesign — rowid-keyed store + view permutations
 
 ## Status
-DRAFT — design locked. Implementation pending. Strategy: build alongside, big-bang replace once tests pass.
+Phases 1-6 + controller layer of phase 7 landed on `feat/smart-row-cache-redesign`. 183 JS tests + 11 Python tests pass. Remaining work (consumer cutover) is listed at the bottom.
 
 ## Today's architecture (briefly)
 
@@ -117,9 +117,32 @@ Each phase has its own commit pair (failing test → implementation), per repo T
 | 4 | Pinned head/tail: eager fetch policy after sort lands | client-side fetch logic |
 | 5 | LRU-4 on SortViews/FilterViews | view registry |
 | 6 | Server contract: extend `populate` to return `{rowids, rows}`; add `sort` / `filter` shapes | Python `_handle_payload_args` |
-| 7 | Cut over `BuckarooWidgetInfinite.tsx` consumers; rewrite/retire `SmartRowCache.test.ts`; delete old types | net deletion |
+| 7a | RowCache.test.ts: end-to-end controller behavior | `RowCache.ts` |
+| 7b | Wire RowCache into `TableInfinite.tsx` consumer | replace KeyAwareSmartRowCache reads |
+| 7c | Wire `row_cache_payloads` into widget message handler | new `populate` / `sort` / `filter` message kinds |
+| 7d | Verify Playwright tests pass with new wire protocol | update fixtures as needed |
+| 7e | Retire `SmartRowCache.test.ts` (keep tests for `KeyAwareSmartRowCache` if it survives as the "rows that change" path) | net deletion |
 
-Phases 1-5 are pure TS, no Python touched. Phase 6 is the contract change. Phase 7 is the big-bang.
+Phases 1-5 are pure TS, no Python touched. Phase 6 is the Python contract. Phase 7a is the JS controller layer (the API consumers will use). Phases 7b-e are the actual consumer cutover and are the next session of work.
+
+## What's built
+
+| File | Surface |
+|---|---|
+| `packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts` | `set/setMany/get/getMany/has/delete/size/rowids/missingRowids` |
+| `…/Views.ts` | `View` interface + `IdentityView` / `SortView` / `FilterView` |
+| `…/RowStoreGc.ts` | `gcRowStore(rs, activeWindows, padding, pin?)` |
+| `…/ViewRegistry.ts` | LRU cache of views keyed by `viewKey()` |
+| `…/RowCache.ts` | Integration controller — the API the consumer uses |
+| `buckaroo/row_cache_payloads.py` | `tag_with_rowids` + populate/sort/filter response builders |
+
+## What's left (next session)
+
+- Wire `RowCache` into `TableInfinite.tsx` so the AG-Grid datasource pulls from it instead of `KeyAwareSmartRowCache`.
+- Wire `row_cache_payloads` into the Python widget message handler (new `populate` / `sort` / `filter` message kinds).
+- Decide whether to keep `KeyAwareSmartRowCache` (design says yes, for the "postprocessor-changed-rows" path) or fully replace.
+- Verify Playwright tests pass against the new wire format; update fixtures.
+- Delete dead code: at minimum, `SmartRowCache.ts` and `SmartRowCache.test.ts` once `KeyAwareSmartRowCache` no longer depends on them.
 
 ## Out of scope for v1
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.hooks.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.hooks.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Pins down a Rules-of-Hooks violation in HistogramCell.
+ *
+ * HistogramCell calls useColorScheme() unconditionally (1 hook), then
+ * early-returns <span/> when props.value is undefined or not an array.
+ * In the "valid array" branch it returns `TypedHistogramCell({...})` —
+ * a plain function call, not JSX. React therefore counts the
+ * `React.useState(...)` inside TypedHistogramCell on HistogramCell's own
+ * hook list.
+ *
+ * Hook count is 1 in the invalid branch and 2 in the valid branch. AG-Grid
+ * reuses a single cell instance across rows/refreshes; when summary stats
+ * regenerate (e.g. after the user toggles cleaning_method on the
+ * autocleaning system), the same instance flips between branches and
+ * React throws minified error #310: "Rendered more hooks than during
+ * the previous render."
+ */
+// jsdom's `crypto` lacks `randomUUID`; HistogramCell's gensym() uses it.
+// Without this polyfill the test crashes inside gensym BEFORE React reaches
+// the `useState` call, masking the actual Rules-of-Hooks violation.
+{
+    let n = 0;
+    const existing: any = (globalThis as any).crypto || {};
+    if (typeof existing.randomUUID !== "function") {
+        try {
+            Object.defineProperty(existing, "randomUUID", {
+                configurable: true,
+                value: () => `test-uuid-${++n}`,
+            });
+        } catch {
+            // Fall back to redefining the whole crypto global.
+            Object.defineProperty(globalThis, "crypto", {
+                configurable: true,
+                value: { ...existing, randomUUID: () => `test-uuid-${++n}` },
+            });
+        }
+    }
+}
+
+// ts-jest in this repo doesn't apply esModuleInterop, so the default import
+// `import React from "react"` in HistogramCell.tsx resolves to `undefined`
+// at runtime. Provide a `.default` so React.useState is callable and React
+// can actually detect the hook-count mismatch this test is pinning down.
+jest.mock("react", () => {
+    const actual = jest.requireActual("react");
+    return { __esModule: true, default: actual, ...actual };
+});
+
+import { render } from "@testing-library/react";
+import { HistogramCell } from "./HistogramCell";
+
+// Do NOT mock useColorScheme to a plain () => "light" — that would erase
+// the underlying React hook it calls (useSyncExternalStore) and remove the
+// "first hook" from HistogramCell's invalid-branch render, hiding the
+// hook-count mismatch we're trying to surface here.
+
+// recharts pulls in DOM-measurement code that doesn't run cleanly under
+// jsdom — stub the few exports HistogramCell touches.
+jest.mock("recharts", () => {
+    const React = require("react");
+    return {
+        Bar: () => null,
+        BarChart: ({ children }: any) =>
+            React.createElement("div", { "data-testid": "barchart-mock" }, children),
+        Tooltip: () => null,
+    };
+});
+
+const validHistogram = [
+    { name: "true", true: 60, population: 60 },
+    { name: "false", false: 40, population: 40 },
+];
+
+const mkProps = (value: any) => ({
+    value,
+    api: {} as any,
+    colDef: { cellClass: "" } as any,
+    column: {} as any,
+    context: {},
+});
+
+describe("HistogramCell — Rules of Hooks", () => {
+    it("does not change hook count when value flips from invalid to a valid histogram array", () => {
+        const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            // First render: value is the literal string "histogram" (what comes in
+            // for the index column). HistogramCell calls useColorScheme then
+            // returns <span/>. One hook recorded.
+            const { rerender } = render(<HistogramCell {...mkProps("histogram")} />);
+
+            // Same component instance re-renders with a valid array. The valid
+            // branch additionally calls React.useState via TypedHistogramCell,
+            // bumping the hook count from 1 -> 2 and tripping React error #310.
+            expect(() => {
+                rerender(<HistogramCell {...mkProps(validHistogram)} />);
+            }).not.toThrow();
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+
+    it("does not change hook count when value flips from a valid histogram array to invalid", () => {
+        const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            const { rerender } = render(<HistogramCell {...mkProps(validHistogram)} />);
+            expect(() => {
+                rerender(<HistogramCell {...mkProps(undefined)} />);
+            }).not.toThrow();
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.hooks.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.hooks.test.tsx
@@ -47,6 +47,7 @@ jest.mock("react", () => {
 });
 
 import { render } from "@testing-library/react";
+import type { ColDef, Column, Context, GridApi } from "ag-grid-community";
 import { HistogramCell } from "./HistogramCell";
 
 // Do NOT mock useColorScheme to a plain () => "light" — that would erase
@@ -71,12 +72,15 @@ const validHistogram = [
     { name: "false", false: 40, population: 40 },
 ];
 
+// HistogramCell expects fully-typed AG-Grid handles. Tests don't exercise
+// any of those surfaces, so cast empty stubs to the declared interfaces —
+// honest about the type contract, no `as any` escape hatches.
 const mkProps = (value: any) => ({
     value,
-    api: {} as any,
-    colDef: { cellClass: "" } as any,
-    column: {} as any,
-    context: {},
+    api: {} as GridApi,
+    colDef: { cellClass: "" } as ColDef,
+    column: {} as Column,
+    context: {} as Context,
 });
 
 describe("HistogramCell — Rules of Hooks", () => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -95,6 +95,10 @@ export const HistogramCell = (props:
         return <span></span>;
     }
   const histogramArr = potentialHistogramArr as HistogramBar[];
+  // cellClass is string | string[] | CellClassFunc; only the string form
+  // ever flows through here in practice, so narrow defensively.
+  const rawCellClass = props.colDef.cellClass;
+  const cellClass = typeof rawCellClass === "string" ? rawCellClass : "";
   // Render as a child component (not a function call) so the useState in
   // TypedHistogramCell lives on its own fiber. Otherwise its hook is
   // counted on HistogramCell's hook list and the count differs between
@@ -104,7 +108,7 @@ export const HistogramCell = (props:
   return <TypedHistogramCell
     histogramArr={histogramArr}
     context={props.context}
-    className={props.colDef.cellClass || ""}
+    className={cellClass}
     colorScheme={colorScheme}
   />;
 }

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/HistogramCell.tsx
@@ -95,8 +95,18 @@ export const HistogramCell = (props:
         return <span></span>;
     }
   const histogramArr = potentialHistogramArr as HistogramBar[];
-  //@ts-ignore
-  return TypedHistogramCell({histogramArr, context:props.context, className:props.colDef.cellClass|| "", colorScheme});
+  // Render as a child component (not a function call) so the useState in
+  // TypedHistogramCell lives on its own fiber. Otherwise its hook is
+  // counted on HistogramCell's hook list and the count differs between
+  // the early-return branch and this one — tripping React error #310
+  // when AG-Grid reuses a cell instance and value flips between an
+  // array and the literal string "histogram" (e.g. on autoclean toggle).
+  return <TypedHistogramCell
+    histogramArr={histogramArr}
+    context={props.context}
+    className={props.colDef.cellClass || ""}
+    colorScheme={colorScheme}
+  />;
 }
 
 export const TypedHistogramCell = ({histogramArr, context, className, colorScheme = 'dark'}:

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowCache.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowCache.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Phase 7 — the RowCache controller.
+ *
+ * Integrates the four pieces from phases 1-5 into a single API that
+ * the widget consumer will use:
+ *
+ *   - RowStore: rowid → row contents
+ *   - ViewRegistry × 2: SortViews + FilterViews (each LRU-4)
+ *   - gcRowStore + PinSpec for visibility-aware + head/tail GC
+ *
+ * Surface:
+ *   - populate({rowids, rows})        — server populate response
+ *   - applySort({sortKey, dir, order}) — server sort response
+ *   - applyFilter({key, subset})       — server filter response
+ *   - rowsAt(view, start, end)         — what the renderer needs
+ *   - missingAt(view, start, end)      — what to ask the server for
+ *   - gc(activeWindow)                 — trim around current viewport
+ *
+ * No network/widget plumbing here — pure controller logic.
+ */
+import { RowCache } from "./RowCache";
+import { SortView, FilterView, IdentityView } from "./Views";
+
+
+describe("RowCache — populate", () => {
+    test("populate stores rows under their rowids", () => {
+        const c = new RowCache({ datasetLength: 10 });
+        c.populate({
+            rowids: [0, 1, 2],
+            rows: [{ a: 0 }, { a: 1 }, { a: 2 }],
+        });
+        expect(c.rowStoreSize()).toBe(3);
+    });
+
+    test("repeated populate of the same rowid overwrites", () => {
+        const c = new RowCache({ datasetLength: 10 });
+        c.populate({ rowids: [0], rows: [{ a: 0 }] });
+        c.populate({ rowids: [0], rows: [{ a: "updated" }] });
+        expect(c.rowStoreSize()).toBe(1);
+    });
+});
+
+
+describe("RowCache — default identity view", () => {
+    test("rowsAt without an active view uses the identity view", () => {
+        const c = new RowCache({ datasetLength: 10 });
+        c.populate({ rowids: [0, 1, 2], rows: [{ a: 0 }, { a: 1 }, { a: 2 }] });
+        const view = c.defaultView();
+        expect(view).toBeInstanceOf(IdentityView);
+        expect(view.length()).toBe(10);
+
+        const rows = c.rowsAt(view, 0, 3);
+        expect(rows).toStrictEqual([{ a: 0 }, { a: 1 }, { a: 2 }]);
+    });
+
+    test("rowsAt for a window with missing rowids returns undefined for gaps", () => {
+        const c = new RowCache({ datasetLength: 10 });
+        c.populate({ rowids: [0, 2], rows: [{ a: 0 }, { a: 2 }] });
+        const rows = c.rowsAt(c.defaultView(), 0, 3);
+        expect(rows).toStrictEqual([{ a: 0 }, undefined, { a: 2 }]);
+    });
+
+    test("missingAt enumerates uncached rowids in a window", () => {
+        const c = new RowCache({ datasetLength: 10 });
+        c.populate({ rowids: [0, 2], rows: [{ a: 0 }, { a: 2 }] });
+        expect(c.missingAt(c.defaultView(), 0, 3)).toStrictEqual([1]);
+    });
+});
+
+
+describe("RowCache — sort", () => {
+    test("applySort registers the SortView and rowsAt resolves through it", () => {
+        const c = new RowCache({ datasetLength: 5 });
+        c.populate({
+            rowids: [0, 1, 2, 3, 4],
+            rows: [
+                { a: 0, age: 30 },
+                { a: 1, age: 25 },
+                { a: 2, age: 40 },
+                { a: 3, age: 35 },
+                { a: 4, age: 28 },
+            ],
+        });
+
+        // sort by age asc → rowids: 1, 4, 0, 3, 2
+        c.applySort({
+            sortKey: "age",
+            sortDirection: "asc",
+            rowidOrder: Int32Array.from([1, 4, 0, 3, 2]),
+        });
+
+        const sv = c.getSortView("age", "asc")!;
+        expect(sv).toBeInstanceOf(SortView);
+
+        const rows = c.rowsAt(sv, 0, 3);
+        // position 0,1,2 → rowids 1, 4, 0 → ages 25, 28, 30
+        expect(rows!.map((r) => r && (r as any).age)).toStrictEqual([25, 28, 30]);
+    });
+
+    test("after a sort, the rows under the sort are reused — no row refetch needed", () => {
+        const c = new RowCache({ datasetLength: 5 });
+        c.populate({
+            rowids: [0, 1, 2, 3, 4],
+            rows: [
+                { a: 0 },
+                { a: 1 },
+                { a: 2 },
+                { a: 3 },
+                { a: 4 },
+            ],
+        });
+        c.applySort({
+            sortKey: "k",
+            sortDirection: "asc",
+            rowidOrder: Int32Array.from([4, 3, 2, 1, 0]),
+        });
+        const sv = c.getSortView("k", "asc")!;
+        // Every rowid is already cached — missingAt is empty.
+        expect(c.missingAt(sv, 0, 5)).toStrictEqual([]);
+        expect(c.rowsAt(sv, 0, 5)).toStrictEqual([
+            { a: 4 },
+            { a: 3 },
+            { a: 2 },
+            { a: 1 },
+            { a: 0 },
+        ]);
+    });
+
+    test("two sorts coexist — neither refetches rows", () => {
+        const c = new RowCache({ datasetLength: 3 });
+        c.populate({
+            rowids: [0, 1, 2],
+            rows: [{ a: 10 }, { a: 20 }, { a: 30 }],
+        });
+        c.applySort({
+            sortKey: "k1",
+            sortDirection: "asc",
+            rowidOrder: Int32Array.from([2, 1, 0]),
+        });
+        c.applySort({
+            sortKey: "k2",
+            sortDirection: "desc",
+            rowidOrder: Int32Array.from([0, 2, 1]),
+        });
+        const s1 = c.getSortView("k1", "asc")!;
+        const s2 = c.getSortView("k2", "desc")!;
+
+        expect(c.missingAt(s1, 0, 3)).toStrictEqual([]);
+        expect(c.missingAt(s2, 0, 3)).toStrictEqual([]);
+    });
+});
+
+
+describe("RowCache — filter", () => {
+    test("applyFilter registers a FilterView and rowsAt resolves through it", () => {
+        const c = new RowCache({ datasetLength: 5 });
+        c.populate({
+            rowids: [0, 1, 2, 3, 4],
+            rows: [
+                { a: 0, name: "foo" },
+                { a: 1, name: "bar" },
+                { a: 2, name: "foo" },
+                { a: 3, name: "baz" },
+                { a: 4, name: "foo" },
+            ],
+        });
+        c.applyFilter({
+            filterKey: "name~foo",
+            rowidSubset: Int32Array.from([0, 2, 4]),
+        });
+        const fv = c.getFilterView("name~foo")!;
+        expect(fv).toBeInstanceOf(FilterView);
+        expect(fv.length()).toBe(3);
+
+        const rows = c.rowsAt(fv, 0, 3);
+        expect(rows!.map((r) => r && (r as any).a)).toStrictEqual([0, 2, 4]);
+    });
+});
+
+
+describe("RowCache — view LRU", () => {
+    test("the sort view registry evicts at capacity", () => {
+        const c = new RowCache({ datasetLength: 1, sortCapacity: 2 });
+        c.applySort({ sortKey: "a", sortDirection: "asc", rowidOrder: Int32Array.from([0]) });
+        c.applySort({ sortKey: "b", sortDirection: "asc", rowidOrder: Int32Array.from([0]) });
+        c.applySort({ sortKey: "c", sortDirection: "asc", rowidOrder: Int32Array.from([0]) });
+        expect(c.getSortView("a", "asc")).toBeUndefined();
+        expect(c.getSortView("b", "asc")).toBeDefined();
+        expect(c.getSortView("c", "asc")).toBeDefined();
+    });
+
+    test("the filter view registry evicts at capacity", () => {
+        const c = new RowCache({ datasetLength: 1, filterCapacity: 2 });
+        c.applyFilter({ filterKey: "a", rowidSubset: Int32Array.from([0]) });
+        c.applyFilter({ filterKey: "b", rowidSubset: Int32Array.from([0]) });
+        c.applyFilter({ filterKey: "c", rowidSubset: Int32Array.from([0]) });
+        expect(c.getFilterView("a")).toBeUndefined();
+        expect(c.getFilterView("b")).toBeDefined();
+        expect(c.getFilterView("c")).toBeDefined();
+    });
+});
+
+
+describe("RowCache — GC", () => {
+    test("gc() drops rowids far from the active window, keeping pinned head/tail", () => {
+        const c = new RowCache({
+            datasetLength: 20,
+            padding: 2,
+            headSize: 2,
+            tailSize: 2,
+        });
+        // populate everything
+        c.populate({
+            rowids: Array.from({ length: 20 }, (_, i) => i),
+            rows: Array.from({ length: 20 }, (_, i) => ({ a: i })),
+        });
+        // active window in the middle of the identity view
+        c.gc({ view: c.defaultView(), start: 8, end: 11 });
+
+        // visibility window: positions 6..13 ⇒ rowids 6..12
+        // head: rowids 0, 1
+        // tail: rowids 18, 19
+        for (const r of [0, 1, 6, 7, 8, 9, 10, 11, 12, 18, 19]) {
+            expect(c.has(r)).toBe(true);
+        }
+        for (const r of [2, 3, 4, 5, 13, 14, 15, 16, 17]) {
+            expect(c.has(r)).toBe(false);
+        }
+    });
+
+    test("gc pins head/tail of every active SortView too", () => {
+        const c = new RowCache({
+            datasetLength: 10,
+            padding: 0,
+            headSize: 2,
+            tailSize: 0,
+        });
+        c.populate({
+            rowids: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+            rows: Array.from({ length: 10 }, (_, i) => ({ a: i })),
+        });
+        // sort: rowids reverse
+        c.applySort({
+            sortKey: "k",
+            sortDirection: "asc",
+            rowidOrder: Int32Array.from([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]),
+        });
+        const sv = c.getSortView("k", "asc")!;
+
+        // active window on the sort, deep in the middle
+        c.gc({ view: sv, start: 4, end: 6 });
+
+        // identity head: rowids 0, 1
+        // sort head:     rowids 9, 8
+        // window pos 4..6 in sort → rowids 5, 4
+        for (const r of [0, 1, 4, 5, 8, 9]) expect(c.has(r)).toBe(true);
+        for (const r of [2, 3, 6, 7]) expect(c.has(r)).toBe(false);
+    });
+});
+
+
+describe("RowCache — defaults", () => {
+    test("the default config picks sensible padding / head / tail", () => {
+        const c = new RowCache({ datasetLength: 100 });
+        const cfg = c.config();
+        // Just assert these are positive — the exact numbers should
+        // be tunable, but never zero.
+        expect(cfg.padding).toBeGreaterThan(0);
+        expect(cfg.headSize).toBeGreaterThan(0);
+        expect(cfg.tailSize).toBeGreaterThan(0);
+        expect(cfg.sortCapacity).toBeGreaterThanOrEqual(1);
+        expect(cfg.filterCapacity).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowCache.ts
@@ -6,6 +6,8 @@ import {
     SortView,
     FilterView,
     SortDirection,
+    sortViewKey,
+    filterViewKey,
 } from "./Views";
 import { ViewRegistry } from "./ViewRegistry";
 import { gcRowStore, ActiveWindow, PinSpec } from "./RowStoreGc";
@@ -117,13 +119,12 @@ export class RowCache {
     }
 
     public getSortView(sortKey: string, sortDirection: SortDirection): SortView | undefined {
-        const key = `sort:${sortKey}:${sortDirection}`;
-        const v = this.sortRegistry.get(key);
+        const v = this.sortRegistry.get(sortViewKey(sortKey, sortDirection));
         return v as SortView | undefined;
     }
 
     public getFilterView(filterKey: string): FilterView | undefined {
-        const v = this.filterRegistry.get(`filter:${filterKey}`);
+        const v = this.filterRegistry.get(filterViewKey(filterKey));
         return v as FilterView | undefined;
     }
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowCache.ts
@@ -1,0 +1,157 @@
+import { DFDataRow } from "./DFWhole";
+import { RowStore } from "./RowStore";
+import {
+    View,
+    IdentityView,
+    SortView,
+    FilterView,
+    SortDirection,
+} from "./Views";
+import { ViewRegistry } from "./ViewRegistry";
+import { gcRowStore, ActiveWindow, PinSpec } from "./RowStoreGc";
+
+
+export interface RowCacheConfig {
+    datasetLength: number;
+    padding?: number;
+    headSize?: number;
+    tailSize?: number;
+    sortCapacity?: number;
+    filterCapacity?: number;
+}
+
+
+interface ResolvedConfig {
+    datasetLength: number;
+    padding: number;
+    headSize: number;
+    tailSize: number;
+    sortCapacity: number;
+    filterCapacity: number;
+}
+
+
+function resolveConfig(c: RowCacheConfig): ResolvedConfig {
+    return {
+        datasetLength: c.datasetLength,
+        padding: c.padding ?? 200,
+        headSize: c.headSize ?? 20,
+        tailSize: c.tailSize ?? 20,
+        sortCapacity: c.sortCapacity ?? 4,
+        filterCapacity: c.filterCapacity ?? 4,
+    };
+}
+
+
+export interface PopulateInput {
+    rowids: number[];
+    rows: DFDataRow[];
+}
+
+
+export interface SortInput {
+    sortKey: string;
+    sortDirection: SortDirection;
+    rowidOrder: Int32Array;
+}
+
+
+export interface FilterInput {
+    filterKey: string;
+    rowidSubset: Int32Array;
+}
+
+
+/**
+ * Controller that integrates RowStore + ViewRegistry + gcRowStore.
+ *
+ * This is the API the widget consumer talks to. Network plumbing and
+ * AG-Grid wiring live outside; the controller is pure state.
+ *
+ * The default view is IdentityView(datasetLength) — no allocation.
+ */
+export class RowCache {
+    private readonly cfg: ResolvedConfig;
+    private readonly rowStore: RowStore = new RowStore();
+    private readonly sortRegistry: ViewRegistry;
+    private readonly filterRegistry: ViewRegistry;
+    private readonly _defaultView: IdentityView;
+
+    constructor(cfg: RowCacheConfig) {
+        this.cfg = resolveConfig(cfg);
+        this.sortRegistry = new ViewRegistry(this.cfg.sortCapacity);
+        this.filterRegistry = new ViewRegistry(this.cfg.filterCapacity);
+        this._defaultView = new IdentityView(this.cfg.datasetLength);
+    }
+
+    public config(): ResolvedConfig {
+        return this.cfg;
+    }
+
+    public defaultView(): IdentityView {
+        return this._defaultView;
+    }
+
+    public rowStoreSize(): number {
+        return this.rowStore.size();
+    }
+
+    public has(rowid: number): boolean {
+        return this.rowStore.has(rowid);
+    }
+
+    public populate(input: PopulateInput): void {
+        this.rowStore.setMany(input.rowids, input.rows);
+    }
+
+    public applySort(input: SortInput): SortView {
+        const view = new SortView(input.sortKey, input.sortDirection, input.rowidOrder);
+        this.sortRegistry.add(view);
+        return view;
+    }
+
+    public applyFilter(input: FilterInput): FilterView {
+        const view = new FilterView(input.filterKey, input.rowidSubset);
+        this.filterRegistry.add(view);
+        return view;
+    }
+
+    public getSortView(sortKey: string, sortDirection: SortDirection): SortView | undefined {
+        const key = `sort:${sortKey}:${sortDirection}`;
+        const v = this.sortRegistry.get(key);
+        return v as SortView | undefined;
+    }
+
+    public getFilterView(filterKey: string): FilterView | undefined {
+        const v = this.filterRegistry.get(`filter:${filterKey}`);
+        return v as FilterView | undefined;
+    }
+
+    public rowsAt(view: View, start: number, end: number): (DFDataRow | undefined)[] {
+        const rowids = view.rowidsInRange(start, end);
+        return this.rowStore.getMany(rowids);
+    }
+
+    public missingAt(view: View, start: number, end: number): number[] {
+        const rowids = view.rowidsInRange(start, end);
+        return this.rowStore.missingRowids(rowids);
+    }
+
+    public gc(activeWindow: ActiveWindow): void {
+        const pinnedViews: View[] = [this._defaultView];
+        for (const k of this.sortRegistry.keys()) {
+            const v = this.sortRegistry.get(k);
+            if (v !== undefined) pinnedViews.push(v);
+        }
+        for (const k of this.filterRegistry.keys()) {
+            const v = this.filterRegistry.get(k);
+            if (v !== undefined) pinnedViews.push(v);
+        }
+        const pin: PinSpec = {
+            views: pinnedViews,
+            headSize: this.cfg.headSize,
+            tailSize: this.cfg.tailSize,
+        };
+        gcRowStore(this.rowStore, [activeWindow], this.cfg.padding, pin);
+    }
+}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Phase 1 — basic Map-like surface keyed by rowid.
+ *
+ * GC, pinning, and view-aware eviction land in later phases and are
+ * deliberately not exercised here.
+ */
+import { DFDataRow } from "./DFWhole";
+import { RowStore } from "./RowStore";
+
+
+const row = (n: number): DFDataRow => ({ a: n, b: `name_${n}` });
+
+
+describe("RowStore — basic API", () => {
+    test("an empty store has size 0 and has() returns false", () => {
+        const rs = new RowStore();
+        expect(rs.size()).toBe(0);
+        expect(rs.has(0)).toBe(false);
+        expect(rs.has(1234)).toBe(false);
+    });
+
+    test("set + get round-trips a row", () => {
+        const rs = new RowStore();
+        rs.set(7, row(7));
+        expect(rs.has(7)).toBe(true);
+        expect(rs.get(7)).toStrictEqual(row(7));
+        expect(rs.size()).toBe(1);
+    });
+
+    test("get of an unknown rowid returns undefined", () => {
+        const rs = new RowStore();
+        rs.set(1, row(1));
+        expect(rs.get(999)).toBeUndefined();
+    });
+
+    test("set on an existing rowid overwrites", () => {
+        const rs = new RowStore();
+        rs.set(3, row(3));
+        rs.set(3, { ...row(3), b: "renamed" });
+        expect(rs.get(3)).toStrictEqual({ a: 3, b: "renamed" });
+        expect(rs.size()).toBe(1);
+    });
+
+    test("delete removes a rowid", () => {
+        const rs = new RowStore();
+        rs.set(5, row(5));
+        expect(rs.has(5)).toBe(true);
+        rs.delete(5);
+        expect(rs.has(5)).toBe(false);
+        expect(rs.get(5)).toBeUndefined();
+        expect(rs.size()).toBe(0);
+    });
+
+    test("delete of an unknown rowid is a no-op", () => {
+        const rs = new RowStore();
+        rs.set(5, row(5));
+        rs.delete(999);
+        expect(rs.size()).toBe(1);
+        expect(rs.has(5)).toBe(true);
+    });
+});
+
+
+describe("RowStore — bulk operations", () => {
+    test("setMany stores paired rowids and rows", () => {
+        const rs = new RowStore();
+        const rowids = [10, 11, 12];
+        const rows = [row(10), row(11), row(12)];
+        rs.setMany(rowids, rows);
+        expect(rs.size()).toBe(3);
+        for (const r of rowids) {
+            expect(rs.get(r)).toStrictEqual(row(r));
+        }
+    });
+
+    test("setMany throws when arrays have different lengths", () => {
+        const rs = new RowStore();
+        expect(() => rs.setMany([1, 2], [row(1)])).toThrow();
+    });
+
+    test("setMany on overlapping rowids overwrites in place", () => {
+        const rs = new RowStore();
+        rs.set(10, row(10));
+        rs.setMany([10, 11], [{ a: 10, b: "updated" }, row(11)]);
+        expect(rs.size()).toBe(2);
+        expect(rs.get(10)).toStrictEqual({ a: 10, b: "updated" });
+        expect(rs.get(11)).toStrictEqual(row(11));
+    });
+
+    test("getMany returns rows in input order", () => {
+        const rs = new RowStore();
+        rs.setMany([10, 11, 12], [row(10), row(11), row(12)]);
+        expect(rs.getMany([12, 10, 11])).toStrictEqual([
+            row(12),
+            row(10),
+            row(11),
+        ]);
+    });
+
+    test("getMany returns undefined for missing rowids", () => {
+        const rs = new RowStore();
+        rs.set(10, row(10));
+        expect(rs.getMany([10, 999, 11])).toStrictEqual([
+            row(10),
+            undefined,
+            undefined,
+        ]);
+    });
+
+    test("getMany on empty input returns empty array", () => {
+        const rs = new RowStore();
+        rs.set(10, row(10));
+        expect(rs.getMany([])).toStrictEqual([]);
+    });
+});
+
+
+describe("RowStore — missingRowids", () => {
+    // Used by the view layer to figure out which rowids it has to ask
+    // the server for after a position-range lookup hits some uncached
+    // slots. Trivial wrapper over has(), but the call site is hot
+    // enough that it's worth a method.
+    test("missingRowids returns rowids not present, preserving input order", () => {
+        const rs = new RowStore();
+        rs.setMany([10, 12], [row(10), row(12)]);
+        expect(rs.missingRowids([10, 11, 12, 13])).toStrictEqual([11, 13]);
+    });
+
+    test("missingRowids on an empty store returns the input unchanged", () => {
+        const rs = new RowStore();
+        expect(rs.missingRowids([1, 2, 3])).toStrictEqual([1, 2, 3]);
+    });
+
+    test("missingRowids deduplicates", () => {
+        const rs = new RowStore();
+        rs.set(5, row(5));
+        expect(rs.missingRowids([5, 6, 6, 7, 7])).toStrictEqual([6, 7]);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts
@@ -50,6 +50,10 @@ export class RowStore {
         return this.rows.size;
     }
 
+    public rowids(): IterableIterator<number> {
+        return this.rows.keys();
+    }
+
     public missingRowids(rowids: number[]): number[] {
         const seen = new Set<number>();
         const out: number[] = [];

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts
@@ -1,0 +1,63 @@
+import { DFDataRow } from "./DFWhole";
+
+
+/**
+ * Rowid-keyed store of row contents. The only place row data lives in
+ * the redesigned cache (see docs/smart-row-cache-redesign.md).
+ *
+ * Rowids are stable identifiers assigned by the server at initial
+ * population — they survive sort and filter, so a single RowStore can
+ * back any number of SortViews and FilterViews.
+ *
+ * This class is intentionally tiny in phase 1. GC and pinning land in
+ * later phases.
+ */
+export class RowStore {
+    private rows: Map<number, DFDataRow> = new Map();
+
+    public set(rowid: number, row: DFDataRow): void {
+        this.rows.set(rowid, row);
+    }
+
+    public setMany(rowids: number[], rows: DFDataRow[]): void {
+        if (rowids.length !== rows.length) {
+            throw new Error(
+                `RowStore.setMany: rowids.length=${rowids.length} !== rows.length=${rows.length}`,
+            );
+        }
+        for (let i = 0; i < rowids.length; i++) {
+            this.rows.set(rowids[i], rows[i]);
+        }
+    }
+
+    public get(rowid: number): DFDataRow | undefined {
+        return this.rows.get(rowid);
+    }
+
+    public getMany(rowids: number[]): (DFDataRow | undefined)[] {
+        return rowids.map((r) => this.rows.get(r));
+    }
+
+    public has(rowid: number): boolean {
+        return this.rows.has(rowid);
+    }
+
+    public delete(rowid: number): void {
+        this.rows.delete(rowid);
+    }
+
+    public size(): number {
+        return this.rows.size;
+    }
+
+    public missingRowids(rowids: number[]): number[] {
+        const seen = new Set<number>();
+        const out: number[] = [];
+        for (const r of rowids) {
+            if (seen.has(r)) continue;
+            seen.add(r);
+            if (!this.rows.has(r)) out.push(r);
+        }
+        return out;
+    }
+}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStore.ts
@@ -7,10 +7,8 @@ import { DFDataRow } from "./DFWhole";
  *
  * Rowids are stable identifiers assigned by the server at initial
  * population — they survive sort and filter, so a single RowStore can
- * back any number of SortViews and FilterViews.
- *
- * This class is intentionally tiny in phase 1. GC and pinning land in
- * later phases.
+ * back any number of SortViews and FilterViews. Visibility-aware GC
+ * and head/tail pinning live in `RowStoreGc.ts`.
  */
 export class RowStore {
     private rows: Map<number, DFDataRow> = new Map();

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.test.ts
@@ -160,3 +160,87 @@ describe("gcRowStore — edge cases", () => {
         expect(rs.size()).toBe(0);
     });
 });
+
+
+describe("gcRowStore — head/tail pinning", () => {
+    test("pinned head survives even when active window is far away", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        // sort: positions 0..10 → rowids [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        const sv = new SortView("k", "asc", Int32Array.from([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
+        // active window deep in the middle
+        gcRowStore(rs, [aw(sv, 4, 6)], 0, { views: [sv], headSize: 3, tailSize: 0 });
+
+        // head ⇒ positions 0..3 ⇒ rowids 9, 8, 7
+        // window ⇒ positions 4..6 ⇒ rowids 5, 4
+        for (const r of [9, 8, 7, 5, 4]) expect(rs.has(r)).toBe(true);
+        for (const r of [0, 1, 2, 3, 6]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("pinned tail survives even when active window is far away", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        const sv = new SortView("k", "asc", Int32Array.from([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
+        gcRowStore(rs, [aw(sv, 0, 2)], 0, { views: [sv], headSize: 0, tailSize: 3 });
+
+        // tail ⇒ positions 7..10 ⇒ rowids 2, 1, 0
+        // window ⇒ positions 0..2 ⇒ rowids 9, 8
+        for (const r of [9, 8, 2, 1, 0]) expect(rs.has(r)).toBe(true);
+        for (const r of [3, 4, 5, 6, 7]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("head + tail across multiple pinned views are all kept", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        // sort by k: rowidOrder = [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
+        const sk = new SortView("k", "asc", Int32Array.from([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]));
+        // sort by m: rowidOrder = [0, 2, 4, 6, 8, 1, 3, 5, 7, 9]
+        const sm = new SortView("m", "asc", Int32Array.from([0, 2, 4, 6, 8, 1, 3, 5, 7, 9]));
+
+        gcRowStore(rs, [], 0, { views: [sk, sm], headSize: 2, tailSize: 2 });
+
+        // sk head: 9, 8;     tail: 1, 0
+        // sm head: 0, 2;     tail: 7, 9
+        // union:   0, 1, 2, 7, 8, 9
+        for (const r of [0, 1, 2, 7, 8, 9]) expect(rs.has(r)).toBe(true);
+        for (const r of [3, 4, 5, 6]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("headSize=0 + tailSize=0 disables pinning", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4]);
+        const sv = new SortView("k", "asc", Int32Array.from([4, 3, 2, 1, 0]));
+        gcRowStore(rs, [], 0, { views: [sv], headSize: 0, tailSize: 0 });
+        expect(rs.size()).toBe(0);
+    });
+
+    test("head/tail larger than view length pins everything", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2]);
+        const sv = new SortView("k", "asc", Int32Array.from([2, 1, 0]));
+        gcRowStore(rs, [], 0, { views: [sv], headSize: 100, tailSize: 100 });
+        expect(rs.size()).toBe(3);
+    });
+
+    test("identity view can be pinned too", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        const idv = new IdentityView(10);
+        gcRowStore(rs, [], 0, { views: [idv], headSize: 2, tailSize: 2 });
+        // head 0, 1; tail 8, 9
+        for (const r of [0, 1, 8, 9]) expect(rs.has(r)).toBe(true);
+        for (const r of [2, 3, 4, 5, 6, 7]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("head and tail overlap (small view) is deduped", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3]);
+        const sv = new SortView("k", "asc", Int32Array.from([0, 1, 2, 3]));
+        gcRowStore(rs, [], 0, { views: [sv], headSize: 3, tailSize: 3 });
+        // head 0,1,2; tail 1,2,3 — union 0..4
+        expect(rs.size()).toBe(4);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Phase 3 — visibility-aware GC for RowStore.
+ *
+ * "Active window" = a position range within a view. To decide which
+ * rowids are still needed, the GC takes every active window, expands
+ * by padding, maps positions → rowids through each window's view, and
+ * keeps the union. Everything else is dropped.
+ *
+ * No knowledge of head/tail pinning yet — that's phase 4.
+ */
+import { RowStore } from "./RowStore";
+import { IdentityView, SortView, FilterView, View } from "./Views";
+import { gcRowStore, ActiveWindow } from "./RowStoreGc";
+
+
+function fillStore(rs: RowStore, rowids: number[]): void {
+    rs.setMany(
+        rowids,
+        rowids.map((r) => ({ a: r })),
+    );
+}
+
+function aw(view: View, start: number, end: number): ActiveWindow {
+    return { view, start, end };
+}
+
+
+describe("gcRowStore — identity view", () => {
+    test("keeps only rowids inside the visible window ± padding", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        gcRowStore(rs, [aw(new IdentityView(10), 3, 6)], 1);
+
+        // window [3, 6) ± 1 ⇒ keep rowids [2, 3, 4, 5, 6]
+        for (const r of [2, 3, 4, 5, 6]) expect(rs.has(r)).toBe(true);
+        for (const r of [0, 1, 7, 8, 9]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("zero padding keeps exactly the window", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4]);
+        gcRowStore(rs, [aw(new IdentityView(5), 1, 4)], 0);
+        expect(rs.size()).toBe(3);
+        expect(rs.has(0)).toBe(false);
+        expect(rs.has(1)).toBe(true);
+        expect(rs.has(3)).toBe(true);
+        expect(rs.has(4)).toBe(false);
+    });
+
+    test("padding doesn't extend below 0 or beyond view length", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4]);
+        gcRowStore(rs, [aw(new IdentityView(5), 0, 5)], 100);
+        // window covers everything, padding can't add more
+        for (const r of [0, 1, 2, 3, 4]) expect(rs.has(r)).toBe(true);
+    });
+});
+
+
+describe("gcRowStore — sort view", () => {
+    test("keeps the rowids at the visible positions under the sort", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        // sort: positions [0..10) → rowids [3, 1, 4, 1, 5, 9, 2, 6, 5, 0]
+        const order = Int32Array.from([3, 1, 4, 1, 5, 9, 2, 6, 5, 0]);
+        const sv = new SortView("k", "asc", order);
+
+        // visible window [2, 5) under sort ⇒ positions 2,3,4 ⇒ rowids 4, 1, 5
+        gcRowStore(rs, [aw(sv, 2, 5)], 0);
+
+        for (const r of [1, 4, 5]) expect(rs.has(r)).toBe(true);
+        for (const r of [0, 2, 3, 6, 7, 8, 9]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("padding works in position-space, not rowid-space", () => {
+        const rs = new RowStore();
+        fillStore(rs, [10, 20, 30, 40, 50]);
+
+        const order = Int32Array.from([30, 10, 50, 20, 40]);
+        const sv = new SortView("k", "asc", order);
+
+        // window [2, 3) ± 1 ⇒ positions [1, 4) ⇒ rowids 10, 50, 20
+        gcRowStore(rs, [aw(sv, 2, 3)], 1);
+
+        expect(rs.has(10)).toBe(true);
+        expect(rs.has(20)).toBe(true);
+        expect(rs.has(50)).toBe(true);
+        expect(rs.has(30)).toBe(false);
+        expect(rs.has(40)).toBe(false);
+    });
+});
+
+
+describe("gcRowStore — multiple views", () => {
+    test("keeps the union of rowids across all active windows", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+        const idv = new IdentityView(10);
+        // sort: pos 0..10 → rowids [7, 6, 5, 4, 3, 2, 1, 0, 9, 8]
+        const sv = new SortView("k", "desc", Int32Array.from([7, 6, 5, 4, 3, 2, 1, 0, 9, 8]));
+
+        // identity window [0, 2) ⇒ rowids 0, 1
+        // sort window [0, 2) ⇒ rowids 7, 6
+        gcRowStore(rs, [aw(idv, 0, 2), aw(sv, 0, 2)], 0);
+
+        for (const r of [0, 1, 6, 7]) expect(rs.has(r)).toBe(true);
+        for (const r of [2, 3, 4, 5, 8, 9]) expect(rs.has(r)).toBe(false);
+    });
+
+    test("filter and sort window unions are tracked separately", () => {
+        const rs = new RowStore();
+        fillStore(rs, [10, 20, 30, 40, 50, 60, 70, 80, 90]);
+
+        const fv = new FilterView("active", Int32Array.from([20, 40, 60, 80]));
+        const sv = new SortView("k", "asc", Int32Array.from([90, 80, 70, 60, 50, 40, 30, 20, 10]));
+
+        // filter window [0, 2) ⇒ rowids 20, 40
+        // sort window   [0, 1) ⇒ rowids 90
+        gcRowStore(rs, [aw(fv, 0, 2), aw(sv, 0, 1)], 0);
+
+        for (const r of [20, 40, 90]) expect(rs.has(r)).toBe(true);
+        for (const r of [10, 30, 50, 60, 70, 80]) expect(rs.has(r)).toBe(false);
+    });
+});
+
+
+describe("gcRowStore — edge cases", () => {
+    test("empty active-windows list drops everything", () => {
+        const rs = new RowStore();
+        fillStore(rs, [1, 2, 3]);
+        gcRowStore(rs, [], 5);
+        expect(rs.size()).toBe(0);
+    });
+
+    test("does not touch rowids not in any window's reach (still in store)", () => {
+        // Verify gcRowStore only deletes from RowStore, doesn't create
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2]);
+        const before = rs.size();
+        gcRowStore(rs, [aw(new IdentityView(10), 0, 3)], 0);
+        expect(rs.size()).toBe(before);
+    });
+
+    test("a rowid in the keep set but missing from the store is a no-op", () => {
+        // Keep set asks for rowid 99, store doesn't have it — no error.
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2]);
+        gcRowStore(rs, [aw(new IdentityView(100), 0, 100)], 0);
+        // Nothing weird happens; the rowids it did have survive.
+        expect(rs.size()).toBe(3);
+    });
+
+    test("window with start >= end is treated as empty", () => {
+        const rs = new RowStore();
+        fillStore(rs, [0, 1, 2]);
+        gcRowStore(rs, [aw(new IdentityView(10), 5, 5)], 0);
+        expect(rs.size()).toBe(0);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.ts
@@ -1,0 +1,38 @@
+import { RowStore } from "./RowStore";
+import { View } from "./Views";
+
+
+export interface ActiveWindow {
+    view: View;
+    start: number;
+    end: number;
+}
+
+
+/**
+ * Visibility-aware GC. For each active window, expand the position
+ * range by `padding`, map through the window's view to get rowids,
+ * union the lot, and drop everything else from the RowStore.
+ *
+ * Empty active-window list drops everything.
+ */
+export function gcRowStore(
+    rowStore: RowStore,
+    activeWindows: ActiveWindow[],
+    padding: number,
+): void {
+    const keep = new Set<number>();
+    for (const w of activeWindows) {
+        const start = Math.max(0, w.start - padding);
+        const end = Math.min(w.view.length(), w.end + padding);
+        if (start >= end) continue;
+        for (const r of w.view.rowidsInRange(start, end)) keep.add(r);
+    }
+
+    // Array.from rather than for-of on the iterator — the latter compiles
+    // to a no-op iteration under this repo's tsconfig target.
+    const allRowids = Array.from(rowStore.rowids());
+    for (const rowid of allRowids) {
+        if (!keep.has(rowid)) rowStore.delete(rowid);
+    }
+}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/RowStoreGc.ts
@@ -9,24 +9,49 @@ export interface ActiveWindow {
 }
 
 
+export interface PinSpec {
+    views: View[];
+    headSize: number;
+    tailSize: number;
+}
+
+
 /**
  * Visibility-aware GC. For each active window, expand the position
  * range by `padding`, map through the window's view to get rowids,
- * union the lot, and drop everything else from the RowStore.
+ * union the lot. If `pin` is provided, also union in the first
+ * `headSize` and last `tailSize` rowids of every pinned view.
+ * Everything else is dropped.
  *
- * Empty active-window list drops everything.
+ * Empty active-window list + no pin spec drops everything.
  */
 export function gcRowStore(
     rowStore: RowStore,
     activeWindows: ActiveWindow[],
     padding: number,
+    pin?: PinSpec,
 ): void {
     const keep = new Set<number>();
+
     for (const w of activeWindows) {
         const start = Math.max(0, w.start - padding);
         const end = Math.min(w.view.length(), w.end + padding);
         if (start >= end) continue;
         for (const r of w.view.rowidsInRange(start, end)) keep.add(r);
+    }
+
+    if (pin !== undefined) {
+        for (const v of pin.views) {
+            const len = v.length();
+            if (pin.headSize > 0) {
+                const headEnd = Math.min(pin.headSize, len);
+                for (const r of v.rowidsInRange(0, headEnd)) keep.add(r);
+            }
+            if (pin.tailSize > 0) {
+                const tailStart = Math.max(0, len - pin.tailSize);
+                for (const r of v.rowidsInRange(tailStart, len)) keep.add(r);
+            }
+        }
     }
 
     // Array.from rather than for-of on the iterator — the latter compiles

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/ViewRegistry.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/ViewRegistry.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Phase 5 — capacity-bounded LRU registry of views.
+ *
+ * The widget holds one registry per view *kind* (one for sort views,
+ * one for filter views). Each is capped — the design picks 4 so
+ * toggling between two columns / filters stays fast at all times.
+ */
+import { IdentityView, SortView, FilterView } from "./Views";
+import { ViewRegistry } from "./ViewRegistry";
+
+
+const sortV = (key: string) =>
+    new SortView(key, "asc", Int32Array.from([0]));
+const filterV = (key: string) =>
+    new FilterView(key, Int32Array.from([0]));
+
+
+describe("ViewRegistry — basics", () => {
+    test("an empty registry has size 0", () => {
+        const r = new ViewRegistry(4);
+        expect(r.size()).toBe(0);
+        expect(r.has("nope")).toBe(false);
+        expect(r.get("nope")).toBeUndefined();
+    });
+
+    test("add + get round-trips a view by its viewKey", () => {
+        const r = new ViewRegistry(4);
+        const v = sortV("age");
+        r.add(v);
+        expect(r.size()).toBe(1);
+        expect(r.has(v.viewKey())).toBe(true);
+        expect(r.get(v.viewKey())).toBe(v);
+    });
+
+    test("adding two views with different keys keeps both", () => {
+        const r = new ViewRegistry(4);
+        const v1 = sortV("age");
+        const v2 = sortV("name");
+        r.add(v1);
+        r.add(v2);
+        expect(r.size()).toBe(2);
+        expect(r.get(v1.viewKey())).toBe(v1);
+        expect(r.get(v2.viewKey())).toBe(v2);
+    });
+
+    test("adding a view with an existing key replaces in place", () => {
+        const r = new ViewRegistry(4);
+        const original = sortV("age");
+        const replacement = sortV("age");
+        r.add(original);
+        r.add(replacement);
+        expect(r.size()).toBe(1);
+        expect(r.get("sort:age:asc")).toBe(replacement);
+    });
+
+    test("delete removes a view", () => {
+        const r = new ViewRegistry(4);
+        const v = sortV("age");
+        r.add(v);
+        r.delete(v.viewKey());
+        expect(r.size()).toBe(0);
+        expect(r.has(v.viewKey())).toBe(false);
+    });
+});
+
+
+describe("ViewRegistry — LRU eviction", () => {
+    test("overflow evicts the least-recently-added view", () => {
+        const r = new ViewRegistry(2);
+        const v1 = sortV("a");
+        const v2 = sortV("b");
+        const v3 = sortV("c");
+        r.add(v1);
+        r.add(v2);
+        r.add(v3);
+        expect(r.size()).toBe(2);
+        expect(r.has(v1.viewKey())).toBe(false); // evicted
+        expect(r.has(v2.viewKey())).toBe(true);
+        expect(r.has(v3.viewKey())).toBe(true);
+    });
+
+    test("get() touches a view so it survives the next eviction", () => {
+        const r = new ViewRegistry(2);
+        const v1 = sortV("a");
+        const v2 = sortV("b");
+        r.add(v1);
+        r.add(v2);
+        // Touch v1 → now v2 is LRU
+        expect(r.get(v1.viewKey())).toBe(v1);
+        const v3 = sortV("c");
+        r.add(v3);
+        expect(r.has(v2.viewKey())).toBe(false); // evicted
+        expect(r.has(v1.viewKey())).toBe(true);
+        expect(r.has(v3.viewKey())).toBe(true);
+    });
+
+    test("re-adding an existing key refreshes its LRU position", () => {
+        const r = new ViewRegistry(2);
+        const v1 = sortV("a");
+        const v2 = sortV("b");
+        r.add(v1);
+        r.add(v2);
+        // Re-add v1 with a different instance — v1 is now MRU, v2 LRU
+        const v1b = sortV("a");
+        r.add(v1b);
+        const v3 = sortV("c");
+        r.add(v3);
+        expect(r.has(v2.viewKey())).toBe(false); // evicted
+        expect(r.get(v1b.viewKey())).toBe(v1b);
+        expect(r.has(v3.viewKey())).toBe(true);
+    });
+
+    test("add returns the evicted view (or undefined if none)", () => {
+        const r = new ViewRegistry(2);
+        expect(r.add(sortV("a"))).toBeUndefined();
+        expect(r.add(sortV("b"))).toBeUndefined();
+        const evicted = r.add(sortV("c"));
+        expect(evicted).not.toBeUndefined();
+        expect(evicted!.viewKey()).toBe("sort:a:asc");
+    });
+
+    test("capacity of 0 evicts immediately and never holds anything", () => {
+        const r = new ViewRegistry(0);
+        expect(r.add(sortV("a"))).not.toBeUndefined(); // immediately evicted
+        expect(r.size()).toBe(0);
+    });
+});
+
+
+describe("ViewRegistry — view-kind isolation", () => {
+    // Sort and filter views with the same metadata key produce different
+    // viewKey() strings, so they live in the same registry without
+    // colliding — but the design uses two separate registries (one for
+    // sorts, one for filters). These tests assert the registry doesn't
+    // care which kind you give it.
+    test("a single registry can hold sort + filter views with overlapping metadata names", () => {
+        const r = new ViewRegistry(4);
+        const s = sortV("age");
+        const f = filterV("age");
+        r.add(s);
+        r.add(f);
+        expect(r.size()).toBe(2);
+        expect(r.get(s.viewKey())).toBe(s);
+        expect(r.get(f.viewKey())).toBe(f);
+    });
+
+    test("identity view can live in a registry too", () => {
+        const r = new ViewRegistry(4);
+        const idv = new IdentityView(10);
+        r.add(idv);
+        expect(r.get("identity")).toBe(idv);
+    });
+});
+
+
+describe("ViewRegistry — keys() ordering", () => {
+    test("keys() returns viewKeys in LRU-to-MRU order", () => {
+        const r = new ViewRegistry(4);
+        r.add(sortV("a"));
+        r.add(sortV("b"));
+        r.add(sortV("c"));
+        // MRU is c; LRU is a
+        expect(r.keys()).toStrictEqual(["sort:a:asc", "sort:b:asc", "sort:c:asc"]);
+    });
+
+    test("get() reorders keys()", () => {
+        const r = new ViewRegistry(4);
+        r.add(sortV("a"));
+        r.add(sortV("b"));
+        r.add(sortV("c"));
+        r.get("sort:a:asc"); // touch a
+        expect(r.keys()).toStrictEqual(["sort:b:asc", "sort:c:asc", "sort:a:asc"]);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/ViewRegistry.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/ViewRegistry.ts
@@ -1,0 +1,61 @@
+import { View } from "./Views";
+
+
+/**
+ * Capacity-bounded LRU registry of views, keyed by viewKey().
+ *
+ * Uses the standard JS-Map insertion-order trick: a get/touch deletes
+ * and re-inserts the entry to put it at the MRU end; eviction pops
+ * the first iteration entry (LRU).
+ *
+ * Capacity 0 is allowed — anything added is evicted immediately.
+ */
+export class ViewRegistry {
+    private readonly capacity: number;
+    private readonly map: Map<string, View> = new Map();
+
+    constructor(capacity: number) {
+        this.capacity = capacity;
+    }
+
+    public size(): number {
+        return this.map.size;
+    }
+
+    public has(viewKey: string): boolean {
+        return this.map.has(viewKey);
+    }
+
+    public get(viewKey: string): View | undefined {
+        const v = this.map.get(viewKey);
+        if (v === undefined) return undefined;
+        // touch: move to MRU end
+        this.map.delete(viewKey);
+        this.map.set(viewKey, v);
+        return v;
+    }
+
+    public add(view: View): View | undefined {
+        const key = view.viewKey();
+        // Re-add behaves as touch + replace
+        if (this.map.has(key)) {
+            this.map.delete(key);
+        }
+        this.map.set(key, view);
+        if (this.map.size > this.capacity) {
+            const lruKey = Array.from(this.map.keys())[0];
+            const evicted = this.map.get(lruKey);
+            this.map.delete(lruKey);
+            return evicted;
+        }
+        return undefined;
+    }
+
+    public delete(viewKey: string): void {
+        this.map.delete(viewKey);
+    }
+
+    public keys(): string[] {
+        return Array.from(this.map.keys());
+    }
+}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Views.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Views.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Phase 2 — the view layer.
+ *
+ * A view answers "what rowid is at position k under this ordering?"
+ * Three flavors:
+ *
+ *   - IdentityView: default order. position == rowid. No allocation.
+ *   - SortView:     {sortKey, sortDirection, rowidOrder: Int32Array}.
+ *                   Full permutation of the dataset's rowids.
+ *   - FilterView:   {filterKey, rowidSubset: Int32Array}.
+ *                   Strict subset of rowids, in source order.
+ *
+ * Every view exposes the same lookup surface:
+ *   length(), positionAt(k), rowidsInRange(start, end), viewKey().
+ *
+ * Tests are organized as
+ *   - per-class behavior
+ *   - a parameterized "View contract" suite that runs the same
+ *     invariants against every view kind.
+ */
+import {
+    IdentityView,
+    SortView,
+    FilterView,
+    View,
+} from "./Views";
+
+
+describe("IdentityView", () => {
+    test("position equals rowid", () => {
+        const v = new IdentityView(100);
+        expect(v.positionAt(0)).toBe(0);
+        expect(v.positionAt(42)).toBe(42);
+        expect(v.positionAt(99)).toBe(99);
+    });
+
+    test("length matches constructor arg", () => {
+        expect(new IdentityView(0).length()).toBe(0);
+        expect(new IdentityView(1).length()).toBe(1);
+        expect(new IdentityView(1_000_000).length()).toBe(1_000_000);
+    });
+
+    test("rowidsInRange returns [start..end)", () => {
+        const v = new IdentityView(100);
+        expect(v.rowidsInRange(0, 5)).toStrictEqual([0, 1, 2, 3, 4]);
+        expect(v.rowidsInRange(10, 13)).toStrictEqual([10, 11, 12]);
+    });
+
+    test("rowidsInRange clamps end at length", () => {
+        const v = new IdentityView(5);
+        expect(v.rowidsInRange(3, 10)).toStrictEqual([3, 4]);
+    });
+
+    test("rowidsInRange returns [] for empty or inverted range", () => {
+        const v = new IdentityView(100);
+        expect(v.rowidsInRange(50, 50)).toStrictEqual([]);
+        expect(v.rowidsInRange(50, 40)).toStrictEqual([]);
+    });
+
+    test("viewKey is a stable 'identity' tag", () => {
+        // Used as the cache lookup key; identity views share one key
+        // because they're all the same view.
+        expect(new IdentityView(100).viewKey()).toBe("identity");
+        expect(new IdentityView(50).viewKey()).toBe("identity");
+    });
+});
+
+
+describe("SortView", () => {
+    const perm = (xs: number[]) => Int32Array.from(xs);
+
+    test("positionAt indexes into rowidOrder", () => {
+        const v = new SortView("age", "asc", perm([3, 1, 4, 1, 5, 9, 2, 6]));
+        expect(v.positionAt(0)).toBe(3);
+        expect(v.positionAt(4)).toBe(5);
+        expect(v.positionAt(7)).toBe(6);
+    });
+
+    test("length matches rowidOrder length", () => {
+        expect(new SortView("age", "asc", perm([])).length()).toBe(0);
+        expect(new SortView("age", "asc", perm([0, 1, 2])).length()).toBe(3);
+    });
+
+    test("rowidsInRange returns the slice as plain number[]", () => {
+        const v = new SortView("age", "asc", perm([3, 1, 4, 1, 5, 9, 2, 6]));
+        const slice = v.rowidsInRange(2, 5);
+        expect(slice).toStrictEqual([4, 1, 5]);
+        expect(Array.isArray(slice)).toBe(true);
+    });
+
+    test("rowidsInRange clamps end at length", () => {
+        const v = new SortView("age", "asc", perm([10, 20, 30]));
+        expect(v.rowidsInRange(1, 100)).toStrictEqual([20, 30]);
+    });
+
+    test("viewKey encodes sortKey + direction", () => {
+        const asc = new SortView("age", "asc", perm([0]));
+        const desc = new SortView("age", "desc", perm([0]));
+        const other = new SortView("name", "asc", perm([0]));
+        expect(asc.viewKey()).not.toBe(desc.viewKey());
+        expect(asc.viewKey()).not.toBe(other.viewKey());
+        expect(asc.viewKey()).toBe(new SortView("age", "asc", perm([0])).viewKey());
+    });
+});
+
+
+describe("FilterView", () => {
+    const sub = (xs: number[]) => Int32Array.from(xs);
+
+    test("positionAt indexes into rowidSubset", () => {
+        const v = new FilterView("name~foo", sub([7, 11, 13, 21]));
+        expect(v.positionAt(0)).toBe(7);
+        expect(v.positionAt(3)).toBe(21);
+    });
+
+    test("length matches subset length, not source length", () => {
+        // The whole point of filter: length is the size of the result,
+        // not the source.
+        const v = new FilterView("name~foo", sub([7, 11, 13]));
+        expect(v.length()).toBe(3);
+    });
+
+    test("rowidsInRange returns plain number[] slice", () => {
+        const v = new FilterView("name~foo", sub([7, 11, 13, 21, 30]));
+        expect(v.rowidsInRange(1, 4)).toStrictEqual([11, 13, 21]);
+    });
+
+    test("viewKey encodes filterKey", () => {
+        const a = new FilterView("name~foo", sub([0]));
+        const b = new FilterView("name~bar", sub([0]));
+        expect(a.viewKey()).not.toBe(b.viewKey());
+    });
+
+    test("viewKey of a FilterView does not collide with a SortView", () => {
+        // Used to live in different LRU caches; verify the keys can't
+        // accidentally alias.
+        const f = new FilterView("age", sub([0]));
+        const s = new SortView("age", "asc", Int32Array.from([0]));
+        expect(f.viewKey()).not.toBe(s.viewKey());
+    });
+});
+
+
+describe("View contract — invariants across all view kinds", () => {
+    const cases: Array<[string, View]> = [
+        ["IdentityView(8)", new IdentityView(8)],
+        ["SortView", new SortView("k", "asc", Int32Array.from([3, 1, 4, 1, 5, 9, 2, 6]))],
+        ["FilterView", new FilterView("f", Int32Array.from([3, 1, 4, 1, 5, 9, 2, 6]))],
+    ];
+
+    test.each(cases)("%s — rowidsInRange(0, length()) returns length() items", (_label, v) => {
+        const all = v.rowidsInRange(0, v.length());
+        expect(all).toHaveLength(v.length());
+    });
+
+    test.each(cases)("%s — rowidsInRange and positionAt agree", (_label, v) => {
+        const slice = v.rowidsInRange(2, 5);
+        for (let i = 0; i < slice.length; i++) {
+            expect(slice[i]).toBe(v.positionAt(2 + i));
+        }
+    });
+
+    test.each(cases)("%s — viewKey is non-empty", (_label, v) => {
+        expect(v.viewKey().length).toBeGreaterThan(0);
+    });
+});
+
+
+describe("View — out-of-bounds positionAt", () => {
+    // Phase 2 contract: callers are expected to clamp via length()
+    // before calling positionAt. The view does not need to be defensive
+    // — out-of-bounds is the caller's bug. We assert "doesn't crash on
+    // negative", which means it either returns garbage or throws —
+    // either is fine, we just don't want a silent infinite loop.
+    test("IdentityView positionAt(-1) is well-behaved (doesn't hang)", () => {
+        const v = new IdentityView(10);
+        // either throws or returns a number; both are acceptable
+        expect(() => v.positionAt(-1)).not.toThrow(/timeout/i);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Views.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Views.ts
@@ -18,6 +18,17 @@
 export type SortDirection = "asc" | "desc";
 
 
+export const IDENTITY_VIEW_KEY = "identity";
+
+export function sortViewKey(sortKey: string, sortDirection: SortDirection): string {
+    return `sort:${sortKey}:${sortDirection}`;
+}
+
+export function filterViewKey(filterKey: string): string {
+    return `filter:${filterKey}`;
+}
+
+
 export interface View {
     length(): number;
     positionAt(pos: number): number;
@@ -50,7 +61,7 @@ export class IdentityView implements View {
     }
 
     public viewKey(): string {
-        return "identity";
+        return IDENTITY_VIEW_KEY;
     }
 }
 
@@ -81,7 +92,7 @@ export class SortView implements View {
     }
 
     public viewKey(): string {
-        return `sort:${this.sortKey}:${this.sortDirection}`;
+        return sortViewKey(this.sortKey, this.sortDirection);
     }
 }
 
@@ -110,6 +121,6 @@ export class FilterView implements View {
     }
 
     public viewKey(): string {
-        return `filter:${this.filterKey}`;
+        return filterViewKey(this.filterKey);
     }
 }

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Views.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Views.ts
@@ -1,0 +1,115 @@
+/**
+ * View layer: "what rowid is at position k under this ordering?"
+ *
+ * The RowStore holds row contents keyed by rowid; views answer the
+ * complementary question of which rowid lives where. The renderer
+ * composes:
+ *
+ *   view V at position k  →  rowid r = V.positionAt(k)  →  RowStore.get(r)
+ *
+ * Three kinds, all answering the same contract:
+ *   - IdentityView: position == rowid. No backing array.
+ *   - SortView:     wraps an Int32Array permutation of the dataset.
+ *   - FilterView:   wraps an Int32Array subset of the dataset.
+ *
+ * See docs/smart-row-cache-redesign.md.
+ */
+
+export type SortDirection = "asc" | "desc";
+
+
+export interface View {
+    length(): number;
+    positionAt(pos: number): number;
+    rowidsInRange(start: number, end: number): number[];
+    viewKey(): string;
+}
+
+
+export class IdentityView implements View {
+    private readonly _length: number;
+
+    constructor(length: number) {
+        this._length = length;
+    }
+
+    public length(): number {
+        return this._length;
+    }
+
+    public positionAt(pos: number): number {
+        return pos;
+    }
+
+    public rowidsInRange(start: number, end: number): number[] {
+        const clampedEnd = Math.min(end, this._length);
+        if (clampedEnd <= start) return [];
+        const out: number[] = new Array(clampedEnd - start);
+        for (let i = 0; i < out.length; i++) out[i] = start + i;
+        return out;
+    }
+
+    public viewKey(): string {
+        return "identity";
+    }
+}
+
+
+export class SortView implements View {
+    public readonly sortKey: string;
+    public readonly sortDirection: SortDirection;
+    public readonly rowidOrder: Int32Array;
+
+    constructor(sortKey: string, sortDirection: SortDirection, rowidOrder: Int32Array) {
+        this.sortKey = sortKey;
+        this.sortDirection = sortDirection;
+        this.rowidOrder = rowidOrder;
+    }
+
+    public length(): number {
+        return this.rowidOrder.length;
+    }
+
+    public positionAt(pos: number): number {
+        return this.rowidOrder[pos];
+    }
+
+    public rowidsInRange(start: number, end: number): number[] {
+        const clampedEnd = Math.min(end, this.rowidOrder.length);
+        if (clampedEnd <= start) return [];
+        return Array.from(this.rowidOrder.subarray(start, clampedEnd));
+    }
+
+    public viewKey(): string {
+        return `sort:${this.sortKey}:${this.sortDirection}`;
+    }
+}
+
+
+export class FilterView implements View {
+    public readonly filterKey: string;
+    public readonly rowidSubset: Int32Array;
+
+    constructor(filterKey: string, rowidSubset: Int32Array) {
+        this.filterKey = filterKey;
+        this.rowidSubset = rowidSubset;
+    }
+
+    public length(): number {
+        return this.rowidSubset.length;
+    }
+
+    public positionAt(pos: number): number {
+        return this.rowidSubset[pos];
+    }
+
+    public rowidsInRange(start: number, end: number): number[] {
+        const clampedEnd = Math.min(end, this.rowidSubset.length);
+        if (clampedEnd <= start) return [];
+        return Array.from(this.rowidSubset.subarray(start, clampedEnd));
+    }
+
+    public viewKey(): string {
+        return `filter:${this.filterKey}`;
+    }
+}

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/autocleaning.toggle.integration.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/autocleaning.toggle.integration.test.tsx
@@ -321,4 +321,86 @@ describe("BuckarooInfiniteWidget — autocleaning toggle", () => {
             errSpy.mockRestore();
         }
     });
+
+    // Models a user mashing the cleaning_method dropdown faster than Python
+    // round-trips can complete. The summary stats vary in shape across the
+    // sequence — some columns flip between valid arrays, empty arrays, null,
+    // undefined, and the string sentinel. Every same-fiber rerender that
+    // takes a cell into or out of its early-return branch is a place where
+    // a Rules-of-Hooks violation could surface as React #300/#310.
+    it("survives rapid cleaning_method toggles with varying summary-stats shapes", () => {
+        const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            const src = new KeyAwareSmartRowCache(() => {});
+
+            // A library of plausible cell-value shapes Python could push for
+            // a single column across an autoclean toggle.
+            const valueShapes: any[] = [
+                validHistogram,
+                altHistogram,
+                [], // empty array — still passes _.isArray but TypedHistogramCell
+                    // would render a no-data BarChart
+                "histogram", // pinned-row sentinel for missing data
+                undefined,
+                null,
+                validHistogram, // back to baseline
+            ];
+            const chartShapes: any[] = [
+                validChart,
+                altChart,
+                [],
+                "chart",
+                undefined,
+                null,
+                validChart,
+            ];
+            const cleaningMethods: BuckarooState["cleaning_method"][] = [
+                false,
+                "aggressive",
+                "conservative",
+                "",
+                "aggressive",
+                false,
+                "conservative",
+            ];
+
+            // Mount with the first frame.
+            const mkStats = (i: number): DFData => [
+                { index: "histogram", a: valueShapes[i], b: valueShapes[(i + 3) % valueShapes.length] },
+                { index: "chart", a: chartShapes[i], b: chartShapes[(i + 3) % chartShapes.length] },
+            ];
+
+            const { rerender } = render(widget(cleaningMethods[0], mkStats(0), src));
+
+            // Rapid-fire rerender across every (cleaning_method × stat shape)
+            // combination. No `act()` boundaries between renders — that's
+            // closer to "user mashes the dropdown" than the slow paced test.
+            for (let i = 1; i < cleaningMethods.length; i++) {
+                expect(() => {
+                    rerender(widget(cleaningMethods[i], mkStats(i), src));
+                }).not.toThrow();
+            }
+
+            // Now do it again, faster — 20 randomish toggles cycling shapes.
+            for (let k = 0; k < 20; k++) {
+                const i = (k * 3 + 1) % cleaningMethods.length;
+                expect(() => {
+                    rerender(widget(cleaningMethods[i], mkStats(i), src));
+                }).not.toThrow();
+            }
+
+            const reactErrors = errSpy.mock.calls.filter((args) =>
+                args.some(
+                    (a) =>
+                        typeof a === "string" &&
+                        /Rendered (more|fewer) hooks|Minified React error #(300|310)/i.test(
+                            a,
+                        ),
+                ),
+            );
+            expect(reactErrors).toEqual([]);
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
 });

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/autocleaning.toggle.integration.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/autocleaning.toggle.integration.test.tsx
@@ -1,0 +1,324 @@
+/**
+ * Integration test: BuckarooInfiniteWidget under an autocleaning toggle.
+ *
+ * Reproduces the user's report from Full-tour.ipynb: "Just toggling the
+ * cleaning method twice triggered React error #300" (Rendered fewer hooks
+ * than expected).
+ *
+ * Production flow this test mirrors:
+ *   1. Widget mounts with summary stats containing histogram + chart values.
+ *   2. User flips cleaning_method in the status bar.
+ *   3. Python regenerates summary stats; new `df_data_dict.summary_stats`
+ *      comes back with values for some columns potentially missing or
+ *      shape-changed.
+ *   4. AG-Grid keeps the same cell-fiber instances and just sets new
+ *      pinnedTopRowData via setGridOption — pushing fresh `value` props
+ *      into the same React fibers used for the pinned cells.
+ *   5. If any cellRenderer's hook count varies by value-shape branch,
+ *      React throws #300 / #310 depending on direction.
+ *
+ * Unlike the existing flash matrix tests (which stub AG-Grid to a `<div/>`
+ * and never actually mount cell renderers), this test installs an AG-Grid
+ * mock that walks `pinnedTopRowData × columnDefs` and renders each cell
+ * through `cellRendererSelector` — the same selector path that ships to
+ * production. That's the only way the bug surfaces in jsdom: AG-Grid's
+ * cell layer is where the hook violation actually fires.
+ */
+
+// jsdom polyfill for crypto.randomUUID (used by HistogramCell.gensym).
+{
+    let n = 0;
+    const existing: any = (globalThis as any).crypto || {};
+    if (typeof existing.randomUUID !== "function") {
+        try {
+            Object.defineProperty(existing, "randomUUID", {
+                configurable: true,
+                value: () => `test-uuid-${++n}`,
+            });
+        } catch {
+            Object.defineProperty(globalThis, "crypto", {
+                configurable: true,
+                value: { ...existing, randomUUID: () => `test-uuid-${++n}` },
+            });
+        }
+    }
+}
+
+// ts-jest doesn't apply esModuleInterop. Patch the React default import so
+// HistogramCell.tsx and ChartCell.tsx (which both do `import React from "react"`)
+// see a working React object at runtime.
+jest.mock("react", () => {
+    const actual = jest.requireActual("react");
+    return { __esModule: true, default: actual, ...actual };
+});
+
+import { render } from "@testing-library/react";
+import type {
+    ColDef,
+    GridApi,
+    ICellRendererParams,
+    CellRendererSelectorResult,
+} from "ag-grid-community";
+
+import { BuckarooInfiniteWidget } from "../BuckarooWidgetInfinite";
+import { KeyAwareSmartRowCache } from "./SmartRowCache";
+import type { BuckarooOptions, BuckarooState, DFMeta } from "../WidgetTypes";
+import type { DFData, DFViewerConfig } from "./DFWhole";
+import type { IDisplayArgs } from "./gridUtils";
+
+// recharts pulls in DOM measurement; stub the surface both cell renderers touch.
+jest.mock("recharts", () => {
+    const React = require("react") as typeof import("react");
+    const stub = ({ children }: any) =>
+        React.createElement("div", { "data-testid": "recharts-mock" }, children);
+    return {
+        Area: () => null,
+        Bar: () => null,
+        BarChart: stub,
+        ComposedChart: stub,
+        Line: () => null,
+        Tooltip: () => null,
+    };
+});
+
+// Stub StatusBar so its own AG-Grid usage doesn't get picked up by our mock.
+jest.mock("../StatusBar", () => ({
+    StatusBar: () => null,
+}));
+
+// Custom AG-Grid mock that ACTUALLY renders each pinned-row cell via the
+// cellRendererSelector path. DFViewerInfinite sets pinnedTopRowData via
+// the imperative api.setGridOption call (not via gridOptions props), so
+// the mock keeps its own React state for pinnedTopRowData and updates it
+// when setGridOption is invoked.
+jest.mock("ag-grid-react", () => {
+    const React = require("react") as typeof import("react");
+
+    const renderOneCell = (
+        rowData: any,
+        col: ColDef,
+        cellRendererSelector: any,
+        rowPinned: "top" | "bottom" | undefined,
+        outerContext: any,
+    ): any => {
+        const value = col.field ? rowData[col.field] : undefined;
+        const params: Partial<ICellRendererParams> = {
+            value,
+            data: rowData,
+            colDef: col,
+            column: { getColId: () => col.field ?? "" } as any,
+            api: {} as GridApi,
+            context: outerContext,
+            node: { rowPinned, data: rowData } as any,
+        };
+        let component: any = col.cellRenderer;
+        if (!component && typeof cellRendererSelector === "function") {
+            const sel: CellRendererSelectorResult | undefined = cellRendererSelector(
+                params as ICellRendererParams,
+            );
+            component = sel?.component ?? null;
+        }
+        if (!component) return null;
+        if (typeof component === "string") return null; // skip 'agCheckboxCellRenderer' etc.
+        return React.createElement(component, { ...params, key: col.field });
+    };
+
+    return {
+        AgGridReact: React.forwardRef((props: any, ref: any) => {
+            const [pinnedTopRowData, setPinnedTopRowData] = React.useState<any[]>([]);
+            const [rowData, setRowData] = React.useState<any[]>([]);
+
+            const api = React.useMemo(
+                () => ({
+                    setGridOption: (key: string, value: any) => {
+                        if (key === "pinnedTopRowData") setPinnedTopRowData(value || []);
+                        if (key === "rowData") setRowData(value || []);
+                    },
+                }),
+                [],
+            );
+
+            React.useImperativeHandle(ref, () => ({ api }), [api]);
+
+            // Fire onGridReady so DFViewerInfinite's imperative-API path runs,
+            // pushing the initial pinnedTopRowData into our captured state.
+            React.useEffect(() => {
+                props.onGridReady?.({ api });
+            }, [api]);
+
+            const columnDefs: ColDef[] = props.columnDefs ?? [];
+            const cellRendererSelector = props.defaultColDef?.cellRendererSelector;
+
+            const renderRow = (rd: any, idx: number, pinned: "top" | undefined) =>
+                React.createElement(
+                    "div",
+                    { key: `row-${pinned ?? "body"}-${idx}`, "data-testid": `row-${idx}` },
+                    columnDefs.map((c) =>
+                        renderOneCell(rd, c, cellRendererSelector, pinned, props.context),
+                    ),
+                );
+
+            return React.createElement(
+                "div",
+                { "data-testid": "ag-grid-render-mock" },
+                pinnedTopRowData.map((rd, i) => renderRow(rd, i, "top")),
+                rowData.map((rd, i) => renderRow(rd, i, undefined)),
+            );
+        }),
+    };
+});
+
+// ---------- realistic data --------------------------------------------------
+
+const validHistogram = [
+    { name: "true", true: 60, population: 60 },
+    { name: "false", false: 40, population: 40 },
+];
+const altHistogram = [
+    { name: "longtail", longtail: 100, population: 100 },
+];
+const validChart = [
+    { lineRed: 1, lineBlue: 2 },
+    { lineRed: 3, lineBlue: 4 },
+];
+const altChart = [
+    { lineRed: 5 },
+];
+
+const dfViewerConfig: DFViewerConfig = {
+    pinned_rows: [
+        { primary_key_val: "histogram", displayer_args: { displayer: "histogram" } },
+        { primary_key_val: "chart", displayer_args: { displayer: "chart" } },
+    ],
+    column_config: [
+        { col_name: "index", header_name: "index", displayer_args: { displayer: "obj" } },
+        { col_name: "a", header_name: "a", displayer_args: { displayer: "obj" } },
+        { col_name: "b", header_name: "b", displayer_args: { displayer: "obj" } },
+    ],
+    left_col_configs: [],
+};
+
+const baseDisplayArgs: Record<string, IDisplayArgs> = {
+    main: {
+        data_key: "main",
+        df_viewer_config: dfViewerConfig,
+        summary_stats_key: "summary_stats",
+    },
+};
+
+const baseDfMeta: DFMeta = {
+    total_rows: 50,
+    columns: 3,
+    filtered_rows: 50,
+    rows_shown: 50,
+};
+
+const baseOptions: BuckarooOptions = {
+    sampled: [],
+    cleaning_method: ["", "aggressive", "conservative"],
+    post_processing: [],
+    df_display: ["main"],
+    show_commands: [],
+};
+
+const initialState: BuckarooState = {
+    sampled: false,
+    cleaning_method: false,
+    quick_command_args: {},
+    post_processing: false,
+    df_display: "main",
+    show_commands: false,
+};
+
+// Summary stats data — each row's `index` matches one of the pinned_rows.
+// `a` is a numeric column with both kinds of stats; `b` loses its chart data
+// after the first toggle to simulate a column whose autoclean strategy
+// dropped the time-series view.
+const summaryStatsBefore: DFData = [
+    { index: "histogram", a: validHistogram, b: validHistogram },
+    { index: "chart", a: validChart, b: validChart },
+];
+
+const summaryStatsAfterToggle1: DFData = [
+    // `b` loses BOTH its histogram and chart data after aggressive cleaning
+    // (column dtype change → no per-row stats). The cells receive the
+    // string sentinel that pinned-row cells fall back to when the column
+    // has no value — flipping HistogramCell and ChartCell on column `b`
+    // into their early-return branches.
+    { index: "histogram", a: altHistogram, b: "histogram" },
+    { index: "chart", a: altChart, b: "chart" },
+];
+
+const summaryStatsAfterToggle2: DFData = [
+    { index: "histogram", a: validHistogram, b: validHistogram },
+    { index: "chart", a: validChart, b: validChart },
+];
+
+const widget = (
+    cleaning_method: BuckarooState["cleaning_method"],
+    summaryStats: DFData,
+    src: KeyAwareSmartRowCache,
+) => (
+    <BuckarooInfiniteWidget
+        df_data_dict={{ summary_stats: summaryStats }}
+        df_display_args={baseDisplayArgs}
+        df_meta={baseDfMeta}
+        operations={[]}
+        on_operations={jest.fn()}
+        operation_results={{} as any}
+        command_config={{ argspecs: {}, defaultArgs: {} }}
+        buckaroo_state={{ ...initialState, cleaning_method }}
+        on_buckaroo_state={jest.fn()}
+        buckaroo_options={baseOptions}
+        src={src}
+    />
+);
+
+describe("BuckarooInfiniteWidget — autocleaning toggle", () => {
+    it("does not throw a React hook error when cleaning_method is toggled twice", () => {
+        const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+        try {
+            const src = new KeyAwareSmartRowCache(() => {});
+
+            // Mount with the "before autoclean" state — valid histogram +
+            // chart values in every pinned cell.
+            const { rerender, container } = render(widget(false, summaryStatsBefore, src));
+
+            // Sanity: the mock must have rendered cells. 2 pinned rows ×
+            // 2 numeric columns = 4 chart/histogram mounts. If this is 0,
+            // the cell-renderers never fired and the test is vacuous.
+            const rechartsNodes = container.querySelectorAll(
+                '[data-testid="recharts-mock"]',
+            );
+            expect(rechartsNodes.length).toBeGreaterThan(0);
+
+            // First toggle: cleaning_method = "aggressive". Summary stats
+            // regenerate. Column `b` loses its chart data (now the string
+            // sentinel) — the chart cell-fiber for column `b` rerenders
+            // with a different value shape.
+            expect(() => {
+                rerender(widget("aggressive", summaryStatsAfterToggle1, src));
+            }).not.toThrow();
+
+            // Second toggle: cleaning_method = "conservative". Data comes
+            // back for column `b`. Same cell-fibers, value shape flips.
+            expect(() => {
+                rerender(widget("conservative", summaryStatsAfterToggle2, src));
+            }).not.toThrow();
+
+            // Belt-and-braces: no React errors were logged either.
+            const reactErrors = errSpy.mock.calls.filter((args) =>
+                args.some(
+                    (a) =>
+                        typeof a === "string" &&
+                        /Rendered (more|fewer) hooks|Minified React error #(300|310)/i.test(
+                            a,
+                        ),
+                ),
+            );
+            expect(reactErrors).toEqual([]);
+        } finally {
+            errSpy.mockRestore();
+        }
+    });
+});

--- a/tests/unit/test_row_cache_payloads.py
+++ b/tests/unit/test_row_cache_payloads.py
@@ -11,11 +11,11 @@ client-side cache layer:
 Phase 7 wires these into the widget; phase 6 just establishes the wire shape.
 """
 
-from io import BytesIO
-
 import pyarrow as pa
 import pyarrow.parquet as pq
-import xorq.api as xo
+import pytest
+
+xo = pytest.importorskip("xorq.api")
 
 
 def _read_parquet_bytes(b: bytes) -> pa.Table:

--- a/tests/unit/test_row_cache_payloads.py
+++ b/tests/unit/test_row_cache_payloads.py
@@ -59,6 +59,27 @@ class TestTagWithRowids:
         assert "age" in cols
         assert "_buckaroo_rowid" in cols
 
+    def test_rowid_column_is_int32(self):
+        # The JS view layer reads rowids into Int32Array (4 B/row); the
+        # design doc's 40 MB-per-10 M-rows wire budget assumes int32.
+        # Emitting int64 would double the wire payload.
+        from buckaroo.row_cache_payloads import tag_with_rowids
+
+        tagged = tag_with_rowids(_make_source())
+        assert tagged.to_pyarrow()["_buckaroo_rowid"].type == pa.int32()
+
+    def test_raises_when_source_already_has_rowid_column(self):
+        # pa.Table.append_column happily creates duplicate column names;
+        # then tagged.select("_buckaroo_rowid") is ambiguous and the
+        # rowid contract is silently broken. Reject up front.
+        from buckaroo.row_cache_payloads import tag_with_rowids
+
+        collision = xo.memtable(
+            {"_buckaroo_rowid": [10, 20, 30], "name": ["a", "b", "c"]}
+        )
+        with pytest.raises(ValueError, match="_buckaroo_rowid"):
+            tag_with_rowids(collision)
+
 
 class TestMakePopulatePayload:
     def test_returns_parquet_with_rowids_and_data_columns(self):
@@ -72,6 +93,7 @@ class TestMakePopulatePayload:
         table = _read_parquet_bytes(b)
         assert table.num_rows == 3
         assert table["_buckaroo_rowid"].to_pylist() == [0, 1, 2]
+        assert table["_buckaroo_rowid"].type == pa.int32()
         assert table["name"].to_pylist() == ["alice", "bob", "carol"]
 
     def test_offset_window_carries_the_correct_rowids(self):
@@ -115,6 +137,7 @@ class TestMakeSortPayload:
         table = _read_parquet_bytes(b)
         assert table.schema.names == ["_buckaroo_rowid"]
         assert table["_buckaroo_rowid"].to_pylist() == [1, 4, 0, 3, 2]
+        assert table["_buckaroo_rowid"].type == pa.int32()
 
     def test_returns_rowid_column_in_descending_sort_order(self):
         from buckaroo.row_cache_payloads import (

--- a/tests/unit/test_row_cache_payloads.py
+++ b/tests/unit/test_row_cache_payloads.py
@@ -1,0 +1,172 @@
+"""Phase 6 — server-side payload builders for the new row cache.
+
+Tested in isolation (no widget, no anywidget plumbing). The builders take
+an xorq expression and return parquet bytes shaped for the new
+client-side cache layer:
+
+  populate → bytes carrying {_buckaroo_rowid + data columns} for [start, end)
+  sort     → bytes carrying just _buckaroo_rowid in sort order (rowidOrder)
+  filter   → bytes carrying just _buckaroo_rowid for matching rows (rowidSubset)
+
+Phase 7 wires these into the widget; phase 6 just establishes the wire shape.
+"""
+
+from io import BytesIO
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import xorq.api as xo
+
+
+def _read_parquet_bytes(b: bytes) -> pa.Table:
+    return pq.read_table(pa.BufferReader(b))
+
+
+def _make_source():
+    return xo.memtable(
+        {
+            "name": ["alice", "bob", "carol", "dave", "eve"],
+            "age": [30, 25, 40, 35, 28],
+        }
+    )
+
+
+class TestTagWithRowids:
+    def test_adds_a_dense_rowid_column_starting_at_zero(self):
+        from buckaroo.row_cache_payloads import tag_with_rowids
+
+        tagged = tag_with_rowids(_make_source())
+        table = tagged.to_pyarrow()
+        rowids = table["_buckaroo_rowid"].to_pylist()
+        assert rowids == [0, 1, 2, 3, 4]
+
+    def test_rowid_assignment_is_stable_across_repeated_evaluations(self):
+        # The whole point — a rowid emitted by populate at t=0 must
+        # match the rowid emitted by sort or filter at t=1.
+        from buckaroo.row_cache_payloads import tag_with_rowids
+
+        tagged = tag_with_rowids(_make_source())
+        a = tagged.to_pyarrow()["_buckaroo_rowid"].to_pylist()
+        b = tagged.to_pyarrow()["_buckaroo_rowid"].to_pylist()
+        assert a == b
+
+    def test_preserves_the_data_columns(self):
+        from buckaroo.row_cache_payloads import tag_with_rowids
+
+        tagged = tag_with_rowids(_make_source())
+        cols = tagged.schema().names
+        assert "name" in cols
+        assert "age" in cols
+        assert "_buckaroo_rowid" in cols
+
+
+class TestMakePopulatePayload:
+    def test_returns_parquet_with_rowids_and_data_columns(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_populate_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        b = make_populate_payload(tagged, 0, 3)
+        table = _read_parquet_bytes(b)
+        assert table.num_rows == 3
+        assert table["_buckaroo_rowid"].to_pylist() == [0, 1, 2]
+        assert table["name"].to_pylist() == ["alice", "bob", "carol"]
+
+    def test_offset_window_carries_the_correct_rowids(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_populate_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        b = make_populate_payload(tagged, 2, 5)
+        table = _read_parquet_bytes(b)
+        assert table.num_rows == 3
+        assert table["_buckaroo_rowid"].to_pylist() == [2, 3, 4]
+
+    def test_request_past_end_returns_whatever_rows_exist(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_populate_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        b = make_populate_payload(tagged, 3, 100)
+        table = _read_parquet_bytes(b)
+        # 5-row source, asked from 3 → got 2
+        assert table.num_rows == 2
+        assert table["_buckaroo_rowid"].to_pylist() == [3, 4]
+
+
+class TestMakeSortPayload:
+    def test_returns_rowid_column_in_ascending_sort_order(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_sort_payload,
+        )
+
+        # age: alice=30, bob=25, carol=40, dave=35, eve=28
+        # rowids:        0       1       2        3       4
+        # asc by age → rowids in order: 1, 4, 0, 3, 2
+        tagged = tag_with_rowids(_make_source())
+        b = make_sort_payload(tagged, "age", ascending=True)
+        table = _read_parquet_bytes(b)
+        assert table.schema.names == ["_buckaroo_rowid"]
+        assert table["_buckaroo_rowid"].to_pylist() == [1, 4, 0, 3, 2]
+
+    def test_returns_rowid_column_in_descending_sort_order(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_sort_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        b = make_sort_payload(tagged, "age", ascending=False)
+        table = _read_parquet_bytes(b)
+        assert table["_buckaroo_rowid"].to_pylist() == [2, 3, 0, 4, 1]
+
+    def test_carries_no_data_columns(self):
+        # Sort response is just the permutation; rows are already in the
+        # client's RowStore (or fetched on follow-up populate).
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_sort_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        b = make_sort_payload(tagged, "name", ascending=True)
+        table = _read_parquet_bytes(b)
+        assert table.schema.names == ["_buckaroo_rowid"]
+
+
+class TestMakeFilterPayload:
+    def test_returns_rowid_column_for_filtered_subset(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_filter_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        # age > 30 → carol (rowid 2), dave (rowid 3)
+        filtered = tagged.filter(tagged.age > 30)
+        b = make_filter_payload(filtered)
+        table = _read_parquet_bytes(b)
+        assert table.schema.names == ["_buckaroo_rowid"]
+        # Result order doesn't matter for a filter — the client treats
+        # this as a subset. Sort for stability.
+        assert sorted(table["_buckaroo_rowid"].to_pylist()) == [2, 3]
+
+    def test_empty_filter_returns_zero_rows(self):
+        from buckaroo.row_cache_payloads import (
+            tag_with_rowids,
+            make_filter_payload,
+        )
+
+        tagged = tag_with_rowids(_make_source())
+        filtered = tagged.filter(tagged.age > 1000)
+        b = make_filter_payload(filtered)
+        table = _read_parquet_bytes(b)
+        assert table.num_rows == 0
+        assert table.schema.names == ["_buckaroo_rowid"]

--- a/tests/unit/test_row_cache_payloads.py
+++ b/tests/unit/test_row_cache_payloads.py
@@ -24,11 +24,7 @@ def _read_parquet_bytes(b: bytes) -> pa.Table:
 
 def _make_source():
     return xo.memtable(
-        {
-            "name": ["alice", "bob", "carol", "dave", "eve"],
-            "age": [30, 25, 40, 35, 28],
-        }
-    )
+        {"name": ["alice", "bob", "carol", "dave", "eve"], "age": [30, 25, 40, 35, 28]})
 
 
 class TestTagWithRowids:
@@ -75,18 +71,14 @@ class TestTagWithRowids:
         from buckaroo.row_cache_payloads import tag_with_rowids
 
         collision = xo.memtable(
-            {"_buckaroo_rowid": [10, 20, 30], "name": ["a", "b", "c"]}
-        )
+            {"_buckaroo_rowid": [10, 20, 30], "name": ["a", "b", "c"]})
         with pytest.raises(ValueError, match="_buckaroo_rowid"):
             tag_with_rowids(collision)
 
 
 class TestMakePopulatePayload:
     def test_returns_parquet_with_rowids_and_data_columns(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_populate_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_populate_payload)
 
         tagged = tag_with_rowids(_make_source())
         b = make_populate_payload(tagged, 0, 3)
@@ -97,10 +89,7 @@ class TestMakePopulatePayload:
         assert table["name"].to_pylist() == ["alice", "bob", "carol"]
 
     def test_offset_window_carries_the_correct_rowids(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_populate_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_populate_payload)
 
         tagged = tag_with_rowids(_make_source())
         b = make_populate_payload(tagged, 2, 5)
@@ -109,10 +98,7 @@ class TestMakePopulatePayload:
         assert table["_buckaroo_rowid"].to_pylist() == [2, 3, 4]
 
     def test_request_past_end_returns_whatever_rows_exist(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_populate_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_populate_payload)
 
         tagged = tag_with_rowids(_make_source())
         b = make_populate_payload(tagged, 3, 100)
@@ -124,10 +110,7 @@ class TestMakePopulatePayload:
 
 class TestMakeSortPayload:
     def test_returns_rowid_column_in_ascending_sort_order(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_sort_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_sort_payload)
 
         # age: alice=30, bob=25, carol=40, dave=35, eve=28
         # rowids:        0       1       2        3       4
@@ -140,10 +123,7 @@ class TestMakeSortPayload:
         assert table["_buckaroo_rowid"].type == pa.int32()
 
     def test_returns_rowid_column_in_descending_sort_order(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_sort_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_sort_payload)
 
         tagged = tag_with_rowids(_make_source())
         b = make_sort_payload(tagged, "age", ascending=False)
@@ -153,10 +133,7 @@ class TestMakeSortPayload:
     def test_carries_no_data_columns(self):
         # Sort response is just the permutation; rows are already in the
         # client's RowStore (or fetched on follow-up populate).
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_sort_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_sort_payload)
 
         tagged = tag_with_rowids(_make_source())
         b = make_sort_payload(tagged, "name", ascending=True)
@@ -166,10 +143,7 @@ class TestMakeSortPayload:
 
 class TestMakeFilterPayload:
     def test_returns_rowid_column_for_filtered_subset(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_filter_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_filter_payload)
 
         tagged = tag_with_rowids(_make_source())
         # age > 30 → carol (rowid 2), dave (rowid 3)
@@ -182,10 +156,7 @@ class TestMakeFilterPayload:
         assert sorted(table["_buckaroo_rowid"].to_pylist()) == [2, 3]
 
     def test_empty_filter_returns_zero_rows(self):
-        from buckaroo.row_cache_payloads import (
-            tag_with_rowids,
-            make_filter_payload,
-        )
+        from buckaroo.row_cache_payloads import (tag_with_rowids, make_filter_payload)
 
         tagged = tag_with_rowids(_make_source())
         filtered = tagged.filter(tagged.age > 1000)


### PR DESCRIPTION
## Summary

Two-layer cache redesign so sort doesn't refetch rows and N sorts don't store N copies of the data. Rowid-keyed `RowStore` holds row contents; `View` layer (`IdentityView` / `SortView` / `FilterView`) maps positions to rowids. Sort and filter share the source `RowStore`; only operations that *change* row contents (postprocessors, mutate, etc.) get a fresh store. Design doc lives in `docs/smart-row-cache-redesign.md`.

Built TDD-style: each phase is a (failing tests) → (implementation) commit pair, so every test was seen failing on CI before its fix.

- **Phase 1** — `RowStore` (Map<rowid, row> with `set/setMany/get/getMany/has/delete/size/rowids/missingRowids`). 15 tests.
- **Phase 2** — `View` interface + `IdentityView` (default order, no allocation), `SortView` (Int32Array permutation), `FilterView` (Int32Array subset). 26 tests.
- **Phase 3** — `gcRowStore` visibility-aware GC: union of `[start-pad, end+pad]` positions across active views, map to rowids, drop the rest. 11 tests.
- **Phase 4** — Head/tail pinning via optional `PinSpec` — first/last N rowids of every pinned view always survive GC. 7 tests.
- **Phase 5** — `ViewRegistry` LRU bound (default 4) on `SortView`s / `FilterView`s. 14 tests.
- **Phase 6** — Python wire builders: `tag_with_rowids` (one-time materialise + dense rowid column), `make_populate_payload` / `make_sort_payload` / `make_filter_payload` returning parquet bytes. 11 tests.
- **Phase 7a** — `RowCache` integration controller — the API the consumer will use. `populate / applySort / applyFilter / rowsAt / missingAt / gc`. 14 tests.

98 new tests, 183 JS suite total + 11 Python tests, all green locally.

## What's not in this PR (next session)

- Wiring `RowCache` into `TableInfinite.tsx` so the AG-Grid datasource pulls from it instead of `KeyAwareSmartRowCache`.
- Wiring `row_cache_payloads` into the widget message handler (new `populate` / `sort` / `filter` message kinds).
- Deciding whether `KeyAwareSmartRowCache` survives as the "postprocessor-changed-rows" path (design says yes) or is fully replaced.
- Playwright verification once the wire format changes.

Tracked in the design doc under "What's left."

## Test plan

- [ ] CI: JS test suite is green (RowStore / Views / RowStoreGc / ViewRegistry / RowCache test files all run under jest)
- [ ] CI: Python test suite is green (`tests/unit/test_row_cache_payloads.py` runs under pytest)
- [ ] CI: lint stays green — no consumers touched yet, so no regression risk to existing widget flows
- [ ] Manual: design doc reads cleanly as the spec to point reviewers at

🤖 Generated with [Claude Code](https://claude.com/claude-code)