### PR TITLE
test: re-render & flash matrix (pre-#719 safety net)

### DIFF
--- a/docs/rerender-test-plan.md
+++ b/docs/rerender-test-plan.md
@@ -1,0 +1,179 @@
+# Re-render & Flash Test Plan
+
+## Goal
+
+Comprehensive automated tests that capture, for every kind of state change, exactly what AG-Grid does today: does it remount, does it refetch, does it just refresh cells, or does it do nothing? These tests serve three purposes:
+
+1. **Document the design** — the matrix below is the spec for "when is a full reset *necessary* vs when is it gratuitous (a flash)."
+2. **Pin current behavior** so the SPA `dataframe_id` refactor and the #719 view-layer wiring don't regress anything.
+3. **Make the refactor mechanical** — each fix flips one test from "asserts current behavior" to "asserts desired behavior."
+
+## Motivating use cases
+
+- **SPA embedding** — host app passes a `dataframe_id`. When it changes the widget should fully reset (new dataset). When it stays the same, no state change should remount AG-Grid.
+- **#719 (open PR)** — sort and filter must not invalidate cached rows; only postprocessor / mutate operations get a fresh `RowStore`. Today's `outside_df_params` lumps everything together via the React `key` trick, which conflicts with the future view-layer model.
+
+## What we measure
+
+The existing AG-Grid mock in `DFViewerInfinite.test.tsx` captures props. Extend it (in a new `test-utils/agGridSpy.ts`) to also capture:
+
+| Signal | Why it matters |
+|---|---|
+| Mount count | Catches `key={…}` remounts — the main flash cause |
+| `getRows` calls | Datasource churn; sourceName tells us cache namespacing |
+| `setGridOption(...)` calls | Soft-update path (`pinnedTopRowData`, `rowData`, `datasource`) |
+| `refreshCells` / `purgeInfiniteCache` / `refreshInfiniteCache` | Invalidation paths the refactor will introduce |
+| Column def identity churn | Did the column structure actually change, or just lose memo? |
+| `getRowId` outputs per index | Row ID stability across renders (today it's salted with outside params) |
+
+Each test calls `createAgGridSpy()` → gets a `{ mock, calls }` pair → asserts on `calls`.
+
+## State-change matrix
+
+Legend: **R** = full remount, **D** = datasource swap (no remount), **P** = `purgeInfiniteCache`, **S** = `setGridOption`, **C** = `refreshCells`, **·** = no grid touch.
+
+| Trigger | Today (main) | Desired post-refactor | Desired post-#719 |
+|---|---|---|---|
+| `dataframe_id` (SPA, new) | n/a | D + P + scroll-to-top | same |
+| `post_processing` change | **R** | D + P | D + P (new RowStore) |
+| `operations` change | **R** | D + P | D + P (new RowStore) |
+| `cleaning_method` change | D (via `mainDs` deps; no key change but new ds identity → flash) | D + P | D + P |
+| `quick_command_args` (mutating) | **R** | D + P | D + P |
+| `quick_command_args.search` (filter-like) | **R** | D + P | **·** + view swap (FilterView) |
+| Sort change | getRows with new sortModel (refetch block) | same | **·** + view swap (SortView) |
+| `activeCol` change | C (correct already) | same | same |
+| `df_display` main ↔ summary | **R** + data_type Raw↔DataSource swap | structural — see open question | same |
+| `summary_stats_data` update | S (`pinnedTopRowData`) | same | same |
+| `df_viewer_config.column_config` reshape | column defs new identity; no row refetch | same | same |
+| `df_viewer_config` style-only tweak | column defs new identity (over-invalidation) | minimal cell refresh | same |
+| `df_meta.total_rows` change | propagates via wrapper.length | row count update only | same |
+| `show_commands` toggle | sibling DOM + `buckaroo_state` ref change ripples into `mainDs`/`data_wrapper` deps | **·** | **·** |
+| Theme / OS scheme | rebuilds `myTheme` memo | same (no regression) | same |
+| In-flight response after newer change | namespaced by sourceName in cache, should drop | same | same |
+| `outsideDFParams` identity-only churn (same values, new array literal) | downstream `useMemo` thrash | stable identity | stable identity |
+
+## Tests to write today (current-main behavior)
+
+These go in two files. Each test asserts the **current** behavior; tests that capture the flash are clearly named so we know they're tracking pain, not validating it.
+
+### `DFViewerInfinite.flash.test.tsx` (leaf component)
+
+1. `post_processing change remounts AG-Grid` — mount count 1→2. Captures the current `key`-based flash.
+2. `outside_df_params identity-only change does NOT remount` — same value, new array literal; mount stays 1.
+3. `activeCol change triggers refreshCells, not remount` — refreshCells called with the two affected columns.
+4. `summary_stats_data update calls setGridOption('pinnedTopRowData') without remount`.
+5. `Raw data update calls setGridOption('rowData') without remount` (tighten existing).
+6. `Sort change calls getRows with new sortModel` — datasource exercised, mount stays 1. Sort-refetch is today's behavior; will flip post-#719.
+7. `getRowId for the same index changes when outside_df_params change` — captures the row-id-salting behavior that defeats row recycling.
+8. `Theme / colorScheme change does NOT remount or refetch`.
+9. `column_config reshape rebuilds column defs but does not call getRows`.
+
+### `BuckarooInfiniteWidget.flash.test.tsx` (integration — new file)
+
+10. `show_commands toggle does NOT touch the grid datasource` — likely **fails today** because `buckaroo_state` ref change ripples through `data_wrapper`/`mainDs` deps. This is the test that exposes the memo-dep widening problem.
+11. `cleaning_method change rebuilds datasource` — current behavior (flashes via new ds identity, not via React key).
+12. `outsideDFParams reference stable when no relevant state changed` — likely **fails today** (it's a fresh array literal every render). Drives the `useMemo` fix.
+13. `df_display switch (main → summary) swaps data_type Raw↔DataSource` — captures the legitimate-reset path.
+
+### Edge cases / races
+
+14. `Stale infinite_resp from a previous outside_df_params is discarded` — fire getRows under sourceName=A, change params to B, deliver A's response late, assert no stale rows applied. Likely already handled by `KeyAwareSmartRowCache`'s sourceName namespacing — but un-tested.
+15. `Summary stats update during in-flight getRows applies pinned rows without cancelling the fetch`.
+16. `activeCol persists across a post_processing change` — today the prop survives but the AG-Grid `context` is reset by the remount; documents the UX cost.
+
+## DOM verification (Playwright)
+
+The jest matrix above stops at the AG-Grid API contract — "did `setGridOption('rowData', X)` get called" — because AG-Grid itself is mocked. That catches missed plumbing but not the case where we call the right methods and AG-Grid silently keeps showing stale rows. For each row in the matrix that has a user-visible value swap, we need one Playwright assertion that the new values are actually in the DOM.
+
+Infrastructure already in place: `playwright.config.ts` points at Storybook on :6006, `pw-tests/ag-pw-utils.ts` has `waitForCells`, and the relevant stories already exist. New file: `pw-tests/rerender.spec.ts`.
+
+### Cases to cover
+
+| Case | Story to target | Assertion |
+|---|---|---|
+| `outside_df_params` swap shows new dataset values | `OutsideParamsInconsistency--primary` (already has Toggle button) | Click "Toggle Params"; assert cells contain `B1/B2/B3`, not `A1/A2/A3`. Toggle back; assert `A1` returns. |
+| `outside_df_params` swap with network delay (no stale-after-toggle race) | `OutsideParamsInconsistency--with-delay` | Toggle, wait for `B1`; assert no `A*` value is ever visible after the toggle settles. |
+| Pinned-row update reflects in DOM without flicker | `PinnedRowsDynamic` | Trigger the dynamic update; assert pinned-row cell text changed to the new value. |
+| Pinned-row race (rapid updates) | `PinnedRowsRace` | After all updates settle, assert the final value is visible (no torn state). |
+| `post_processing` change via BuckarooWidgetTest | `BuckarooWidgetTest` (add a postprocessing toggle if not present) | Change postprocessing; assert at least one cell value changed to the postprocessed result. |
+| Sort change shows reordered rows | any infinite-row story | Click a column header; assert row at index 0 now has the highest/lowest value for that column. |
+| Column reshape shows new column header in DOM | `Styling` or similar | Change `column_config`; assert new header text is in DOM, old header is gone. |
+| `dataframe_id` reset (deferred — write when prop lands) | new story `DataframeIdReset` | Set initial dataset, scroll down, change `dataframe_id`; assert new dataset values appear at top, scroll returned to 0. |
+
+### How this overlaps with jest
+
+The jest matrix and Playwright suite are complementary, not redundant:
+
+- **Jest** asserts the *mechanism* — mount count, getRows arguments, setGridOption calls. Runs in seconds; gates every commit.
+- **Playwright** asserts the *outcome* — cell text in the DOM. Slower, but catches AG-Grid behavior the mock can't model (virtualization, cell renderers, refresh timing).
+
+If a future change calls all the right APIs but the cell still shows stale text, only Playwright catches it. If a change accidentally adds an extra mount but the cell text is still right, only jest catches it. Both are needed.
+
+### Convention for "current behavior" Playwright cases
+
+Same as Option A in jest: the Playwright tests assert what users see **today** with the `key`-driven remount in place. If a cell flashes empty then fills in, the assertion is "after settle, B1 is visible" — not "during the swap, no empty state is shown." We'll add the flash-free assertions in the refactor PR when the implementation can satisfy them.
+
+## Tests deferred (documented in matrix, not written until refactor)
+
+- `dataframe_id` change → full reset path (write when the prop lands)
+- Sort change → no `getRows` call (write when #719's view layer is wired)
+- Filter / search change → no `getRows` call (write when #719's view layer is wired)
+
+## Refactor sequence enabled by this suite
+
+Once the suite is green on main:
+
+1. Memoize `outsideDFParams` in `BuckarooInfiniteWidget` → flips test 12.
+2. Narrow `data_wrapper` / `mainDs` deps to specific fields → flips test 10.
+3. Remove `key={JSON.stringify(outside_df_params)}` on `AgGridReact`; add an effect that calls `purgeInfiniteCache()` on a memoized signature → flips test 1.
+4. Drop the outside-key suffix from `getRowId` → flips test 7.
+5. Introduce `dataframe_id` prop; treat it as the *only* trigger for the full-reset path → add the deferred SPA test.
+
+Each step is a small PR with a clearly named test transition.
+
+## Open design questions (resolve before refactor, not before tests)
+
+1. **`dataframe_id` API shape.** New top-level prop, or one key inside `outside_df_params`? Folding keeps the surface small; separating makes "this is a hard reset" semantically distinct.
+2. **`df_display` main ↔ summary.** Currently swaps Raw↔DataSource. Is preserving scroll/column state across this swap valuable, or is it expected to feel like switching panels? If the latter, the remount is fine and we just want it to be the *only* place the remount happens.
+3. **Sort-changed scroll behavior.** Today sorts call `ensureIndexVisible(0)`. After #719 the sort is a pure view permutation; do we still scroll to top, or hold the user's position?
+
+## Harness sketch
+
+```ts
+// test-utils/agGridSpy.ts
+export interface AgGridSpyCalls {
+  mountCount: number;
+  setGridOption: Array<[string, unknown]>;
+  refreshCells: RefreshCellsParams[];
+  refreshInfiniteCache: number;
+  purgeInfiniteCache: number;
+  getRowsCallArgs: IGetRowsParams[];
+  rowIdsByIndex: Map<number, Set<string>>; // index → distinct IDs observed
+  lastProps: any;
+}
+
+export const createAgGridSpy = (): {
+  install: () => void;   // wires jest.mock for "ag-grid-react"
+  calls: AgGridSpyCalls;
+};
+```
+
+Tests then look like:
+
+```ts
+const { install, calls } = createAgGridSpy();
+install();
+const { rerender } = render(<DFViewerInfinite ... outside_df_params={{ pp: "a" }} />);
+rerender(<DFViewerInfinite ... outside_df_params={{ pp: "b" }} />);
+expect(calls.mountCount).toBe(2); // current behavior
+// after refactor this becomes: toBe(1) + expect(calls.purgeInfiniteCache).toBe(1);
+```
+
+## Running
+
+```
+cd packages/buckaroo-js-core && pnpm test            # jest matrix (fast, runs on every commit)
+cd packages/buckaroo-js-core && pnpm run test:pw     # Playwright DOM checks (slower, CI-gated)
+```
+
+Both layers must be green before the PR merges. The jest matrix locks in the AG-Grid contract; the Playwright suite locks in what the user actually sees.

--- a/packages/buckaroo-js-core/pw-tests/rerender.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/rerender.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * Flash matrix — DOM verification (Playwright).
+ *
+ * Companion to the jest matrix in:
+ *   - src/components/DFViewerParts/DFViewerInfinite.flash.test.tsx
+ *   - src/components/BuckarooInfiniteWidget.flash.test.tsx
+ *
+ * The jest tests assert the AG-Grid *contract* (mount count, setGridOption
+ * calls, getRows args). These tests assert the user-visible *outcome*:
+ * after a state change, the new values are actually in the DOM.
+ *
+ * Tests assert CURRENT behavior on main. Refactor PRs (remove the React `key`
+ * remount, memoize outsideDFParams, swap to purgeInfiniteCache) should keep
+ * these green.
+ */
+import { test, expect } from "@playwright/test";
+import { waitForCells, getRowContents } from "./ag-pw-utils";
+
+const STORY_URL = (id: string) =>
+  `http://localhost:6006/iframe.html?viewMode=story&id=${id}&globals=&args=`;
+
+test.describe("Rerender flash matrix — DOM verification", () => {
+  test("OutsideParamsInconsistency: toggling outside_df_params swaps visible rows A → B", async ({ page }) => {
+    await page.goto(STORY_URL("buckaroo-dfviewer-outsideparamsinconsistency--primary"));
+    await waitForCells(page);
+
+    // Initial dataset A
+    let rc = await getRowContents(page, 0);
+    expect(rc.join(" ")).toContain("A1");
+
+    await page.getByRole("button", { name: "Toggle Params" }).click();
+    // After toggle: rows now come from dataset B
+    await expect(page.getByText("B1")).toBeVisible();
+    rc = await getRowContents(page, 0);
+    expect(rc.join(" ")).toContain("B1");
+    expect(rc.join(" ")).not.toContain("A1");
+
+    // Toggle back
+    await page.getByRole("button", { name: "Toggle Params" }).click();
+    await expect(page.getByText("A1")).toBeVisible();
+    rc = await getRowContents(page, 0);
+    expect(rc.join(" ")).toContain("A1");
+  });
+
+  test("OutsideParamsInconsistency (with delay): no stale A values after toggle settles", async ({ page }) => {
+    await page.goto(STORY_URL("buckaroo-dfviewer-outsideparamsinconsistency--with-delay"));
+    await waitForCells(page);
+
+    await page.getByRole("button", { name: "Toggle Params" }).click();
+    // After the delayed response lands, the visible row should be from B.
+    // We allow some time for the delayed (150 ms) datasource response.
+    await expect(page.getByText("B1")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("A1")).toHaveCount(0);
+  });
+
+  test("PinnedRowsDynamic: updating summary changes pinned-row cell text in place", async ({ page }) => {
+    await page.goto(STORY_URL("buckaroo-dfviewer-pinnedrowsdynamic--primary"));
+    await waitForCells(page);
+
+    // Initial summary: empty_count.a=0. After toggle: empty_count.a=3.
+    // The "3" appears only in the "updated" variant so it's a clean signal
+    // that pinned-row cells updated via setGridOption('pinnedTopRowData').
+    await expect(page.locator(".ag-floating-top").getByText("3")).toHaveCount(0);
+    await page.getByRole("button", { name: "Toggle pinned rows" }).click();
+    await expect(page.locator(".ag-floating-top").getByText("3")).toBeVisible();
+  });
+
+  test("BuckarooWidgetTest: postprocessing/operations toggles do not leave the grid empty", async ({ page }) => {
+    // Locks in that the flash-mounted grid eventually shows rows again.
+    // After the refactor, this should also pass without the visible empty
+    // chrome interval — but that's a perceptual property hard to assert
+    // here. The contract we lock today is just "rows are visible after toggle".
+    await page.goto(STORY_URL("buckaroo-buckaroowidgettest--primary"));
+    await waitForCells(page);
+
+    const initialRc = await getRowContents(page, 0);
+    expect(initialRc.some((s) => s && s.length > 0)).toBe(true);
+
+    // BuckarooWidgetTest exposes outsideDFParams toggles via its StatusBar.
+    // We don't bind to specific control labels here — that would couple
+    // the test to UI copy. We just verify that after the page settles, a
+    // row at index 0 still has content.
+    await page.waitForTimeout(500);
+    const settled = await getRowContents(page, 0);
+    expect(settled.some((s) => s && s.length > 0)).toBe(true);
+  });
+});

--- a/packages/buckaroo-js-core/pw-tests/rerender.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/rerender.spec.ts
@@ -65,23 +65,35 @@ test.describe("Rerender flash matrix — DOM verification", () => {
     await expect(page.locator(".ag-floating-top").getByText("3")).toBeVisible();
   });
 
-  test("BuckarooWidgetTest: postprocessing/operations toggles do not leave the grid empty", async ({ page }) => {
-    // Locks in that the flash-mounted grid eventually shows rows again.
-    // After the refactor, this should also pass without the visible empty
-    // chrome interval — but that's a perceptual property hard to assert
-    // here. The contract we lock today is just "rows are visible after toggle".
+  test("BuckarooWidgetTest: df_display toggle (an outside_df_params change) does not leave the grid empty", async ({ page }) => {
+    // Locks in that an outside_df_params-driven AG-Grid remount eventually
+    // shows rows again. df_display is the only outside_df_params field this
+    // story actually exposes via its StatusBar (post_processing and
+    // cleaning_method options are empty for this story); the contract being
+    // verified — "remount on outside_df_params change doesn't leave the grid
+    // empty" — is identical.
+    //
+    // After the refactor (purgeInfiniteCache replaces React-key remount),
+    // this should also pass without the visible empty chrome interval — but
+    // that's a perceptual property hard to assert here.
     await page.goto(STORY_URL("buckaroo-buckaroowidgettest--primary"));
     await waitForCells(page);
 
     const initialRc = await getRowContents(page, 0);
     expect(initialRc.some((s) => s && s.length > 0)).toBe(true);
 
-    // BuckarooWidgetTest exposes outsideDFParams toggles via its StatusBar.
-    // We don't bind to specific control labels here — that would couple
-    // the test to UI copy. We just verify that after the page settles, a
-    // row at index 0 still has content.
-    await page.waitForTimeout(500);
-    const settled = await getRowContents(page, 0);
-    expect(settled.some((s) => s && s.length > 0)).toBe(true);
+    // The StatusBar exposes df_display as a <select> with options main/summary.
+    // Flip to summary, then back to main — each flip is a real outside_df_params
+    // change and (today) a full remount of the data grid.
+    const dfDisplaySelect = page.locator(".status-bar select").filter({ hasText: /main|summary/ }).first();
+    await dfDisplaySelect.selectOption("summary");
+    await waitForCells(page);
+    const summaryRc = await getRowContents(page, 0);
+    expect(summaryRc.some((s) => s && s.length > 0)).toBe(true);
+
+    await dfDisplaySelect.selectOption("main");
+    await waitForCells(page);
+    const mainRc = await getRowContents(page, 0);
+    expect(mainRc.some((s) => s && s.length > 0)).toBe(true);
   });
 });

--- a/packages/buckaroo-js-core/src/components/BuckarooInfiniteWidget.flash.test.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooInfiniteWidget.flash.test.tsx
@@ -7,7 +7,6 @@
  * Tests assert CURRENT behavior on main (Option A in docs/rerender-test-plan.md).
  * Tests tagged "[captures current flash]" are tracking pain, not validating it.
  */
-import React from "react";
 import { render } from "@testing-library/react";
 import { BuckarooInfiniteWidget } from "./BuckarooWidgetInfinite";
 import { KeyAwareSmartRowCache } from "./DFViewerParts/SmartRowCache";
@@ -15,7 +14,6 @@ import { getSpyCalls, resetSpy } from "../test-utils/agGridSpy";
 import { BuckarooState, BuckarooOptions, DFMeta } from "./WidgetTypes";
 import { DFViewerConfig } from "./DFViewerParts/DFWhole";
 import { IDisplayArgs } from "./DFViewerParts/gridUtils";
-import { CommandConfigT } from "./CommandUtils";
 
 jest.mock("ag-grid-react", () =>
   require("../test-utils/agGridSpy").agGridReactMockFactory(),
@@ -90,28 +88,6 @@ const initialState: BuckarooState = {
 };
 
 const mkSrc = () => new KeyAwareSmartRowCache(() => {});
-
-const renderWidget = (overrides: { state?: Partial<BuckarooState>; src?: KeyAwareSmartRowCache } = {}) => {
-  const state: BuckarooState = { ...initialState, ...overrides.state };
-  const noopOps = jest.fn();
-  const noopState = jest.fn();
-  const cmd: CommandConfigT = { argspecs: {}, defaultArgs: {} };
-  return render(
-    <BuckarooInfiniteWidget
-      df_data_dict={{ summary_stats: [] }}
-      df_display_args={baseDisplayArgs}
-      df_meta={baseDfMeta}
-      operations={[]}
-      on_operations={noopOps}
-      operation_results={{ transformed_df: [], generated_py_code: "", search_term: "" } as any}
-      command_config={cmd}
-      buckaroo_state={state}
-      on_buckaroo_state={noopState}
-      buckaroo_options={baseOptions}
-      src={overrides.src ?? mkSrc()}
-    />,
-  );
-};
 
 beforeEach(() => {
   resetSpy();
@@ -220,14 +196,35 @@ describe("BuckarooInfiniteWidget — flash matrix (current behavior)", () => {
   });
 
   it("[captures current flash] outsideDFParams is a new array literal on every render (no useMemo)", () => {
-    renderWidget({ state: { post_processing: "" } });
+    // Re-render the *same* widget instance — that's what the planned useMemo
+    // refactor would preserve identity across. Rendering two independent
+    // instances would never see memoization either way, so it can't flip to
+    // the desired assertion post-refactor.
+    const src = mkSrc();
+    const widgetEl = (state: BuckarooState) => (
+      <BuckarooInfiniteWidget
+        df_data_dict={{ summary_stats: [] }}
+        df_display_args={baseDisplayArgs}
+        df_meta={baseDfMeta}
+        operations={[]}
+        on_operations={jest.fn()}
+        operation_results={{} as any}
+        command_config={{ argspecs: {}, defaultArgs: {} }}
+        buckaroo_state={state}
+        on_buckaroo_state={jest.fn()}
+        buckaroo_options={baseOptions}
+        src={src}
+      />
+    );
+    const { rerender } = render(widgetEl({ ...initialState, post_processing: "" }));
     const firstRef = dfvCalls[0].outside_df_params;
     expect(Array.isArray(firstRef)).toBe(true);
-    // Force a parent rerender with the same state. outsideDFParams in
-    // BuckarooInfiniteWidget is a bare array literal; it gets a fresh
-    // identity each render. Post-refactor: should be wrapped in useMemo and
-    // be reference-equal here.
-    renderWidget({ state: { post_processing: "" } });
+
+    // Force a re-render with a fresh-identity state object that has the same
+    // values. outsideDFParams in BuckarooInfiniteWidget is a bare array literal;
+    // it gets a fresh identity each render. Post-refactor: should be wrapped
+    // in useMemo and be reference-equal here.
+    rerender(widgetEl({ ...initialState, post_processing: "" }));
     const secondRef = dfvCalls[dfvCalls.length - 1].outside_df_params;
     expect(secondRef).not.toBe(firstRef);
     // ...but VALUES are equal, which is why the React key doesn't change

--- a/packages/buckaroo-js-core/src/components/BuckarooInfiniteWidget.flash.test.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooInfiniteWidget.flash.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * Flash matrix — integration layer (BuckarooInfiniteWidget).
+ *
+ * Pins down the cascade from buckaroo_state -> mainDs -> data_wrapper ->
+ * DFViewerInfinite -> AG-Grid. Companion to DFViewerInfinite.flash.test.tsx.
+ *
+ * Tests assert CURRENT behavior on main (Option A in docs/rerender-test-plan.md).
+ * Tests tagged "[captures current flash]" are tracking pain, not validating it.
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import { BuckarooInfiniteWidget } from "./BuckarooWidgetInfinite";
+import { KeyAwareSmartRowCache } from "./DFViewerParts/SmartRowCache";
+import { getSpyCalls, resetSpy } from "../test-utils/agGridSpy";
+import { BuckarooState, BuckarooOptions, DFMeta } from "./WidgetTypes";
+import { DFViewerConfig } from "./DFViewerParts/DFWhole";
+import { IDisplayArgs } from "./DFViewerParts/gridUtils";
+import { CommandConfigT } from "./CommandUtils";
+
+jest.mock("ag-grid-react", () =>
+  require("../test-utils/agGridSpy").agGridReactMockFactory(),
+);
+jest.mock("./useColorScheme", () => ({ useColorScheme: () => "light" }));
+
+// StatusBar also instantiates AgGridReact; stub it so the spy only counts the data grid.
+jest.mock("./StatusBar", () => ({
+  StatusBar: () => <div data-testid="status-bar-stub" />,
+}));
+
+// DFViewerInfinite-prop capture for identity-stability assertion.
+let dfvCalls: Array<{ outside_df_params: any; data_wrapper: any }> = [];
+jest.mock("./DFViewerParts/DFViewerInfinite", () => {
+  const actual = jest.requireActual("./DFViewerParts/DFViewerInfinite");
+  return {
+    ...actual,
+    DFViewerInfinite: (props: any) => {
+      dfvCalls.push({
+        outside_df_params: props.outside_df_params,
+        data_wrapper: props.data_wrapper,
+      });
+      return actual.DFViewerInfinite(props);
+    },
+  };
+});
+
+const baseConfig: DFViewerConfig = {
+  pinned_rows: [],
+  left_col_configs: [],
+  column_config: [
+    { col_name: "index", header_name: "index", displayer_args: { displayer: "obj" } },
+    { col_name: "a", header_name: "a", displayer_args: { displayer: "obj" } },
+  ],
+};
+
+const baseDfMeta: DFMeta = {
+  total_rows: 50,
+  columns: 2,
+  filtered_rows: 50,
+  rows_shown: 50,
+};
+
+const baseOptions: BuckarooOptions = {
+  sampled: [],
+  cleaning_method: ["", "clean1", "clean2"],
+  post_processing: ["", "log_scale"],
+  df_display: ["main", "summary"],
+  show_commands: [],
+};
+
+const baseDisplayArgs: Record<string, IDisplayArgs> = {
+  main: {
+    data_key: "main",
+    df_viewer_config: baseConfig,
+    summary_stats_key: "summary_stats",
+  },
+  summary: {
+    data_key: "summary_stats",
+    df_viewer_config: baseConfig,
+    summary_stats_key: "summary_stats",
+  },
+};
+
+const initialState: BuckarooState = {
+  sampled: false,
+  cleaning_method: false,
+  quick_command_args: {},
+  post_processing: false,
+  df_display: "main",
+  show_commands: false,
+};
+
+const mkSrc = () => new KeyAwareSmartRowCache(() => {});
+
+const renderWidget = (overrides: { state?: Partial<BuckarooState>; src?: KeyAwareSmartRowCache } = {}) => {
+  const state: BuckarooState = { ...initialState, ...overrides.state };
+  const noopOps = jest.fn();
+  const noopState = jest.fn();
+  const cmd: CommandConfigT = { argspecs: {}, defaultArgs: {} };
+  return render(
+    <BuckarooInfiniteWidget
+      df_data_dict={{ summary_stats: [] }}
+      df_display_args={baseDisplayArgs}
+      df_meta={baseDfMeta}
+      operations={[]}
+      on_operations={noopOps}
+      operation_results={{ transformed_df: [], generated_py_code: "", search_term: "" } as any}
+      command_config={cmd}
+      buckaroo_state={state}
+      on_buckaroo_state={noopState}
+      buckaroo_options={baseOptions}
+      src={overrides.src ?? mkSrc()}
+    />,
+  );
+};
+
+beforeEach(() => {
+  resetSpy();
+  dfvCalls = [];
+});
+
+describe("BuckarooInfiniteWidget — flash matrix (current behavior)", () => {
+  it("[captures current flash] post_processing change remounts the data grid (via outside_df_params key)", () => {
+    const src = mkSrc();
+    const { rerender } = render(
+      <BuckarooInfiniteWidget
+        df_data_dict={{ summary_stats: [] }}
+        df_display_args={baseDisplayArgs}
+        df_meta={baseDfMeta}
+        operations={[]}
+        on_operations={jest.fn()}
+        operation_results={{} as any}
+        command_config={{ argspecs: {}, defaultArgs: {} }}
+        buckaroo_state={{ ...initialState, post_processing: "" }}
+        on_buckaroo_state={jest.fn()}
+        buckaroo_options={baseOptions}
+        src={src}
+      />,
+    );
+    expect(getSpyCalls().mountCount).toBe(1);
+
+    rerender(
+      <BuckarooInfiniteWidget
+        df_data_dict={{ summary_stats: [] }}
+        df_display_args={baseDisplayArgs}
+        df_meta={baseDfMeta}
+        operations={[]}
+        on_operations={jest.fn()}
+        operation_results={{} as any}
+        command_config={{ argspecs: {}, defaultArgs: {} }}
+        buckaroo_state={{ ...initialState, post_processing: "log_scale" }}
+        on_buckaroo_state={jest.fn()}
+        buckaroo_options={baseOptions}
+        src={src}
+      />,
+    );
+    // post_processing is in outside_df_params, which is the React `key` on
+    // AgGridReact. So the entire grid is destroyed and remounted. This is the
+    // dominant flash cause. Post-refactor: mountCount stays 1, purgeInfiniteCache>=1.
+    expect(getSpyCalls().mountCount).toBe(2);
+  });
+
+  it("cleaning_method change does NOT remount but rebuilds datasource (getRows refires)", () => {
+    const src = mkSrc();
+    const propsA = {
+      df_data_dict: { summary_stats: [] },
+      df_display_args: baseDisplayArgs,
+      df_meta: baseDfMeta,
+      operations: [],
+      on_operations: jest.fn(),
+      operation_results: {} as any,
+      command_config: { argspecs: {}, defaultArgs: {} },
+      buckaroo_options: baseOptions,
+      src,
+      on_buckaroo_state: jest.fn(),
+    };
+    const { rerender } = render(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, cleaning_method: "clean1" }} />,
+    );
+    const beforeMount = getSpyCalls().mountCount;
+    const beforeGetRows = getSpyCalls().getRowsCallArgs.length;
+
+    rerender(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, cleaning_method: "clean2" }} />,
+    );
+    // cleaning_method is in mainDs deps but NOT in outside_df_params, so:
+    //   - no remount (React key unchanged)
+    //   - new mainDs reference → new datasource prop → spy fires getRows again
+    expect(getSpyCalls().mountCount).toBe(beforeMount);
+    expect(getSpyCalls().getRowsCallArgs.length).toBeGreaterThan(beforeGetRows);
+  });
+
+  it("show_commands toggle does not remount and does not refetch", () => {
+    const src = mkSrc();
+    const propsA = {
+      df_data_dict: { summary_stats: [] },
+      df_display_args: baseDisplayArgs,
+      df_meta: baseDfMeta,
+      operations: [],
+      on_operations: jest.fn(),
+      operation_results: {} as any,
+      command_config: { argspecs: {}, defaultArgs: {} },
+      buckaroo_options: baseOptions,
+      src,
+      on_buckaroo_state: jest.fn(),
+    };
+    const { rerender } = render(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, show_commands: false }} />,
+    );
+    const beforeGetRows = getSpyCalls().getRowsCallArgs.length;
+
+    rerender(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, show_commands: "1" }} />,
+    );
+    // show_commands is NOT in mainDs deps. The data_wrapper useMemo does
+    // recompute (its deps include the whole buckaroo_state object), but the
+    // datasource it ultimately exposes is reference-equal — so AG-Grid's
+    // datasource prop doesn't change identity and getRows doesn't refire.
+    expect(getSpyCalls().mountCount).toBe(1);
+    expect(getSpyCalls().getRowsCallArgs.length).toBe(beforeGetRows);
+  });
+
+  it("[captures current flash] outsideDFParams is a new array literal on every render (no useMemo)", () => {
+    renderWidget({ state: { post_processing: "" } });
+    const firstRef = dfvCalls[0].outside_df_params;
+    expect(Array.isArray(firstRef)).toBe(true);
+    // Force a parent rerender with the same state. outsideDFParams in
+    // BuckarooInfiniteWidget is a bare array literal; it gets a fresh
+    // identity each render. Post-refactor: should be wrapped in useMemo and
+    // be reference-equal here.
+    renderWidget({ state: { post_processing: "" } });
+    const secondRef = dfvCalls[dfvCalls.length - 1].outside_df_params;
+    expect(secondRef).not.toBe(firstRef);
+    // ...but VALUES are equal, which is why the React key doesn't change
+    // and the grid doesn't remount on this kind of churn.
+    expect(JSON.stringify(secondRef)).toBe(JSON.stringify(firstRef));
+  });
+
+  it("activeCol prop survives a post_processing-driven remount (React state above the remount)", () => {
+    // The user clicks a cell, activeCol is stored in BuckarooInfiniteWidget's
+    // useState. Then post_processing changes and AG-Grid remounts. The new
+    // mount should receive the same activeCol via context.
+    const src = mkSrc();
+    const propsA = {
+      df_data_dict: { summary_stats: [] },
+      df_display_args: baseDisplayArgs,
+      df_meta: baseDfMeta,
+      operations: [],
+      on_operations: jest.fn(),
+      operation_results: {} as any,
+      command_config: { argspecs: {}, defaultArgs: {} },
+      buckaroo_options: baseOptions,
+      src,
+      on_buckaroo_state: jest.fn(),
+    };
+    render(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, post_processing: "" }} />,
+    );
+    // initial activeCol is ["a", "stoptime"] per BuckarooInfiniteWidget useState
+    const activeColAtFirstMount = getSpyCalls().lastProps?.context?.activeCol;
+    expect(activeColAtFirstMount).toEqual(["a", "stoptime"]);
+
+    // Force a remount by changing post_processing.
+    const { rerender } = render(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, post_processing: "" }} />,
+    );
+    rerender(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, post_processing: "log_scale" }} />,
+    );
+    // After remount, activeCol still flows through context. AG-Grid's *internal*
+    // selection visual is reset by the remount (which is one of the UX costs
+    // of the flash), but the prop is preserved.
+    expect(getSpyCalls().lastProps?.context?.activeCol).toEqual(["a", "stoptime"]);
+  });
+
+  it("[captures current flash] df_display switch (main → summary) remounts the grid", () => {
+    const src = mkSrc();
+    const propsA = {
+      df_data_dict: { summary_stats: [{ index: "mean", a: 10 }] },
+      df_display_args: baseDisplayArgs,
+      df_meta: baseDfMeta,
+      operations: [],
+      on_operations: jest.fn(),
+      operation_results: {} as any,
+      command_config: { argspecs: {}, defaultArgs: {} },
+      buckaroo_options: baseOptions,
+      src,
+      on_buckaroo_state: jest.fn(),
+    };
+    const { rerender } = render(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, df_display: "main" }} />,
+    );
+    expect(getSpyCalls().mountCount).toBe(1);
+
+    rerender(
+      <BuckarooInfiniteWidget {...propsA} buckaroo_state={{ ...initialState, df_display: "summary" }} />,
+    );
+    // df_display is in outside_df_params, so the key changes and AG-Grid
+    // remounts. It also switches data_type Raw <-> DataSource which legitimately
+    // needs a structural reconfigure — captured here as a single remount.
+    expect(getSpyCalls().mountCount).toBe(2);
+  });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.flash.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.flash.test.tsx
@@ -1,0 +1,285 @@
+/**
+ * Flash matrix — leaf component (DFViewerInfinite).
+ *
+ * Pins down what AG-Grid sees when each kind of upstream change happens.
+ * Tests assert CURRENT behavior on main (Option A in docs/rerender-test-plan.md);
+ * the refactor PRs will flip the assertions one by one.
+ *
+ * Tests that capture today's flash are tagged "[captures current flash]" so it
+ * is clear they are tracking pain, not validating it.
+ */
+import { render } from "@testing-library/react";
+import { DFViewerInfinite } from "./DFViewerInfinite";
+import { DFViewerConfig } from "./DFWhole";
+import { getSpyCalls, resetSpy } from "../../test-utils/agGridSpy";
+
+// jest.mock factory is hoisted; use require() so the factory resolves at call time.
+jest.mock("ag-grid-react", () =>
+  require("../../test-utils/agGridSpy").agGridReactMockFactory(),
+);
+
+jest.mock("../useColorScheme", () => ({
+  useColorScheme: () => "light",
+}));
+
+const baseConfig: DFViewerConfig = {
+  pinned_rows: [{ primary_key_val: "mean", displayer_args: { displayer: "obj" } }],
+  left_col_configs: [],
+  column_config: [
+    { col_name: "index", header_name: "index", displayer_args: { displayer: "obj" } },
+    { col_name: "a", header_name: "a", displayer_args: { displayer: "obj" } },
+  ],
+};
+
+const rawWrapper = (data: any[]) => ({
+  data_type: "Raw" as const,
+  data,
+  length: data.length,
+});
+
+const dsWrapper = (length = 50, getRows = jest.fn()) => ({
+  data_type: "DataSource" as const,
+  length,
+  datasource: { rowCount: length, getRows },
+});
+
+beforeEach(() => {
+  resetSpy();
+});
+
+describe("DFViewerInfinite — flash matrix (current behavior)", () => {
+  it("[captures current flash] post_processing change in outside_df_params remounts AG-Grid", () => {
+    const { rerender } = render(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper()}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ post_processing: "noop" }}
+      />,
+    );
+    const calls = getSpyCalls();
+    expect(calls.mountCount).toBe(1);
+
+    rerender(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper()}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ post_processing: "log_scale" }}
+      />,
+    );
+    // Today: key={JSON.stringify(outside_df_params)} forces React to unmount and
+    // remount AG-Grid. After the refactor we expect mountCount===1 and
+    // purgeInfiniteCache>=1 instead.
+    expect(calls.mountCount).toBe(2);
+  });
+
+  it("outside_df_params identity-only change (same value, new object) does NOT remount", () => {
+    const { rerender } = render(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper()}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ post_processing: "noop" }}
+      />,
+    );
+    expect(getSpyCalls().mountCount).toBe(1);
+
+    rerender(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper()}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ post_processing: "noop" }}
+      />,
+    );
+    // JSON.stringify of the same value is the same string, so the React key
+    // doesn't change. The widget is correct here even though outside_df_params
+    // is a fresh literal each render.
+    expect(getSpyCalls().mountCount).toBe(1);
+  });
+
+  it("summary_stats_data update calls setGridOption('pinnedTopRowData') without remount", () => {
+    const props = {
+      data_wrapper: rawWrapper([{ index: 0, a: 1 }]),
+      df_viewer_config: baseConfig,
+      setActiveCol: jest.fn(),
+    };
+    const { rerender } = render(
+      <DFViewerInfinite {...props} summary_stats_data={[{ index: "mean", a: 10 }]} />,
+    );
+    expect(getSpyCalls().mountCount).toBe(1);
+
+    rerender(
+      <DFViewerInfinite {...props} summary_stats_data={[{ index: "mean", a: 22 }]} />,
+    );
+
+    const pinnedCalls = getSpyCalls().setGridOption.filter(([k]) => k === "pinnedTopRowData");
+    expect(pinnedCalls.length).toBeGreaterThanOrEqual(2);
+    const last = pinnedCalls[pinnedCalls.length - 1][1] as Array<{ a: number }>;
+    expect(last[0].a).toBe(22);
+    expect(getSpyCalls().mountCount).toBe(1);
+  });
+
+  it("Raw data update calls setGridOption('rowData') without remount", () => {
+    const props = {
+      df_viewer_config: baseConfig,
+      summary_stats_data: [],
+      setActiveCol: jest.fn(),
+    };
+    const { rerender } = render(
+      <DFViewerInfinite {...props} data_wrapper={rawWrapper([{ index: 0, a: 1 }])} />,
+    );
+    expect(getSpyCalls().mountCount).toBe(1);
+
+    rerender(
+      <DFViewerInfinite {...props} data_wrapper={rawWrapper([{ index: 0, a: 9 }])} />,
+    );
+
+    const rowDataCalls = getSpyCalls().setGridOption.filter(([k]) => k === "rowData");
+    expect(rowDataCalls.length).toBeGreaterThanOrEqual(1);
+    const last = rowDataCalls[rowDataCalls.length - 1][1] as Array<{ a: number }>;
+    expect(last[0].a).toBe(9);
+    expect(getSpyCalls().mountCount).toBe(1);
+  });
+
+  it("[captures current flash] getRowId for the same data index changes when outside_df_params change", () => {
+    const { rerender } = render(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper()}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ k: "A" }}
+      />,
+    );
+    rerender(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper()}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ k: "B" }}
+      />,
+    );
+    // Today getRowId returns `${index}-${JSON.stringify(outside_df_params)}` so
+    // the row at index 0 gets two different IDs. AG-Grid then treats those as
+    // brand new rows on remount instead of recycling DOM. Post-refactor we
+    // expect rowIdsByIndex.get(0)!.size === 1.
+    const ids = getSpyCalls().rowIdsByIndex.get(0);
+    expect(ids).toBeDefined();
+    expect(ids!.size).toBe(2);
+  });
+
+  it("DataSource mode datasource is exercised; sourceName carries outside_df_params", () => {
+    render(
+      <DFViewerInfinite
+        data_wrapper={dsWrapper(50, jest.fn())}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        outside_df_params={{ post_processing: "noop", df_display: "main" }}
+      />,
+    );
+    const grCalls = getSpyCalls().getRowsCallArgs;
+    expect(grCalls.length).toBeGreaterThanOrEqual(1);
+    // The spy fires getRows with the live context; the consumer's getRows
+    // implementation reads context.outside_df_params to build sourceName.
+    // We assert the context made it through end-to-end.
+    expect(grCalls[0].context?.outside_df_params).toMatchObject({
+      post_processing: "noop",
+      df_display: "main",
+    });
+  });
+
+  it("column_config reshape does not cause an AG-Grid remount", () => {
+    const cfgA = baseConfig;
+    const cfgB: DFViewerConfig = {
+      ...baseConfig,
+      column_config: [
+        ...baseConfig.column_config,
+        { col_name: "b", header_name: "b", displayer_args: { displayer: "obj" } },
+      ],
+    };
+    const props = {
+      data_wrapper: dsWrapper(),
+      summary_stats_data: [],
+      setActiveCol: jest.fn(),
+      outside_df_params: { post_processing: "noop" },
+    };
+    const { rerender } = render(<DFViewerInfinite {...props} df_viewer_config={cfgA} />);
+    expect(getSpyCalls().mountCount).toBe(1);
+
+    rerender(<DFViewerInfinite {...props} df_viewer_config={cfgB} />);
+    // Column reshape rebuilds the columnDefs memo but does not change the
+    // outside_df_params React key, so AG-Grid stays mounted.
+    expect(getSpyCalls().mountCount).toBe(1);
+  });
+
+  it("activeCol prop change does not remount AG-Grid", () => {
+    const props = {
+      data_wrapper: dsWrapper(),
+      df_viewer_config: baseConfig,
+      summary_stats_data: [],
+      setActiveCol: jest.fn(),
+      outside_df_params: { post_processing: "noop" },
+    };
+    const { rerender } = render(<DFViewerInfinite {...props} activeCol={["a", "header-a"]} />);
+    expect(getSpyCalls().mountCount).toBe(1);
+    rerender(<DFViewerInfinite {...props} activeCol={["b", "header-b"]} />);
+    // activeCol changes flow through context, not through the React key.
+    expect(getSpyCalls().mountCount).toBe(1);
+  });
+
+  it("summary_stats_data update during in-flight DataSource fetch applies pinned rows and does not abort the fetch", () => {
+    // Mid-flight: AG-Grid has called getRows but no response yet. Then Python
+    // pushes a fresh summary. The pinned-row imperative path should fire
+    // independently of the data fetch.
+    const getRows = jest.fn();
+    const wrapper = {
+      data_type: "DataSource" as const,
+      length: 50,
+      datasource: { rowCount: 50, getRows },
+    };
+    const baseProps = {
+      data_wrapper: wrapper,
+      df_viewer_config: baseConfig,
+      setActiveCol: jest.fn(),
+      outside_df_params: { post_processing: "noop" },
+    };
+    const { rerender } = render(
+      <DFViewerInfinite {...baseProps} summary_stats_data={[{ index: "mean", a: 1 }]} />,
+    );
+    expect(getSpyCalls().mountCount).toBe(1);
+    const getRowsCallsBefore = getSpyCalls().getRowsCallArgs.length;
+
+    rerender(
+      <DFViewerInfinite {...baseProps} summary_stats_data={[{ index: "mean", a: 99 }]} />,
+    );
+    // pinned rows applied imperatively via setGridOption
+    const pinnedCalls = getSpyCalls().setGridOption.filter(([k]) => k === "pinnedTopRowData");
+    const last = pinnedCalls[pinnedCalls.length - 1][1] as Array<{ a: number }>;
+    expect(last[0].a).toBe(99);
+    // no remount, and no spurious additional getRows
+    expect(getSpyCalls().mountCount).toBe(1);
+    expect(getSpyCalls().getRowsCallArgs.length).toBe(getRowsCallsBefore);
+  });
+
+  it("error_info renders without touching the grid", () => {
+    const { getByText } = render(
+      <DFViewerInfinite
+        data_wrapper={rawWrapper([{ index: 0, a: 1 }])}
+        df_viewer_config={baseConfig}
+        summary_stats_data={[]}
+        setActiveCol={jest.fn()}
+        error_info="Boom"
+      />,
+    );
+    expect(getByText("Boom")).toBeInTheDocument();
+    expect(getSpyCalls().mountCount).toBe(1);
+  });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
@@ -798,5 +798,56 @@ describe('KeyAwareSmartRowCache tests', () => {
 
 
     })
-    
+
+    test('two sourceNames are isolated — a late response to source A does not contaminate source B', () => {
+        // Flash-matrix edge case: outside_df_params changes from A to B while
+        // a request for A is in flight. When A's response finally arrives, it
+        // must NOT appear under B (which the user is now viewing). The cache
+        // routes responses by sourceName, so this is really a contract test.
+        let src: KeyAwareSmartRowCache;
+        const requestLog: PayloadArgs[] = [];
+        const mockRequestFn = jest.fn((pa: PayloadArgs) => {
+            requestLog.push(pa);
+        });
+        src = new KeyAwareSmartRowCache(mockRequestFn);
+
+        // 1. AG-Grid (sourceName A) asks for rows
+        const cbA = jest.fn();
+        src.getRequestRows({ sourceName: "A", start: 0, end: 20, origEnd: 20 }, cbA, () => {});
+        // 2. Outside_df_params changes; AG-Grid (sourceName B) asks for rows
+        const cbB = jest.fn();
+        src.getRequestRows({ sourceName: "B", start: 0, end: 20, origEnd: 20 }, cbB, () => {});
+
+        // Two requests fired, one per source
+        expect(requestLog).toHaveLength(2);
+        expect(requestLog[0].sourceName).toBe("A");
+        expect(requestLog[1].sourceName).toBe("B");
+
+        // 3. B's response arrives first (normal); cbB fires with B-data.
+        //    genRows uses its 3rd arg as the *column name*, so we can later
+        //    tell A-rows from B-rows by checking which key is present.
+        src.addPayloadResponse({
+            key: requestLog[1],
+            data: genRows(0, 20, "B_col")[1],
+            length: 100,
+        });
+        expect(cbB).toHaveBeenCalledTimes(1);
+        const [bData] = cbB.mock.calls[0];
+        expect(Object.keys(bData[0])).toContain("B_col");
+        expect(Object.keys(bData[0])).not.toContain("A_col");
+
+        // 4. A's stale response arrives late. It fires cbA (the old callback,
+        //    keyed by source A) but MUST NOT be re-delivered to cbB.
+        src.addPayloadResponse({
+            key: requestLog[0],
+            data: genRows(0, 20, "A_col")[1],
+            length: 100,
+        });
+        expect(cbB).toHaveBeenCalledTimes(1);  // unchanged
+        expect(cbA).toHaveBeenCalledTimes(1);
+        const [aData] = cbA.mock.calls[0];
+        expect(Object.keys(aData[0])).toContain("A_col");
+        expect(Object.keys(aData[0])).not.toContain("B_col");
+    });
+
 });

--- a/packages/buckaroo-js-core/src/test-utils/agGridSpy.tsx
+++ b/packages/buckaroo-js-core/src/test-utils/agGridSpy.tsx
@@ -1,0 +1,164 @@
+/**
+ * Spy harness for the ag-grid-react mock used by the flash-matrix tests.
+ *
+ * Replaces the AgGridReact component with a stub that records:
+ *   - mountCount               — how many times AgGridReact mounted
+ *   - setGridOption[]          — every (key, value) passed to setGridOption
+ *   - refreshCells[]            — every refreshCells call
+ *   - refreshInfiniteCache      — count
+ *   - purgeInfiniteCache        — count
+ *   - getRowsCallArgs[]         — every IGetRowsParams passed to the datasource
+ *   - rowIdsByIndex             — for each row index, the distinct row IDs produced
+ *                                 by getRowId across renders (probes the row-id
+ *                                 salting behavior)
+ *   - lastProps                 — the most recent props object
+ *
+ * Use:
+ *
+ *   const spy = createAgGridSpy();
+ *   spy.install();   // call BEFORE `render()` (jest.mock is hoisted by ts-jest;
+ *                    //   install() resets the captured state instead)
+ *
+ *   render(<DFViewerInfinite ... />);
+ *   expect(spy.calls.mountCount).toBe(1);
+ */
+import * as React from "react";
+import type { IGetRowsParams, RefreshCellsParams } from "ag-grid-community";
+
+export interface AgGridSpyCalls {
+    mountCount: number;
+    setGridOption: Array<[string, unknown]>;
+    refreshCells: RefreshCellsParams[];
+    refreshInfiniteCache: number;
+    purgeInfiniteCache: number;
+    getRowsCallArgs: IGetRowsParams[];
+    rowIdsByIndex: Map<number, Set<string>>;
+    lastProps: any;
+    onGridReadyCalled: number;
+}
+
+const sharedCalls: AgGridSpyCalls = {
+    mountCount: 0,
+    setGridOption: [],
+    refreshCells: [],
+    refreshInfiniteCache: 0,
+    purgeInfiniteCache: 0,
+    getRowsCallArgs: [],
+    rowIdsByIndex: new Map(),
+    lastProps: null,
+    onGridReadyCalled: 0,
+};
+
+export const resetSpy = (): void => {
+    sharedCalls.mountCount = 0;
+    sharedCalls.setGridOption = [];
+    sharedCalls.refreshCells = [];
+    sharedCalls.refreshInfiniteCache = 0;
+    sharedCalls.purgeInfiniteCache = 0;
+    sharedCalls.getRowsCallArgs = [];
+    sharedCalls.rowIdsByIndex = new Map();
+    sharedCalls.lastProps = null;
+    sharedCalls.onGridReadyCalled = 0;
+};
+
+/**
+ * Factory called by `jest.mock("ag-grid-react", ...)` to install the spy.
+ *
+ * NOTE: jest.mock() factory bodies must not reference out-of-scope variables.
+ * That's why this module exports `resetSpy` + `getSpyCalls` + the factory
+ * rather than a closure-capturing builder. The factory inlines a reference to
+ * `sharedCalls` via the module re-import, which is allowed.
+ */
+export const agGridReactMockFactory = () => {
+    const ReactLocal = require("react") as typeof React;
+    return {
+        AgGridReact: ReactLocal.forwardRef((props: any, ref: any) => {
+            sharedCalls.lastProps = props;
+
+            // mount count: only increments on actual mount, not on prop update
+            ReactLocal.useEffect(() => {
+                sharedCalls.mountCount += 1;
+                // no cleanup-side-effect; unmount is implied by mountCount delta
+            }, []);
+
+            const api = ReactLocal.useMemo(() => {
+                return {
+                    setGridOption: (key: string, value: unknown) => {
+                        sharedCalls.setGridOption.push([key, value]);
+                    },
+                    refreshCells: (params: RefreshCellsParams) => {
+                        sharedCalls.refreshCells.push(params);
+                    },
+                    refreshInfiniteCache: () => {
+                        sharedCalls.refreshInfiniteCache += 1;
+                    },
+                    purgeInfiniteCache: () => {
+                        sharedCalls.purgeInfiniteCache += 1;
+                    },
+                    getRenderedNodes: () => [],
+                    getColumn: (colId: string) => ({
+                        getColId: () => colId,
+                        colDef: { headerName: colId, field: colId },
+                    }),
+                    getFirstDisplayedRowIndex: () => 0,
+                    getLastDisplayedRowIndex: () => 0,
+                    ensureIndexVisible: () => {},
+                };
+            }, []);
+
+            ReactLocal.useImperativeHandle(ref, () => ({ api }), [api]);
+
+            // exercise getRowId for a stable sample of indexes so tests can
+            // detect row-id salting from outside_df_params
+            if (typeof props.gridOptions?.getRowId === "function") {
+                for (const idx of [0, 1, 2]) {
+                    try {
+                        const rid = props.gridOptions.getRowId({
+                            data: { index: idx },
+                            context: props.context,
+                        });
+                        if (typeof rid === "string") {
+                            const set = sharedCalls.rowIdsByIndex.get(idx) ?? new Set<string>();
+                            set.add(rid);
+                            sharedCalls.rowIdsByIndex.set(idx, set);
+                        }
+                    } catch {
+                        // ignore
+                    }
+                }
+            }
+
+            // exercise getRows once per render so we can see what sourceName
+            // the datasource builds from context.outside_df_params
+            ReactLocal.useEffect(() => {
+                const ds = props.datasource;
+                if (!ds || typeof ds.getRows !== "function") return;
+                const gr: IGetRowsParams = {
+                    startRow: 0,
+                    endRow: 100,
+                    successCallback: () => {},
+                    failCallback: () => {},
+                    sortModel: [],
+                    filterModel: {},
+                    context: props.context,
+                } as any;
+                sharedCalls.getRowsCallArgs.push(gr);
+                try {
+                    ds.getRows(gr);
+                } catch {
+                    // some test stories throw on getRows; we only care about the args
+                }
+            }, [props.datasource]);
+
+            // fire onGridReady so app code that registers options imperatively runs
+            ReactLocal.useEffect(() => {
+                sharedCalls.onGridReadyCalled += 1;
+                props.onGridReady?.({ api });
+            }, [api]);
+
+            return ReactLocal.createElement("div", { "data-testid": "ag-grid-react-spy" });
+        }),
+    };
+};
+
+export const getSpyCalls = (): AgGridSpyCalls => sharedCalls;


### PR DESCRIPTION
## Summary

Tests-only PR. Captures today's rerender behavior at two layers so the SPA `dataframe_id` refactor and the #719 view-layer rewrite have a regression net to work against.

- **Jest matrix** — extends the AG-Grid mock to count mounts and track `setGridOption` / `refreshCells` / `purgeInfiniteCache` / `getRows` calls. 16 new tests across leaf + integration + cache layers.
- **Playwright DOM** — 4 specs against existing stories that assert new values are actually in the DOM after a state change (the jest matrix stops at AG-Grid API contract).
- **Design doc** — `docs/rerender-test-plan.md` lays out the matrix of state changes → today's grid effect → desired post-refactor → desired post-#719. The matrix doubles as the changelog for upcoming refactor PRs.

All assertions lock in **current** behavior. Tests that document today's flash are tagged `[captures current flash]` in their name; refactor PRs flip those assertions.

## What this enables

Once green, the refactor becomes mechanical, each step flipping a specific named test:

1. Memoize `outsideDFParams` in `BuckarooInfiniteWidget` → flips `outsideDFParams is a new array literal on every render`.
2. Narrow `data_wrapper` / `mainDs` deps to specific `buckaroo_state` fields.
3. Drop `key={JSON.stringify(outside_df_params)}` on `AgGridReact`; effect-driven `purgeInfiniteCache()` instead → flips `post_processing change ... remounts the data grid`.
4. Drop the outside-key suffix from `getRowId` → flips `getRowId for the same data index changes when outside_df_params change`.
5. Add `dataframe_id` prop as the only trigger for the full-reset path (the SPA use case).

When #719 lands its consumer wiring, the deferred rows in the matrix (sort/filter → no `getRows` refetch via the view layer) get implemented in that PR.

## Test plan

- [x] `pnpm test` — 113 jest tests pass (15 new flash tests + 1 new cache isolation test).
- [x] `pnpm run test:pw` — 93 Playwright tests pass (4 new).
- [x] No production code changed; refactor target is captured in the plan doc but not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)