### PR TITLE
ci: tolerate post-summary polars/pyo3 SIGABRT in pytest jobs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -304,7 +304,8 @@ jobs:
       - name: Install the project
         run: uv sync --all-extras --dev
       - name: Run tests
-        run: uv run --with pytest-cov pytest ./tests/unit -m "not slow" --color=yes --cov anywidget --cov-report xml
+        # Tolerant of the post-summary polars-stream / pyo3 SIGABRT — see scripts/run_pytest_tolerant.sh.
+        run: scripts/run_pytest_tolerant.sh uv run --with pytest-cov pytest ./tests/unit -m "not slow" --color=yes --cov anywidget --cov-report xml
       - uses: codecov/codecov-action@v6
 
   TestPythonMaxVersions:
@@ -330,7 +331,9 @@ jobs:
           uv sync --resolution=highest --all-extras --dev --no-group datacompy
           uv pip list | grep -i pandas
       - name: Run tests
-        run: .venv/bin/python -m pytest ./tests/unit -m "not slow" --color=yes --cov anywidget --cov-report xml
+        # Tolerant of the post-summary polars-stream / pyo3 SIGABRT — see scripts/run_pytest_tolerant.sh.
+        # This matrix hits it most because it pulls polars >= 1.38 + pyo3 0.27.
+        run: scripts/run_pytest_tolerant.sh .venv/bin/python -m pytest ./tests/unit -m "not slow" --color=yes --cov anywidget --cov-report xml
 
   TestPythonWindows:
     name: Python / Test (Windows)

--- a/scripts/run_pytest_tolerant.sh
+++ b/scripts/run_pytest_tolerant.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Wraps a pytest invocation so a known polars-stream / pyo3 shutdown race
+# does not fail the job when every test passed.
+#
+# Symptom (intermittent, only on polars >= 1.38 + pyo3 0.27 — i.e. our
+# "Max Versions" matrix):
+#
+#   ==== 862 passed, 5 skipped, 103 deselected, 16 warnings in 93s ====
+#   FATAL: exception not rethrown
+#   thread 'tokio-runtime-worker' panicked at .../pyo3-0.27.2/.../interpreter_lifecycle.rs:117:13:
+#     The Python interpreter is not initialized and the `auto-initialize`
+#     feature is not enabled.
+#   thread 'async-executor-1' panicked at crates/polars-stream/src/nodes/io_sinks/writers/parquet/mod.rs
+#   Aborted (core dumped)
+#   ##[error]Process completed with exit code 134.
+#
+# Cause: pytest finishes; Python begins finalization; polars-stream's
+# background workers (tokio + async-executor for the parquet sink) still
+# hold pending tasks and try to call back into Python through pyo3, which
+# is already past Py_Finalize. pyo3 panics, abort() runs, exit code 134
+# (= 128 + SIGABRT). Every test had already passed; the failure is purely
+# in Rust-side teardown.
+#
+# This wrapper:
+#   1. Runs the command (passed as argv).
+#   2. If the command exited 134 AND the captured output shows a passing
+#      pytest summary with no `failed` / `error` lines, emits a CI
+#      ::warning:: and exits 0.
+#   3. Otherwise propagates the original exit code unchanged.
+#
+# Real failures (pytest exit 1, crashes before the summary, errored
+# collection) are preserved because the summary line would either be
+# missing or include "failed" / "error".
+
+set -uo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $0 <pytest-command> [args...]" >&2
+    exit 2
+fi
+
+LOG=$(mktemp)
+trap 'rm -f "$LOG"' EXIT
+
+# Run the command, mirror output to console AND capture for inspection.
+"$@" 2>&1 | tee "$LOG"
+status=${PIPESTATUS[0]}
+
+if [ "$status" -eq 134 ] \
+   && grep -qE "[0-9]+ passed" "$LOG" \
+   && ! grep -qE "[0-9]+ failed" "$LOG" \
+   && ! grep -qE "[0-9]+ error" "$LOG"; then
+    echo ""
+    echo "::warning::pytest exited 134 (SIGABRT) but the summary shows all tests passed."
+    echo "::warning::Known polars-stream / pyo3 shutdown race; treating as success."
+    echo "::warning::See scripts/run_pytest_tolerant.sh for context."
+    exit 0
+fi
+
+exit "$status"


### PR DESCRIPTION
## Summary

Recurring intermittent flake on `Python / Test` and `Python / Test (Max Versions)` matrix jobs. Every test passes, then between pytest's summary line and process exit, polars-stream's background workers (`tokio-runtime-worker` + `async-executor-1`) try to call back into Python through pyo3 — but the interpreter is already past `Py_Finalize`. pyo3 panics, `abort()` runs, exit code 134 (= 128 + SIGABRT), CI red.

Example from run [25746760549](https://github.com/buckaroo-data/buckaroo/actions/runs/25746760549) (the most recent build on #721):

```
==== 862 passed, 5 skipped, 103 deselected, 16 warnings in 93.52s ====
FATAL: exception not rethrown
##[error]Process completed with exit code 134.
```

And the underlying Rust panic from an earlier hit on main ([25570636939](https://github.com/buckaroo-data/buckaroo/actions/runs/25570636939)):

```
thread 'tokio-runtime-worker' panicked at .../pyo3-0.27.2/src/interpreter_lifecycle.rs:117:13:
  The Python interpreter is not initialized and the `auto-initialize` feature is not enabled.
thread 'async-executor-1' panicked at crates/polars-stream/src/nodes/io_sinks/writers/parquet/mod.rs:153:29
```

Max Versions hits it hardest because the resolution pulls polars 1.38.x + pyo3 0.27, where DataFrame.write_parquet routes through the new streaming sink. The pinned matrix uses polars 1.35.2 which doesn't take that path.

## Fix

New `scripts/run_pytest_tolerant.sh` wraps any pytest invocation. If the wrapped command exits 134 **and** the captured output shows `N passed` **and** no `failed` / `error` lines, it emits a CI `::warning::` and exits 0. Otherwise it propagates the original exit code unchanged.

Wired into both Linux pytest jobs in `checks.yml`. Windows job intentionally untouched (different signal semantics; not affected in practice).

When upstream polars/pyo3 fix the shutdown ordering, this wrapper can be removed — the `::warning::` will stop firing first as a signal.

## Test plan

Smoke-tested the wrapper locally with five scenarios:

| Scenario | Expected | Actual |
|---|---|---|
| Real failure: exit 134 with `failed` in summary | propagate 134 | 134 ✓ |
| Shutdown race: exit 134 with passing summary, no failures | exit 0 + warning | 0 ✓ |
| Normal success: exit 0 | exit 0 | 0 ✓ |
| Real failure: exit 1 with `failed` in summary | propagate 1 | 1 ✓ |
| Collection error: exit 134, no summary line | propagate 134 | 134 ✓ |

CI run will exercise the wrapper against the real test suite. Won't always reproduce the flake (it's intermittent) — but the wrapper is a no-op when the race doesn't happen.

## Out of scope

- Recent failures on PR #721 (npm-pkg + integration-tests) include a separate, deterministic break in `Build and Deploy` / `Build and Publish Storybook` because `pnpm/action-setup@v6` with `run_install: true` recursively picks up `integration-tests/built-pkg/package.json` from the repo root. That's a different bug in those two workflows (or in #721's directory placement) and will be addressed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)