### PR TITLE
feat(js-core): embed a Buckaroo server session via npm — no more iframe

### DIFF
--- a/docs/examples/server-embed/.gitignore
+++ b/docs/examples/server-embed/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.vite
+*.log
+pnpm-lock.yaml

--- a/docs/examples/server-embed/.gitignore
+++ b/docs/examples/server-embed/.gitignore
@@ -2,4 +2,6 @@ node_modules
 dist
 .vite
 *.log
-pnpm-lock.yaml
+data/
+test-results/
+playwright-report/

--- a/docs/examples/server-embed/README.md
+++ b/docs/examples/server-embed/README.md
@@ -1,0 +1,82 @@
+# BuckarooServerView playground
+
+Minimal Vite + React app that embeds a live Buckaroo server session via
+`<BuckarooServerView>` from `buckaroo-js-core` — no iframe.
+
+```
+docs/examples/server-embed/
+├── package.json    # buckaroo-js-core linked via file:../../../packages/buckaroo-js-core
+├── index.html
+├── vite.config.ts
+└── src/
+    ├── main.tsx
+    └── App.tsx    # input boxes for server URL + session id; renders the view
+```
+
+## One-time setup
+
+Build the local `buckaroo-js-core` package — the example resolves it by file path,
+so its `dist/` must exist.
+
+```
+cd packages/buckaroo-js-core && pnpm install && pnpm build
+```
+
+## Run it
+
+Three terminals. From the repo root:
+
+### 1. Start the Buckaroo server
+
+```
+uv run python -m buckaroo.server --port 8700 --no-browser
+```
+
+### 2. Load a session
+
+Any file path the server can read works. The repo ships a sample parquet:
+
+```
+curl -X POST http://localhost:8700/load \
+  -H 'Content-Type: application/json' \
+  -d '{"session":"demo","path":"docs/example-notebooks/citibike-trips-2016-04.parq","mode":"buckaroo","no_browser":true}'
+```
+
+`mode` picks the widget the React side renders:
+
+- `"buckaroo"` → full UI (status bar, summary stats, search, post-processing)
+- `"viewer"`  → just the infinite-scroll DFViewer
+- `"lazy"`    → polars LazyFrame, pushes ops to polars
+
+### 3. Start the example app
+
+```
+cd docs/examples/server-embed
+pnpm install
+pnpm dev
+```
+
+Open <http://localhost:5173>. The top bar lets you point at any server URL
+and session id — change them, hit **Connect**, and `<BuckarooServerView>`
+reconnects.
+
+## Loading more sessions
+
+POST another session and switch to it in the UI:
+
+```
+curl -X POST http://localhost:8700/load \
+  -H 'Content-Type: application/json' \
+  -d '{"session":"grease","path":"docs/example-notebooks/grease_violations.csv","mode":"viewer","no_browser":true}'
+```
+
+Then type `grease` into the Session box and click Connect.
+
+## What's happening
+
+`BuckarooServerView` opens a WebSocket to `ws://<host>/ws/<session-id>`,
+waits for the server's `initial_state` frame, decodes the embedded parquet,
+and renders `BuckarooInfiniteWidget` or `DFViewerInfiniteDS` based on the
+session's `mode`. Sort, search, infinite scroll, and post-processing all
+flow through the same WebSocket — same as the standalone server page,
+just rendered inline in your React tree.

--- a/docs/examples/server-embed/README.md
+++ b/docs/examples/server-embed/README.md
@@ -5,78 +5,108 @@ Minimal Vite + React app that embeds a live Buckaroo server session via
 
 ```
 docs/examples/server-embed/
-├── package.json    # buckaroo-js-core linked via file:../../../packages/buckaroo-js-core
+├── package.json     # buckaroo-js-core linked via link:../../../packages/buckaroo-js-core
 ├── index.html
-├── vite.config.ts
+├── vite.config.ts   # proxies /load + /ws/* → http://localhost:8700
+├── tsconfig.json
 └── src/
     ├── main.tsx
-    └── App.tsx    # input boxes for server URL + session id; renders the view
+    ├── App.tsx     # dropdown of preset datasets → POST /load → render the view
+    └── types.d.ts
 ```
+
+The app has a dropdown of preset datasets. Pick one, hit **Load**, and
+the app POSTs `/load` to the Buckaroo server (via the Vite proxy), then
+opens a WebSocket session for it.
 
 ## One-time setup
 
-Build the local `buckaroo-js-core` package — the example resolves it by file path,
-so its `dist/` must exist.
+Build the local `buckaroo-js-core` package — the example resolves it by
+file path, so its `dist/` must exist.
 
 ```
 cd packages/buckaroo-js-core && pnpm install && pnpm build
 ```
 
+## Optional: download some bigger parquet files
+
+The first preset (Citi Bike, April 2016) is bundled in the repo and works
+out of the box. The other presets point at NYC TLC trip-data parquet
+files that are *not* checked in. Download whichever you want to play
+with — they're all from the same public TLC cloudfront bucket. Run from
+the repo root:
+
+```
+mkdir -p docs/examples/server-embed/data
+cd docs/examples/server-embed/data
+
+# Yellow taxi, Jan 2024 — ~50 MB, ~3M rows
+curl -L -O https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2024-01.parquet
+
+# Green taxi, Jan 2024 — ~1.4 MB, ~57k rows (small, useful sanity check)
+curl -L -O https://d37ci6vzurychx.cloudfront.net/trip-data/green_tripdata_2024-01.parquet
+
+# For-hire vehicle high-volume, Jan 2024 — ~470 MB, ~20M rows
+curl -L -O https://d37ci6vzurychx.cloudfront.net/trip-data/fhvhv_tripdata_2024-01.parquet
+```
+
+`data/` is gitignored — don't worry about checking these in by accident.
+Browse the whole TLC archive at
+<https://www.nyc.gov/site/tlc/about/tlc-trip-record-data.page> if you
+want other months.
+
 ## Run it
 
-Three terminals. From the repo root:
-
-### 1. Start the Buckaroo server
+Two terminals, both from the repo root:
 
 ```
+# Terminal 1 — Buckaroo server
 uv run python -m buckaroo.server --port 8700 --no-browser
+
+# Terminal 2 — the example app
+cd docs/examples/server-embed && pnpm install && pnpm dev
 ```
 
-### 2. Load a session
+Open <http://localhost:5173>. Pick a dataset from the dropdown, hit
+**Load**, and the embedded `<BuckarooServerView>` connects to that
+session.
 
-Any file path the server can read works. The repo ships a sample parquet:
+## How it works
+
+- Vite proxies `/load` (HTTP) and `/ws/*` (WebSocket) to
+  `http://localhost:8700`. The browser only ever talks to
+  `localhost:5173`, so there's no CORS preflight on `/load`.
+- The **Load** button does `fetch("/load", { method: "POST", … })` with
+  the preset's `session` + `path` + `mode`. The server reads the file,
+  creates/refreshes the session, and replies with metadata.
+- `<BuckarooServerView wsUrl={…} />` then opens
+  `ws://localhost:5173/ws/<session-id>`, which Vite proxies to the
+  server's `/ws/<session-id>` endpoint.
+- The server's `mode` decides which widget the React side renders:
+  `"buckaroo"` for the full UI, `"viewer"` for plain DFViewer,
+  `"lazy"` for polars LazyFrames.
+
+## Pointing at a different server
 
 ```
-curl -X POST http://localhost:8700/load \
-  -H 'Content-Type: application/json' \
-  -d '{"session":"demo","path":"docs/example-notebooks/citibike-trips-2016-04.parq","mode":"buckaroo","no_browser":true}'
+BUCKAROO_SERVER=http://my-host:8700 pnpm dev
 ```
 
-`mode` picks the widget the React side renders:
+Vite picks that up at start time; nothing else needs to change.
 
-- `"buckaroo"` → full UI (status bar, summary stats, search, post-processing)
-- `"viewer"`  → just the infinite-scroll DFViewer
-- `"lazy"`    → polars LazyFrame, pushes ops to polars
+## Tests
 
-### 3. Start the example app
+There's a Playwright integration test that boots a real Buckaroo server,
+the example's Vite dev server, opens the page, clicks Load on the
+bundled citibike preset, and asserts the grid renders. Run it:
 
 ```
 cd docs/examples/server-embed
-pnpm install
-pnpm dev
+pnpm exec playwright install chromium    # one-time, ~150 MB
+pnpm test
 ```
 
-Open <http://localhost:5173>. The top bar lets you point at any server URL
-and session id — change them, hit **Connect**, and `<BuckarooServerView>`
-reconnects.
-
-## Loading more sessions
-
-POST another session and switch to it in the UI:
-
-```
-curl -X POST http://localhost:8700/load \
-  -H 'Content-Type: application/json' \
-  -d '{"session":"grease","path":"docs/example-notebooks/grease_violations.csv","mode":"viewer","no_browser":true}'
-```
-
-Then type `grease` into the Session box and click Connect.
-
-## What's happening
-
-`BuckarooServerView` opens a WebSocket to `ws://<host>/ws/<session-id>`,
-waits for the server's `initial_state` frame, decodes the embedded parquet,
-and renders `BuckarooInfiniteWidget` or `DFViewerInfiniteDS` based on the
-session's `mode`. Sort, search, infinite scroll, and post-processing all
-flow through the same WebSocket — same as the standalone server page,
-just rendered inline in your React tree.
+The Python server is started by `pw-tests/global-setup.ts` from the
+repo root (so `uv run python -m buckaroo.server` finds the venv) and
+torn down by `pw-tests/global-teardown.ts`. Vite is launched by
+Playwright's own `webServer` config.

--- a/docs/examples/server-embed/index.html
+++ b/docs/examples/server-embed/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BuckarooServerView playground</title>
+  </head>
+  <body style="margin: 0; font-family: system-ui, sans-serif">
+    <div id="root" style="height: 100vh; display: flex; flex-direction: column"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/docs/examples/server-embed/package.json
+++ b/docs/examples/server-embed/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "playwright test",
+    "test:headed": "playwright test --headed"
   },
   "dependencies": {
     "buckaroo-js-core": "link:../../../packages/buckaroo-js-core",
@@ -14,6 +16,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.52.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/docs/examples/server-embed/package.json
+++ b/docs/examples/server-embed/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "buckaroo-server-embed-example",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "buckaroo-js-core": "link:../../../packages/buckaroo-js-core",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@vitejs/plugin-react": "^4.3.3",
+    "typescript": "~5.6.2",
+    "vite": "^5.4.10"
+  }
+}

--- a/docs/examples/server-embed/playwright.config.ts
+++ b/docs/examples/server-embed/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./pw-tests",
+  testMatch: /.*\.spec\.ts$/,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: process.env.CI ? "line" : "html",
+  timeout: 60_000,
+  globalSetup: "./pw-tests/global-setup.ts",
+  globalTeardown: "./pw-tests/global-teardown.ts",
+  use: {
+    baseURL: "http://127.0.0.1:5173",
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // The Buckaroo server is started by global-setup.ts (see comment there).
+  // Vite stays in webServer because Playwright handles a Node dev server fine.
+  webServer: {
+    command: "pnpm dev",
+    url: "http://127.0.0.1:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+});

--- a/docs/examples/server-embed/pnpm-lock.yaml
+++ b/docs/examples/server-embed/pnpm-lock.yaml
@@ -1,0 +1,1123 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      buckaroo-js-core:
+        specifier: link:../../../packages/buckaroo-js-core
+        version: link:../../../packages/buckaroo-js-core
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@playwright/test':
+        specifier: ^1.52.0
+        version: 1.60.0
+      '@types/react':
+        specifier: ^18.3.12
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.1
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.3
+        version: 4.7.0(vite@5.4.21)
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
+      vite:
+        specifier: ^5.4.10
+        version: 5.4.21
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/prop-types@15.7.15':
+    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
+
+  '@types/react-dom@18.3.7':
+    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+    peerDependencies:
+      '@types/react': ^18.0.0
+
+  '@types/react@18.3.28':
+    resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.10.29:
+    resolution: {integrity: sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  electron-to-chromium@1.5.355:
+    resolution: {integrity: sha512-LUPZhKzZPYSPme1jEYohpkA+ybYCJztr1quAdBd7E7h3+VOBVcKkwwtBJu41nrjawrRzfb8mtMfzWozoaK0ZIQ==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.44:
+    resolution: {integrity: sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.3
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@playwright/test@1.60.0':
+    dependencies:
+      playwright: 1.60.0
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/prop-types@15.7.15': {}
+
+  '@types/react-dom@18.3.7(@types/react@18.3.28)':
+    dependencies:
+      '@types/react': 18.3.28
+
+  '@types/react@18.3.28':
+    dependencies:
+      '@types/prop-types': 15.7.15
+      csstype: 3.2.3
+
+  '@vitejs/plugin-react@4.7.0(vite@5.4.21)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.10.29: {}
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.29
+      caniuse-lite: 1.0.30001792
+      electron-to-chromium: 1.5.355
+      node-releases: 2.0.44
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  caniuse-lite@1.0.30001792: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  electron-to-chromium@1.5.355: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  escalade@3.2.0: {}
+
+  fsevents@2.3.2:
+    optional: true
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.12: {}
+
+  node-releases@2.0.44: {}
+
+  picocolors@1.1.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  postcss@8.5.14:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react-refresh@0.17.0: {}
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  typescript@5.6.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.14
+      rollup: 4.60.4
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/docs/examples/server-embed/pw-tests/global-setup.ts
+++ b/docs/examples/server-embed/pw-tests/global-setup.ts
@@ -1,0 +1,68 @@
+/**
+ * Starts a Buckaroo server from the repo root before tests run, tears
+ * it down after. We do this in globalSetup rather than Playwright's
+ * `webServer` array because launching a non-Node, non-localhost-on-the-
+ * config-port background process from there has been flaky for us.
+ *
+ * Stored handle is read by global-teardown.ts via a temp PID file.
+ */
+import { spawn } from "node:child_process";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import http from "node:http";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..", "..");
+const PID_DIR = path.join(tmpdir(), "buckaroo-server-embed-pw");
+const PID_FILE = path.join(PID_DIR, "server.pid");
+
+const PORT = 8700;
+const HEALTH_URL = `http://127.0.0.1:${PORT}/health`;
+
+async function waitForHealth(timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ok = await new Promise<boolean>((resolve) => {
+      const req = http.get(HEALTH_URL, (res) => {
+        res.resume();
+        resolve(res.statusCode === 200);
+      });
+      req.on("error", () => resolve(false));
+      req.setTimeout(1000, () => {
+        req.destroy();
+        resolve(false);
+      });
+    });
+    if (ok) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+export default async function globalSetup() {
+  mkdirSync(PID_DIR, { recursive: true });
+
+  // If something's already serving /health on this port, reuse it.
+  if (await waitForHealth(500)) {
+    writeFileSync(PID_FILE, ""); // empty file = nothing to kill
+    return;
+  }
+
+  const child = spawn(
+    "uv",
+    ["run", "python", "-m", "buckaroo.server", "--port", String(PORT), "--no-browser"],
+    { cwd: REPO_ROOT, detached: true, stdio: "ignore" }
+  );
+  child.unref();
+  writeFileSync(PID_FILE, String(child.pid ?? ""));
+
+  if (!(await waitForHealth(30_000))) {
+    throw new Error(
+      `Buckaroo server did not become healthy at ${HEALTH_URL} within 30s ` +
+        `(pid=${child.pid}). Check that 'uv run python -m buckaroo.server' ` +
+        `works from the repo root.`
+    );
+  }
+}

--- a/docs/examples/server-embed/pw-tests/global-teardown.ts
+++ b/docs/examples/server-embed/pw-tests/global-teardown.ts
@@ -1,0 +1,19 @@
+import { readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const PID_FILE = path.join(tmpdir(), "buckaroo-server-embed-pw", "server.pid");
+
+export default async function globalTeardown() {
+  if (!existsSync(PID_FILE)) return;
+  const raw = readFileSync(PID_FILE, "utf8").trim();
+  rmSync(PID_FILE, { force: true });
+  if (!raw) return; // empty file means we reused an existing server
+  const pid = Number(raw);
+  if (!Number.isFinite(pid) || pid <= 0) return;
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    // already gone
+  }
+}

--- a/docs/examples/server-embed/pw-tests/server-embed.spec.ts
+++ b/docs/examples/server-embed/pw-tests/server-embed.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * End-to-end test for the BuckarooServerView example app.
+ *
+ * Boots a real Buckaroo server + the example's Vite dev server (both
+ * via playwright.config.ts webServer entries), opens the page, clicks
+ * Load on the bundled citibike preset, and asserts the grid renders.
+ *
+ * What this proves:
+ * - `/load` POST proxied through Vite reaches the Python server
+ * - The server-issued `initial_state` reaches BuckarooServerView
+ * - The WebSocket proxy (`/ws/<session>` → Buckaroo server) works
+ * - Row data + column headers actually paint into AG-Grid
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("BuckarooServerView playground", () => {
+  test("loads the bundled citibike preset and renders grid cells", async ({ page }) => {
+    await page.goto("/");
+
+    // Pre-Load state: dropdown is there, no grid yet.
+    await expect(page.getByRole("button", { name: /Load/ })).toBeVisible();
+    await expect(page.getByText("Pick a dataset and hit Load.")).toBeVisible();
+
+    // First preset is the bundled citibike file — just click Load.
+    await page.getByRole("button", { name: /^Load$/ }).click();
+
+    // Status text appears once /load returns. Citibike sample is 100k rows.
+    await expect(page.getByText(/100,000 rows/)).toBeVisible({ timeout: 30_000 });
+
+    // BuckarooServerView opens the WS, decodes initial_state, AG-Grid renders.
+    await page
+      .locator(".ag-cell")
+      .first()
+      .waitFor({ state: "visible", timeout: 20_000 });
+
+    // A known column header from the citibike schema.
+    await expect(page.locator(".ag-header-cell").getByText("tripduration")).toBeVisible();
+
+    // At least a couple of body cells are populated.
+    const cellCount = await page.locator(".ag-cell").count();
+    expect(cellCount).toBeGreaterThan(5);
+  });
+
+  test("switching presets reconnects the view", async ({ page }) => {
+    await page.goto("/");
+
+    // Load citibike (preset index 0).
+    await page.getByRole("button", { name: /^Load$/ }).click();
+    await expect(page.getByText(/100,000 rows/)).toBeVisible({ timeout: 30_000 });
+    await page
+      .locator(".ag-cell")
+      .first()
+      .waitFor({ state: "visible", timeout: 20_000 });
+
+    // Re-select citibike and reload — exercises the wsUrl `key` remount
+    // path in App.tsx and confirms a second /load on the same session
+    // returns metadata cleanly.
+    await page.selectOption("select", "0");
+    await page.getByRole("button", { name: /^Load$/ }).click();
+    await expect(page.getByText(/100,000 rows/)).toBeVisible({ timeout: 30_000 });
+    await page
+      .locator(".ag-cell")
+      .first()
+      .waitFor({ state: "visible", timeout: 20_000 });
+  });
+});

--- a/docs/examples/server-embed/src/App.tsx
+++ b/docs/examples/server-embed/src/App.tsx
@@ -1,0 +1,70 @@
+import { useMemo, useState } from "react";
+import { BuckarooServerView, buckarooWsUrl } from "buckaroo-js-core";
+import "buckaroo-js-core/dist/style.css";
+
+type Metadata = { path?: string; rows?: number; [k: string]: unknown };
+
+export default function App() {
+  const [serverUrl, setServerUrl] = useState("http://localhost:8700");
+  const [sessionId, setSessionId] = useState("demo");
+  const [committed, setCommitted] = useState({ serverUrl, sessionId });
+  const [metadata, setMetadata] = useState<Metadata | null>(null);
+
+  const wsUrl = useMemo(
+    () => buckarooWsUrl(committed.serverUrl, committed.sessionId),
+    [committed]
+  );
+
+  return (
+    <>
+      <header style={bar}>
+        <label style={field}>
+          Server
+          <input
+            value={serverUrl}
+            onChange={(e) => setServerUrl(e.target.value)}
+            style={input}
+          />
+        </label>
+        <label style={field}>
+          Session
+          <input
+            value={sessionId}
+            onChange={(e) => setSessionId(e.target.value)}
+            style={input}
+          />
+        </label>
+        <button
+          onClick={() => {
+            setMetadata(null);
+            setCommitted({ serverUrl, sessionId });
+          }}
+          style={button}
+        >
+          Connect
+        </button>
+        <span style={status}>
+          {metadata
+            ? `${metadata.path ?? "(no path)"} — ${metadata.rows ?? "?"} rows`
+            : `connecting to ${wsUrl}`}
+        </span>
+      </header>
+      <main style={{ flex: 1, minHeight: 0 }}>
+        <BuckarooServerView wsUrl={wsUrl} onMetadata={setMetadata} />
+      </main>
+    </>
+  );
+}
+
+const bar: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 12,
+  padding: "10px 14px",
+  borderBottom: "1px solid #ddd",
+  background: "#f7f7f8",
+};
+const field: React.CSSProperties = { display: "flex", flexDirection: "column", fontSize: 11, color: "#555" };
+const input: React.CSSProperties = { padding: "4px 6px", border: "1px solid #ccc", borderRadius: 4, fontSize: 13, minWidth: 220 };
+const button: React.CSSProperties = { padding: "6px 14px", border: "1px solid #888", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: 13 };
+const status: React.CSSProperties = { marginLeft: "auto", fontSize: 12, color: "#666" };

--- a/docs/examples/server-embed/src/App.tsx
+++ b/docs/examples/server-embed/src/App.tsx
@@ -1,59 +1,151 @@
-import { useMemo, useState } from "react";
-import { BuckarooServerView, buckarooWsUrl } from "buckaroo-js-core";
+import { useState } from "react";
+import { BuckarooServerView } from "buckaroo-js-core";
 import "buckaroo-js-core/dist/style.css";
 
-type Metadata = { path?: string; rows?: number; [k: string]: unknown };
+type Mode = "viewer" | "buckaroo" | "lazy";
+type Preset = {
+  label: string;
+  session: string;
+  path: string;
+  mode: Mode;
+  hint?: string;
+};
+
+// The `path` is read by the Buckaroo server, so it must be reachable
+// from where `python -m buckaroo.server` is running (the repo root in
+// the README). See README for the curl commands that download the
+// "in-the-wild" parquet files into docs/examples/server-embed/data/.
+const PRESETS: Preset[] = [
+  {
+    label: "Citi Bike, April 2016 (bundled in repo, ~10 MB)",
+    session: "citibike-2016-04",
+    path: "docs/example-notebooks/citibike-trips-2016-04.parq",
+    mode: "buckaroo",
+  },
+  {
+    label: "NYC Yellow Taxi, Jan 2024 (~50 MB)",
+    session: "yellow-2024-01",
+    path: "docs/examples/server-embed/data/yellow_tripdata_2024-01.parquet",
+    mode: "buckaroo",
+    hint: "download — see README",
+  },
+  {
+    label: "NYC Green Taxi, Jan 2024 (~1.4 MB)",
+    session: "green-2024-01",
+    path: "docs/examples/server-embed/data/green_tripdata_2024-01.parquet",
+    mode: "buckaroo",
+    hint: "download — see README",
+  },
+  {
+    label: "NYC FHV high-volume, Jan 2024 (~470 MB, ~20M rows)",
+    session: "fhvhv-2024-01",
+    path: "docs/examples/server-embed/data/fhvhv_tripdata_2024-01.parquet",
+    mode: "buckaroo",
+    hint: "download — see README",
+  },
+];
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "loading"; preset: Preset }
+  | { kind: "ready"; preset: Preset; rows: number; path?: string }
+  | { kind: "error"; message: string };
 
 export default function App() {
-  const [serverUrl, setServerUrl] = useState("http://localhost:8700");
-  const [sessionId, setSessionId] = useState("demo");
-  const [committed, setCommitted] = useState({ serverUrl, sessionId });
-  const [metadata, setMetadata] = useState<Metadata | null>(null);
+  const [presetIdx, setPresetIdx] = useState(0);
+  const [activeSession, setActiveSession] = useState<string | null>(null);
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
 
-  const wsUrl = useMemo(
-    () => buckarooWsUrl(committed.serverUrl, committed.sessionId),
-    [committed]
-  );
+  async function load() {
+    const preset = PRESETS[presetIdx];
+    setStatus({ kind: "loading", preset });
+    try {
+      const res = await fetch("/load", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session: preset.session,
+          path: preset.path,
+          mode: preset.mode,
+          no_browser: true,
+        }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        const msg = body?.message || body?.error || `HTTP ${res.status}`;
+        throw new Error(msg);
+      }
+      setStatus({
+        kind: "ready",
+        preset,
+        rows: body?.metadata?.rows ?? body?.rows ?? 0,
+        path: body?.metadata?.filename ?? preset.path,
+      });
+      setActiveSession(preset.session);
+    } catch (err) {
+      setStatus({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  // wsUrl is relative to the page origin — vite.config.ts proxies
+  // /ws/* to the Buckaroo server, so the same proxy that handles
+  // /load handles the WebSocket too.
+  const wsUrl = activeSession
+    ? `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws/${encodeURIComponent(activeSession)}`
+    : null;
 
   return (
     <>
       <header style={bar}>
         <label style={field}>
-          Server
-          <input
-            value={serverUrl}
-            onChange={(e) => setServerUrl(e.target.value)}
+          Dataset
+          <select
+            value={presetIdx}
+            onChange={(e) => setPresetIdx(Number(e.target.value))}
             style={input}
-          />
-        </label>
-        <label style={field}>
-          Session
-          <input
-            value={sessionId}
-            onChange={(e) => setSessionId(e.target.value)}
-            style={input}
-          />
+          >
+            {PRESETS.map((p, i) => (
+              <option key={p.session} value={i}>
+                {p.label}
+                {p.hint ? ` — ${p.hint}` : ""}
+              </option>
+            ))}
+          </select>
         </label>
         <button
-          onClick={() => {
-            setMetadata(null);
-            setCommitted({ serverUrl, sessionId });
-          }}
+          onClick={load}
+          disabled={status.kind === "loading"}
           style={button}
         >
-          Connect
+          {status.kind === "loading" ? "Loading…" : "Load"}
         </button>
-        <span style={status}>
-          {metadata
-            ? `${metadata.path ?? "(no path)"} — ${metadata.rows ?? "?"} rows`
-            : `connecting to ${wsUrl}`}
-        </span>
+        <span style={statusStyle(status)}>{statusText(status)}</span>
       </header>
       <main style={{ flex: 1, minHeight: 0 }}>
-        <BuckarooServerView wsUrl={wsUrl} onMetadata={setMetadata} />
+        {wsUrl ? (
+          <BuckarooServerView key={wsUrl} wsUrl={wsUrl} />
+        ) : (
+          <div style={empty}>Pick a dataset and hit Load.</div>
+        )}
       </main>
     </>
   );
+}
+
+function statusText(s: Status): string {
+  switch (s.kind) {
+    case "idle":
+      return "";
+    case "loading":
+      return `loading ${s.preset.path}…`;
+    case "ready":
+      return `${s.path ?? s.preset.path} — ${s.rows.toLocaleString()} rows`;
+    case "error":
+      return `error: ${s.message}`;
+  }
 }
 
 const bar: React.CSSProperties = {
@@ -64,7 +156,38 @@ const bar: React.CSSProperties = {
   borderBottom: "1px solid #ddd",
   background: "#f7f7f8",
 };
-const field: React.CSSProperties = { display: "flex", flexDirection: "column", fontSize: 11, color: "#555" };
-const input: React.CSSProperties = { padding: "4px 6px", border: "1px solid #ccc", borderRadius: 4, fontSize: 13, minWidth: 220 };
-const button: React.CSSProperties = { padding: "6px 14px", border: "1px solid #888", borderRadius: 4, background: "#fff", cursor: "pointer", fontSize: 13 };
-const status: React.CSSProperties = { marginLeft: "auto", fontSize: 12, color: "#666" };
+const field: React.CSSProperties = {
+  display: "flex",
+  flexDirection: "column",
+  fontSize: 11,
+  color: "#555",
+  flex: 1,
+  maxWidth: 540,
+};
+const input: React.CSSProperties = {
+  padding: "4px 6px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  fontSize: 13,
+};
+const button: React.CSSProperties = {
+  padding: "6px 14px",
+  border: "1px solid #888",
+  borderRadius: 4,
+  background: "#fff",
+  cursor: "pointer",
+  fontSize: 13,
+};
+const empty: React.CSSProperties = {
+  padding: 40,
+  fontFamily: "system-ui, sans-serif",
+  color: "#888",
+};
+
+function statusStyle(s: Status): React.CSSProperties {
+  return {
+    marginLeft: "auto",
+    fontSize: 12,
+    color: s.kind === "error" ? "#b00020" : "#666",
+  };
+}

--- a/docs/examples/server-embed/src/main.tsx
+++ b/docs/examples/server-embed/src/main.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/docs/examples/server-embed/src/types.d.ts
+++ b/docs/examples/server-embed/src/types.d.ts
@@ -1,0 +1,4 @@
+// buckaroo-js-core has no `types` field in its package.json on this branch.
+// tsconfig `paths` points the bare import at the real d.ts; this just
+// silences the CSS side-effect import.
+declare module "buckaroo-js-core/dist/style.css";

--- a/docs/examples/server-embed/tsconfig.json
+++ b/docs/examples/server-embed/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": ".",
+    "paths": {
+      "buckaroo-js-core": ["./node_modules/buckaroo-js-core/dist/src/index.d.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/docs/examples/server-embed/vite.config.ts
+++ b/docs/examples/server-embed/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: { port: 5173 },
+});

--- a/docs/examples/server-embed/vite.config.ts
+++ b/docs/examples/server-embed/vite.config.ts
@@ -1,7 +1,21 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
+// Proxy /load (HTTP) and /ws/* (WebSocket) to the running Buckaroo
+// server so the app can use relative URLs and there's no CORS to deal
+// with. Override the target with BUCKAROO_SERVER if you run the server
+// somewhere other than http://localhost:8700.
+const BUCKAROO_SERVER = process.env.BUCKAROO_SERVER ?? "http://localhost:8700";
+
 export default defineConfig({
   plugins: [react()],
-  server: { port: 5173 },
+  server: {
+    host: "127.0.0.1",
+    port: 5173,
+    strictPort: true,
+    proxy: {
+      "/load": { target: BUCKAROO_SERVER, changeOrigin: true },
+      "/ws": { target: BUCKAROO_SERVER, ws: true, changeOrigin: true },
+    },
+  },
 });

--- a/docs/source/articles/embedding.rst
+++ b/docs/source/articles/embedding.rst
@@ -326,25 +326,95 @@ want to revisit; integration with external tools (MCP, scripts,
 ``curl``); team viewing of files on a shared host.
 
 
-5. Full JS embedding via npm *(coming soon)*
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. Full JS embedding via npm
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A future release will publish ``buckaroo-js-core`` to npm so JS apps
-can ``npm install buckaroo-js-core`` and import the React components
-directly — no Python required at any point. You'd build the
-``df_viewer_config`` and the row data on the JS side (typically from
-a parquet file fetched over HTTP, or from your own backend) and feed
-it to ``DFViewer`` or ``BuckarooStaticTable`` the way the static-embed
-bundle already does internally.
+``buckaroo-js-core`` ships the React components, the
+``WebSocketModel`` glue, and a ready-made ``BuckarooServerView`` that
+talks to a running Buckaroo server. JS apps can ``npm install
+buckaroo-js-core`` and embed Buckaroo straight into their React tree —
+**no iframe**. The component renders inline, inherits the host's CSS
+context, and lets you control sizing and lifecycle with regular React
+props.
 
-The component shapes are already there — the static-embed and
-artifact paths described above use the same React entry points
-that the npm package will expose. The blocker is publishing the
-package and stabilizing the public API.
+There are two flavors of embedding, depending on whether you have a
+live server.
 
-To get a feel for what this will look like in practice, the
-Storybook stories already drive the components from raw JS data
-with no Python on the other end. Run them locally with:
+**5a. Server-backed (infinite scroll, live data)**
+
+Start a Buckaroo server somewhere reachable:
+
+.. code-block:: bash
+
+    python -m buckaroo.server --port 8700
+    curl -X POST http://localhost:8700/load \
+        -H 'Content-Type: application/json' \
+        -d '{"session":"sales", "path":"/data/sales.parquet", "mode":"buckaroo"}'
+
+Then in your React app:
+
+.. code-block:: tsx
+
+    import { BuckarooServerView, buckarooWsUrl } from "buckaroo-js-core";
+    import "buckaroo-js-core/style.css";
+
+    function SalesPanel() {
+      return (
+        <div style={{ height: 600 }}>
+          <BuckarooServerView
+            wsUrl={buckarooWsUrl("http://localhost:8700", "sales")}
+            onMetadata={(m) => console.log("loaded:", m.path)}
+          />
+        </div>
+      );
+    }
+
+The component opens the WebSocket, waits for the server's
+``initial_state``, decodes the embedded parquet, and renders the same
+``BuckarooInfiniteWidget`` or ``DFViewerInfiniteDS`` the standalone
+page uses — selected by the session's ``mode``. Sort, infinite
+scroll, search, and post-processing all work the way they do in the
+standalone page; the server is doing the same things either way.
+
+The server's ``check_origin`` is permissive by default — cross-origin
+embedding works without configuration. Set ``BUCKAROO_STRICT_ORIGIN=1``
+on the server to restrict to localhost.
+
+**5b. Static (no server, no Python at view time)**
+
+For a fully static embed, build the artifact in Python and render it
+on the JS side:
+
+.. code-block:: python
+
+    from buckaroo import prepare_buckaroo_artifact, artifact_to_json
+
+    artifact = prepare_buckaroo_artifact(df, embed_type="DFViewer")
+    json_str = artifact_to_json(artifact)
+    # serve json_str to your page however you want
+
+.. code-block:: typescript
+
+    import {
+        BuckarooStaticTable,
+        resolveDFDataAsync,
+        preResolveDFDataDict,
+    } from "buckaroo-js-core";
+    import "buckaroo-js-core/style.css";
+
+    const artifact = JSON.parse(jsonStrFromYourBackend);
+    const dfData = await resolveDFDataAsync(artifact.df_data);
+    const summary = await resolveDFDataAsync(artifact.summary_stats_data);
+    const resolved = { ...artifact, df_data: dfData, summary_stats_data: summary };
+    // <BuckarooStaticTable artifact={resolved} />
+
+Same eager-only limitations as the static-HTML deployment — full
+sampled dataframe in the page, no command UI without Python.
+
+**Storybook reference**
+
+For an exhaustive demo of the components, the Storybook stories drive
+the same React entry points from raw JS data. Run locally with:
 
 .. code-block:: bash
 
@@ -354,25 +424,19 @@ with no Python on the other end. Run them locally with:
 The most directly relevant stories:
 
 - `DFViewer.stories.tsx <https://github.com/buckaroo-data/buckaroo/blob/main/packages/buckaroo-js-core/src/stories/DFViewer.stories.tsx>`_ —
-  plain table fed by a JS ``df_data`` array and a ``df_viewer_config``
-  object. This is the closest match to what an npm consumer will write.
+  plain table fed by a JS ``df_data`` array and ``df_viewer_config``.
 - `DFViewerInfiniteShadow.stories.tsx <https://github.com/buckaroo-data/buckaroo/blob/main/packages/buckaroo-js-core/src/stories/DFViewerInfiniteShadow.stories.tsx>`_ —
-  the infinite-scroll variant with a JS-side mock datasource, showing
-  the row-fetch contract you'd implement against your backend.
+  the infinite-scroll variant with a JS-side mock datasource. Useful
+  for understanding the row-fetch contract that
+  ``BuckarooServerView`` implements against the Buckaroo server.
 - `BuckarooWidgetTest.stories.tsx <https://github.com/buckaroo-data/buckaroo/blob/main/packages/buckaroo-js-core/src/stories/BuckarooWidgetTest.stories.tsx>`_ —
   the full BuckarooWidget with status bar, summary stats, and a JS-side
-  shim that handles search via ``quick_command_args``. Useful for
-  understanding what the widget expects from the host app once Python
-  is out of the picture.
+  shim that handles search via ``quick_command_args``.
 - `Styling.stories.tsx <https://github.com/buckaroo-data/buckaroo/blob/main/packages/buckaroo-js-core/src/stories/Styling.stories.tsx>`_
   and
   `ThemeCustomization.stories.tsx <https://github.com/buckaroo-data/buckaroo/blob/main/packages/buckaroo-js-core/src/stories/ThemeCustomization.stories.tsx>`_ —
-  same theming and column-config dicts described in
-  :doc:`theme-customization` and :doc:`data_flow`, but assembled in JS.
-
-Until the npm package is published, the supported way to embed
-without a Python runtime at view time is the static-embed bundle
-(modes 2 and 3 above), which uses these same components.
+  theming and column-config dicts from :doc:`theme-customization` and
+  :doc:`data_flow`, assembled in JS.
 
 
 6. Solara
@@ -488,8 +552,10 @@ Quick chooser
      - Buckaroo server via MCP (``buckaroo[mcp]``)
    * - Solara dashboard
      - ``SolaraDFViewer`` / ``SolaraBuckarooWidget``
-   * - JS app, no Python at view time, npm install
-     - Coming soon — for now use static HTML or HTML+JS artifact
+   * - React app embedding a live Buckaroo session
+     - ``BuckarooServerView`` from ``buckaroo-js-core`` (mode 5a)
+   * - React app, no Python at view time
+     - ``BuckarooStaticTable`` from ``buckaroo-js-core`` (mode 5b)
    * - Read-only table inside an existing app
      - ``DFViewer`` family (any deployment)
    * - Full clean-and-explore UI

--- a/packages/buckaroo-js-core/src/index.ts
+++ b/packages/buckaroo-js-core/src/index.ts
@@ -15,6 +15,8 @@ import { BuckarooInfiniteWidget, DFViewerInfiniteDS, getKeySmartRowCache } from 
 import { parquetRead, parquetMetadata } from 'hyparquet';
 import { resolveDFData, resolveDFDataAsync, preResolveDFDataDict } from './components/DFViewerParts/resolveDFData';
 import { BuckarooStaticTable } from './components/BuckarooStaticTable';
+import { BuckarooServerView, buckarooWsUrl } from './server/BuckarooServerView';
+import { WebSocketModel } from './server/WebSocketModel';
 
 import { HistogramCell } from "./components/DFViewerParts/HistogramCell";
 import { InfiniteEx } from "./components/DFViewerParts/TableInfinite";
@@ -54,6 +56,9 @@ export default {
     resolveDFDataAsync,
     preResolveDFDataDict,
     BuckarooStaticTable,
+    BuckarooServerView,
+    buckarooWsUrl,
+    WebSocketModel,
 };
 
 // Named exports for direct imports
@@ -80,4 +85,7 @@ export {
     resolveDFDataAsync,
     preResolveDFDataDict,
     BuckarooStaticTable,
+    BuckarooServerView,
+    buckarooWsUrl,
+    WebSocketModel,
 };

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.test.ts
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.test.ts
@@ -1,0 +1,29 @@
+import { buckarooWsUrl } from "./BuckarooServerView";
+
+describe("buckarooWsUrl", () => {
+    it("maps http → ws", () => {
+        expect(buckarooWsUrl("http://localhost:8700", "sales")).toBe("ws://localhost:8700/ws/sales");
+    });
+
+    it("maps https → wss", () => {
+        expect(buckarooWsUrl("https://example.com", "sales")).toBe("wss://example.com/ws/sales");
+    });
+
+    it("preserves ws://", () => {
+        expect(buckarooWsUrl("ws://localhost:8700", "sales")).toBe("ws://localhost:8700/ws/sales");
+    });
+
+    it("preserves wss://", () => {
+        expect(buckarooWsUrl("wss://example.com", "sales")).toBe("wss://example.com/ws/sales");
+    });
+
+    it("includes the port in the host", () => {
+        expect(buckarooWsUrl("http://10.0.0.5:9000", "s")).toBe("ws://10.0.0.5:9000/ws/s");
+    });
+
+    it("URL-encodes the session id", () => {
+        expect(buckarooWsUrl("http://localhost:8700", "with space/slash")).toBe(
+            "ws://localhost:8700/ws/with%20space%2Fslash",
+        );
+    });
+});

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
@@ -1,0 +1,277 @@
+import * as React from "react";
+
+import { BuckarooInfiniteWidget, DFViewerInfiniteDS, getKeySmartRowCache } from "../components/BuckarooWidgetInfinite";
+import { preResolveDFDataDict } from "../components/DFViewerParts/resolveDFData";
+import { WebSocketModel } from "./WebSocketModel";
+
+/**
+ * BuckarooServerView — embed a Buckaroo server session inside a React tree.
+ *
+ * This is the npm-module alternative to iframing `/s/<session-id>` from the
+ * Buckaroo server. The component opens a WebSocket to the server, waits for
+ * the `initial_state` message, builds the same model + row cache the
+ * standalone bundle uses, and renders the appropriate widget based on the
+ * server-reported `mode`.
+ *
+ *   import { BuckarooServerView } from "buckaroo-js-core";
+ *   import "buckaroo-js-core/style.css";
+ *
+ *   <BuckarooServerView wsUrl="ws://localhost:8700/ws/my-session" />
+ *
+ * The server's session decides the widget — pass `mode="viewer"` to
+ * /load for DFViewerInfiniteDS, `mode="buckaroo"` for the full UI. The host
+ * app does no widget-class selection; it only cares about which session to
+ * connect to.
+ */
+
+export type BuckarooServerMode = "viewer" | "buckaroo";
+
+export interface BuckarooServerMetadata {
+    path?: string;
+    rows?: number;
+    [k: string]: unknown;
+}
+
+export interface BuckarooServerViewProps {
+    /** Full WebSocket URL (ws:// or wss://). For a server at host H serving
+     *  session S, this is `ws://H/ws/S`. Use {@link buckarooWsUrl} if you
+     *  have an HTTP server URL + session id and want it derived. */
+    wsUrl: string;
+
+    /** Optional renderer for the "connecting" / pre-initial_state state.
+     *  Defaults to a plain "Connecting..." text. */
+    renderConnecting?: () => React.ReactNode;
+
+    /** Optional renderer for the error state. Receives the Error. Defaults
+     *  to a plain error message. */
+    renderError?: (err: Error) => React.ReactNode;
+
+    /** Called once the server sends its first `metadata` payload (typically
+     *  contains `path` and `rows`). Useful for host apps that want to mirror
+     *  the filename into their own title bar. */
+    onMetadata?: (metadata: BuckarooServerMetadata, prompt?: string) => void;
+
+    /** Optional inline style applied to the wrapping div. The component
+     *  defaults to `width:100%, height:100%`, so most consumers can rely on
+     *  the parent's flex / grid sizing. */
+    style?: React.CSSProperties;
+
+    /** Optional className on the wrapping div. */
+    className?: string;
+}
+
+interface ReadyState {
+    model: WebSocketModel;
+    src: ReturnType<typeof getKeySmartRowCache>;
+    mode: BuckarooServerMode;
+    initialState: Record<string, any>;
+}
+
+/** Derive a Buckaroo server WebSocket URL from an HTTP server URL + session
+ *  id. Accepts `http://...`, `https://...`, or already-`ws[s]://` URLs. */
+export function buckarooWsUrl(serverUrl: string, sessionId: string): string {
+    const u = new URL(serverUrl);
+    const protocol = u.protocol === "https:" || u.protocol === "wss:" ? "wss:" : "ws:";
+    return `${protocol}//${u.host}/ws/${encodeURIComponent(sessionId)}`;
+}
+
+export function BuckarooServerView({
+    wsUrl,
+    renderConnecting,
+    renderError,
+    onMetadata,
+    style,
+    className,
+}: BuckarooServerViewProps): React.ReactElement {
+    const [ready, setReady] = React.useState<ReadyState | null>(null);
+    const [error, setError] = React.useState<Error | null>(null);
+
+    // Re-fired state values so React re-renders when the model emits change events.
+    const [dfMeta, setDfMeta] = React.useState<any>({ total_rows: 0 });
+    const [dfDataDict, setDfDataDict] = React.useState<Record<string, any>>({});
+    const [dfDisplayArgs, setDfDisplayArgs] = React.useState<Record<string, any>>({});
+    const [buckarooState, setBuckarooStateLocal] = React.useState<any>({});
+    const [buckarooOptions, setBuckarooOptions] = React.useState<any>({});
+    const [commandConfig, setCommandConfig] = React.useState<any>({});
+    const [operationResults, setOperationResults] = React.useState<any>({});
+    const [operations, setOperations] = React.useState<any[]>([]);
+
+    // Keep the latest onMetadata in a ref so we don't reconnect when the
+    // host passes a fresh callback identity each render.
+    const onMetadataRef = React.useRef(onMetadata);
+    React.useEffect(() => { onMetadataRef.current = onMetadata; }, [onMetadata]);
+
+    React.useEffect(() => {
+        let cancelled = false;
+        let ws: WebSocket | null = null;
+
+        (async () => {
+            try {
+                ws = new WebSocket(wsUrl);
+                ws.binaryType = "arraybuffer";
+
+                await new Promise<void>((resolve, reject) => {
+                    ws!.onopen = () => resolve();
+                    ws!.onerror = (e) => reject(new Error(`WebSocket failed to open at ${wsUrl}: ${(e as any)?.message ?? "unknown"}`));
+                });
+
+                const initialState = await new Promise<Record<string, any>>((resolve, reject) => {
+                    const onClose = () => reject(new Error("WebSocket closed before initial_state was received"));
+                    const handler = (event: MessageEvent) => {
+                        if (typeof event.data !== "string") return;
+                        try {
+                            const msg = JSON.parse(event.data);
+                            if (msg.type === "initial_state") {
+                                ws!.removeEventListener("message", handler);
+                                ws!.removeEventListener("close", onClose);
+                                resolve(msg);
+                            }
+                        } catch {
+                            // ignore parse errors here; WebSocketModel handles binary frames separately
+                        }
+                    };
+                    ws!.addEventListener("message", handler);
+                    ws!.addEventListener("close", onClose);
+                });
+
+                if (cancelled) return;
+
+                if (initialState.df_data_dict) {
+                    initialState.df_data_dict = await preResolveDFDataDict(initialState.df_data_dict);
+                }
+
+                const model = new WebSocketModel(ws, initialState);
+                const src = getKeySmartRowCache(model, (a: any, b: any) => console.error("[BuckarooServerView] cache error:", a, b));
+                const mode: BuckarooServerMode = (initialState.mode === "buckaroo" ? "buckaroo" : "viewer");
+
+                setDfMeta(initialState.df_meta || { total_rows: 0 });
+                setDfDataDict(initialState.df_data_dict || {});
+                setDfDisplayArgs(initialState.df_display_args || {});
+                setBuckarooStateLocal(initialState.buckaroo_state || {});
+                setBuckarooOptions(initialState.buckaroo_options || {});
+                setCommandConfig(initialState.command_config || {});
+                setOperationResults(initialState.operation_results || {});
+                setOperations(initialState.operations || []);
+
+                if (initialState.metadata) onMetadataRef.current?.(initialState.metadata, initialState.prompt);
+
+                setReady({ model, src, mode, initialState });
+            } catch (e) {
+                if (cancelled) return;
+                setError(e instanceof Error ? e : new Error(String(e)));
+                try { ws?.close(); } catch {}
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+            try { ws?.close(); } catch {}
+        };
+    }, [wsUrl]);
+
+    // Wire model change-events → React state once ready.
+    React.useEffect(() => {
+        if (!ready) return;
+        const { model } = ready;
+
+        const onMeta = (metadata: any, prompt?: string) => {
+            onMetadataRef.current?.(metadata, prompt);
+            setDfMeta(model.get("df_meta") || { total_rows: metadata?.rows || 0 });
+            preResolveDFDataDict(model.get("df_data_dict") || {}).then(setDfDataDict);
+            setDfDisplayArgs(model.get("df_display_args") || {});
+            setBuckarooStateLocal(model.get("buckaroo_state") || {});
+            setBuckarooOptions(model.get("buckaroo_options") || {});
+            setCommandConfig(model.get("command_config") || {});
+            setOperationResults(model.get("operation_results") || {});
+            setOperations(model.get("operations") || []);
+        };
+        const onDfMeta = (v: any) => setDfMeta(v);
+        const onDfDataDict = (v: any) => { preResolveDFDataDict(v).then(setDfDataDict); };
+        const onDfDisplayArgs = (v: any) => setDfDisplayArgs(v);
+        const onBState = (v: any) => setBuckarooStateLocal(v);
+        const onBOpts = (v: any) => setBuckarooOptions(v);
+        const onCmdCfg = (v: any) => setCommandConfig(v);
+        const onOpRes = (v: any) => setOperationResults(v);
+        const onOps = (v: any) => setOperations(v);
+
+        model.on("metadata", onMeta);
+        model.on("change:df_meta", onDfMeta);
+        model.on("change:df_data_dict", onDfDataDict);
+        model.on("change:df_display_args", onDfDisplayArgs);
+        model.on("change:buckaroo_state", onBState);
+        model.on("change:buckaroo_options", onBOpts);
+        model.on("change:command_config", onCmdCfg);
+        model.on("change:operation_results", onOpRes);
+        model.on("change:operations", onOps);
+
+        return () => {
+            model.off("metadata", onMeta);
+            model.off("change:df_meta", onDfMeta);
+            model.off("change:df_data_dict", onDfDataDict);
+            model.off("change:df_display_args", onDfDisplayArgs);
+            model.off("change:buckaroo_state", onBState);
+            model.off("change:buckaroo_options", onBOpts);
+            model.off("change:command_config", onCmdCfg);
+            model.off("change:operation_results", onOpRes);
+            model.off("change:operations", onOps);
+        };
+    }, [ready]);
+
+    const onBuckarooState = React.useCallback((newState: any) => {
+        if (!ready) return;
+        const resolved = typeof newState === "function" ? newState(buckarooState) : newState;
+        ready.model.set("buckaroo_state", resolved);
+        ready.model.save_changes();
+    }, [ready, buckarooState]);
+
+    const onOperations = React.useCallback((newOps: any) => {
+        if (!ready) return;
+        ready.model.set("operations", newOps);
+        ready.model.save_changes();
+    }, [ready]);
+
+    const wrapperStyle: React.CSSProperties = { width: "100%", height: "100%", ...(style ?? {}) };
+
+    if (error) {
+        return (
+            <div className={className} style={wrapperStyle}>
+                {renderError ? renderError(error) : <div style={{ padding: 20, fontFamily: "sans-serif", color: "#b00020" }}>Failed to connect: {error.message}</div>}
+            </div>
+        );
+    }
+    if (!ready || !dfDisplayArgs?.main) {
+        return (
+            <div className={className} style={wrapperStyle}>
+                {renderConnecting ? renderConnecting() : <div style={{ padding: 20, fontFamily: "sans-serif" }}>Connecting…</div>}
+            </div>
+        );
+    }
+
+    return (
+        <div className={["buckaroo_anywidget", className].filter(Boolean).join(" ")} style={wrapperStyle}>
+            {ready.mode === "buckaroo" ? (
+                <BuckarooInfiniteWidget
+                    df_meta={dfMeta}
+                    df_data_dict={dfDataDict}
+                    df_display_args={dfDisplayArgs}
+                    operations={operations}
+                    on_operations={onOperations}
+                    operation_results={operationResults}
+                    command_config={commandConfig}
+                    buckaroo_state={buckarooState}
+                    on_buckaroo_state={onBuckarooState}
+                    buckaroo_options={buckarooOptions}
+                    src={ready.src}
+                />
+            ) : (
+                <DFViewerInfiniteDS
+                    df_meta={dfMeta}
+                    df_data_dict={dfDataDict}
+                    df_display_args={dfDisplayArgs}
+                    src={ready.src}
+                    df_id={"server"}
+                />
+            )}
+        </div>
+    );
+}

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
@@ -105,6 +105,13 @@ export function BuckarooServerView({
         let cancelled = false;
         let ws: WebSocket | null = null;
 
+        // Clear stale state from any previous wsUrl. Without this, a host
+        // that recovers from a failed connection by updating wsUrl would
+        // keep seeing the old error banner because the render guard checks
+        // `if (error)` before rendering `ready`.
+        setError(null);
+        setReady(null);
+
         (async () => {
             try {
                 ws = new WebSocket(wsUrl);

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
@@ -3,6 +3,34 @@ import * as React from "react";
 import { BuckarooInfiniteWidget, DFViewerInfiniteDS, getKeySmartRowCache } from "../components/BuckarooWidgetInfinite";
 import { preResolveDFDataDict } from "../components/DFViewerParts/resolveDFData";
 import { WebSocketModel } from "./WebSocketModel";
+import { DFMeta, BuckarooState, BuckarooOptions } from "../components/WidgetTypes";
+import { CommandConfigT } from "../components/CommandUtils";
+import { Operation } from "../components/OperationUtils";
+import { OperationResult, baseOperationResults } from "../components/DependentTabs";
+import { DFData, DFDataOrPayload } from "../components/DFViewerParts/DFWhole";
+import { IDisplayArgs } from "../components/DFViewerParts/gridUtils";
+
+// Defaults are only visible to the widgets if the server sends partial
+// initial_state (it should always send these keys, but useState wants a
+// fully-typed initializer, and the render guard below means the widgets
+// never actually see these values).
+const DEFAULT_DF_META: DFMeta = { total_rows: 0, columns: 0, filtered_rows: 0, rows_shown: 0 };
+const DEFAULT_BUCKAROO_STATE: BuckarooState = {
+    sampled: false,
+    cleaning_method: false,
+    quick_command_args: {},
+    post_processing: false,
+    df_display: "main",
+    show_commands: false,
+};
+const DEFAULT_BUCKAROO_OPTIONS: BuckarooOptions = {
+    sampled: [],
+    cleaning_method: [],
+    post_processing: [],
+    df_display: [],
+    show_commands: [],
+};
+const DEFAULT_COMMAND_CONFIG: CommandConfigT = { argspecs: {}, defaultArgs: {} };
 
 /**
  * BuckarooServerView — embed a Buckaroo server session inside a React tree.
@@ -64,7 +92,15 @@ interface ReadyState {
     model: WebSocketModel;
     src: ReturnType<typeof getKeySmartRowCache>;
     mode: BuckarooServerMode;
-    initialState: Record<string, any>;
+    initialState: Record<string, unknown>;
+}
+
+function pickMode(rawMode: unknown): BuckarooServerMode {
+    if (rawMode === "buckaroo" || rawMode === "viewer") return rawMode;
+    if (rawMode !== undefined && rawMode !== null) {
+        console.warn(`[BuckarooServerView] unknown mode ${JSON.stringify(rawMode)} — falling back to "viewer".`);
+    }
+    return "viewer";
 }
 
 /** Derive a Buckaroo server WebSocket URL from an HTTP server URL + session
@@ -87,14 +123,14 @@ export function BuckarooServerView({
     const [error, setError] = React.useState<Error | null>(null);
 
     // Re-fired state values so React re-renders when the model emits change events.
-    const [dfMeta, setDfMeta] = React.useState<any>({ total_rows: 0 });
-    const [dfDataDict, setDfDataDict] = React.useState<Record<string, any>>({});
-    const [dfDisplayArgs, setDfDisplayArgs] = React.useState<Record<string, any>>({});
-    const [buckarooState, setBuckarooStateLocal] = React.useState<any>({});
-    const [buckarooOptions, setBuckarooOptions] = React.useState<any>({});
-    const [commandConfig, setCommandConfig] = React.useState<any>({});
-    const [operationResults, setOperationResults] = React.useState<any>({});
-    const [operations, setOperations] = React.useState<any[]>([]);
+    const [dfMeta, setDfMeta] = React.useState<DFMeta>(DEFAULT_DF_META);
+    const [dfDataDict, setDfDataDict] = React.useState<Record<string, DFData>>({});
+    const [dfDisplayArgs, setDfDisplayArgs] = React.useState<Record<string, IDisplayArgs>>({});
+    const [buckarooState, setBuckarooStateLocal] = React.useState<BuckarooState>(DEFAULT_BUCKAROO_STATE);
+    const [buckarooOptions, setBuckarooOptions] = React.useState<BuckarooOptions>(DEFAULT_BUCKAROO_OPTIONS);
+    const [commandConfig, setCommandConfig] = React.useState<CommandConfigT>(DEFAULT_COMMAND_CONFIG);
+    const [operationResults, setOperationResults] = React.useState<OperationResult>(baseOperationResults);
+    const [operations, setOperations] = React.useState<Operation[]>([]);
 
     // Keep the latest onMetadata in a ref so we don't reconnect when the
     // host passes a fresh callback identity each render.
@@ -123,7 +159,10 @@ export function BuckarooServerView({
                 });
 
                 const initialState = await new Promise<Record<string, any>>((resolve, reject) => {
-                    const onClose = () => reject(new Error("WebSocket closed before initial_state was received"));
+                    const onClose = () => {
+                        ws!.removeEventListener("message", handler);
+                        reject(new Error("WebSocket closed before initial_state was received"));
+                    };
                     const handler = (event: MessageEvent) => {
                         if (typeof event.data !== "string") return;
                         try {
@@ -148,19 +187,19 @@ export function BuckarooServerView({
                 }
 
                 const model = new WebSocketModel(ws, initialState);
-                const src = getKeySmartRowCache(model, (a: any, b: any) => console.error("[BuckarooServerView] cache error:", a, b));
-                const mode: BuckarooServerMode = (initialState.mode === "buckaroo" ? "buckaroo" : "viewer");
+                const src = getKeySmartRowCache(model, (a: unknown, b: unknown) => console.error("[BuckarooServerView] cache error:", a, b));
+                const mode: BuckarooServerMode = pickMode(initialState.mode);
 
-                setDfMeta(initialState.df_meta || { total_rows: 0 });
-                setDfDataDict(initialState.df_data_dict || {});
-                setDfDisplayArgs(initialState.df_display_args || {});
-                setBuckarooStateLocal(initialState.buckaroo_state || {});
-                setBuckarooOptions(initialState.buckaroo_options || {});
-                setCommandConfig(initialState.command_config || {});
-                setOperationResults(initialState.operation_results || {});
-                setOperations(initialState.operations || []);
+                setDfMeta((initialState.df_meta as DFMeta) ?? DEFAULT_DF_META);
+                setDfDataDict((initialState.df_data_dict as Record<string, DFData>) ?? {});
+                setDfDisplayArgs((initialState.df_display_args as Record<string, IDisplayArgs>) ?? {});
+                setBuckarooStateLocal((initialState.buckaroo_state as BuckarooState) ?? DEFAULT_BUCKAROO_STATE);
+                setBuckarooOptions((initialState.buckaroo_options as BuckarooOptions) ?? DEFAULT_BUCKAROO_OPTIONS);
+                setCommandConfig((initialState.command_config as CommandConfigT) ?? DEFAULT_COMMAND_CONFIG);
+                setOperationResults((initialState.operation_results as OperationResult) ?? baseOperationResults);
+                setOperations((initialState.operations as Operation[]) ?? []);
 
-                if (initialState.metadata) onMetadataRef.current?.(initialState.metadata, initialState.prompt);
+                if (initialState.metadata) onMetadataRef.current?.(initialState.metadata as BuckarooServerMetadata, initialState.prompt as string | undefined);
 
                 setReady({ model, src, mode, initialState });
             } catch (e) {
@@ -181,25 +220,28 @@ export function BuckarooServerView({
         if (!ready) return;
         const { model } = ready;
 
-        const onMeta = (metadata: any, prompt?: string) => {
+        const onMeta = (metadata: BuckarooServerMetadata, prompt?: string) => {
             onMetadataRef.current?.(metadata, prompt);
-            setDfMeta(model.get("df_meta") || { total_rows: metadata?.rows || 0 });
-            preResolveDFDataDict(model.get("df_data_dict") || {}).then(setDfDataDict);
-            setDfDisplayArgs(model.get("df_display_args") || {});
-            setBuckarooStateLocal(model.get("buckaroo_state") || {});
-            setBuckarooOptions(model.get("buckaroo_options") || {});
-            setCommandConfig(model.get("command_config") || {});
-            setOperationResults(model.get("operation_results") || {});
-            setOperations(model.get("operations") || []);
+            setDfMeta((model.get("df_meta") as DFMeta | undefined) ?? { ...DEFAULT_DF_META, total_rows: metadata?.rows ?? 0 });
+            preResolveDFDataDict((model.get("df_data_dict") as Record<string, DFDataOrPayload> | undefined) ?? {})
+                .then((d) => setDfDataDict(d as Record<string, DFData>));
+            setDfDisplayArgs((model.get("df_display_args") as Record<string, IDisplayArgs> | undefined) ?? {});
+            setBuckarooStateLocal((model.get("buckaroo_state") as BuckarooState | undefined) ?? DEFAULT_BUCKAROO_STATE);
+            setBuckarooOptions((model.get("buckaroo_options") as BuckarooOptions | undefined) ?? DEFAULT_BUCKAROO_OPTIONS);
+            setCommandConfig((model.get("command_config") as CommandConfigT | undefined) ?? DEFAULT_COMMAND_CONFIG);
+            setOperationResults((model.get("operation_results") as OperationResult | undefined) ?? baseOperationResults);
+            setOperations((model.get("operations") as Operation[] | undefined) ?? []);
         };
-        const onDfMeta = (v: any) => setDfMeta(v);
-        const onDfDataDict = (v: any) => { preResolveDFDataDict(v).then(setDfDataDict); };
-        const onDfDisplayArgs = (v: any) => setDfDisplayArgs(v);
-        const onBState = (v: any) => setBuckarooStateLocal(v);
-        const onBOpts = (v: any) => setBuckarooOptions(v);
-        const onCmdCfg = (v: any) => setCommandConfig(v);
-        const onOpRes = (v: any) => setOperationResults(v);
-        const onOps = (v: any) => setOperations(v);
+        const onDfMeta = (v: DFMeta) => setDfMeta(v);
+        const onDfDataDict = (v: Record<string, DFDataOrPayload>) => {
+            preResolveDFDataDict(v).then((d) => setDfDataDict(d as Record<string, DFData>));
+        };
+        const onDfDisplayArgs = (v: Record<string, IDisplayArgs>) => setDfDisplayArgs(v);
+        const onBState = (v: BuckarooState) => setBuckarooStateLocal(v);
+        const onBOpts = (v: BuckarooOptions) => setBuckarooOptions(v);
+        const onCmdCfg = (v: CommandConfigT) => setCommandConfig(v);
+        const onOpRes = (v: OperationResult) => setOperationResults(v);
+        const onOps = (v: Operation[]) => setOperations(v);
 
         model.on("metadata", onMeta);
         model.on("change:df_meta", onDfMeta);
@@ -224,14 +266,16 @@ export function BuckarooServerView({
         };
     }, [ready]);
 
-    const onBuckarooState = React.useCallback((newState: any) => {
+    const onBuckarooState = React.useCallback<React.Dispatch<React.SetStateAction<BuckarooState>>>((newState) => {
         if (!ready) return;
-        const resolved = typeof newState === "function" ? newState(buckarooState) : newState;
+        const resolved = typeof newState === "function"
+            ? (newState as (prev: BuckarooState) => BuckarooState)(buckarooState)
+            : newState;
         ready.model.set("buckaroo_state", resolved);
         ready.model.save_changes();
     }, [ready, buckarooState]);
 
-    const onOperations = React.useCallback((newOps: any) => {
+    const onOperations = React.useCallback((newOps: Operation[]) => {
         if (!ready) return;
         ready.model.set("operations", newOps);
         ready.model.save_changes();

--- a/packages/buckaroo-js-core/src/server/WebSocketModel.ts
+++ b/packages/buckaroo-js-core/src/server/WebSocketModel.ts
@@ -103,13 +103,14 @@ export class WebSocketModel {
 
     private emit(event: string, ...args: any[]): void {
         const handlers = this.handlers.get(event);
-        if (handlers) {
-            for (const h of handlers) {
-                try {
-                    h(...args);
-                } catch (e) {
-                    console.error(`[WebSocketModel] Error in handler for ${event}:`, e);
-                }
+        if (!handlers) return;
+        // Array.from to satisfy ES5 target without --downlevelIteration.
+        // Also gives us a stable snapshot if a handler unsubscribes during emit.
+        for (const h of Array.from(handlers)) {
+            try {
+                h(...args);
+            } catch (e) {
+                console.error(`[WebSocketModel] Error in handler for ${event}:`, e);
             }
         }
     }

--- a/packages/js/standalone.tsx
+++ b/packages/js/standalone.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom/client";
-import srt from "buckaroo-js-core";
-import { WebSocketModel } from "./WebSocketModel";
+import srt, { WebSocketModel } from "buckaroo-js-core";
 import "./widget.css";
 import "../buckaroo-js-core/dist/style.css";
 


### PR DESCRIPTION
## Summary

Adds `BuckarooServerView` to `buckaroo-js-core` so React apps can embed a running Buckaroo server **inline**, instead of iframing `/s/<session-id>` from the server's HTML page.

```tsx
import { BuckarooServerView, buckarooWsUrl } from "buckaroo-js-core";
import "buckaroo-js-core/style.css";

<BuckarooServerView
  wsUrl={buckarooWsUrl("http://localhost:8700", "sales")}
  onMetadata={(m) => console.log(m.path)}
/>
```

The component opens the WebSocket, waits for `initial_state`, pre-resolves the parquet payload, builds the same `WebSocketModel` + `SmartRowCache` the standalone bundle uses, and renders `BuckarooInfiniteWidget` or `DFViewerInfiniteDS` based on the session's `mode`. All sort / infinite-scroll / search / post-processing paths keep working — the server logic is unchanged; only the host shell moves from a full HTML page to whatever div the consumer mounts.

CORS works out of the box: the server's `check_origin` is permissive by default (`BUCKAROO_STRICT_ORIGIN=1` restricts to localhost).

## Why this is better than an iframe

- CSS inheritance just works — no need for sandbox / postMessage / fixed sizing
- Host app controls sizing with regular flex/grid
- Real React props for metadata, error handling, lifecycle
- One DOM tree, one inspector tab, one bundle of React

## Changes

- **Move** `packages/js/WebSocketModel.ts` → `packages/buckaroo-js-core/src/server/WebSocketModel.ts`. Was previously bundled into the anywidget standalone-only; now part of the public npm surface. Minor refactor: `Array.from` in `emit()` for ES5-target compatibility and stable iteration if a handler unsubscribes mid-emit.

- **New** `packages/buckaroo-js-core/src/server/BuckarooServerView.tsx` — high-level component encapsulating connect → `initial_state` → render. Exposes `onMetadata`, `renderConnecting`, `renderError`, and a `buckarooWsUrl(serverUrl, sessionId)` helper.

- **Re-export** `BuckarooServerView`, `WebSocketModel`, `buckarooWsUrl` from `packages/buckaroo-js-core/src/index.ts` (both default and named).

- **Update** `packages/js/standalone.tsx`: import `WebSocketModel` from `"buckaroo-js-core"` instead of relative. One-line change; the standalone host shell (filename bar / prompt bar / height patching) is untouched.

- **Docs** `docs/source/articles/embedding.rst`: section 5 promoted from *coming soon* to two real subsections — **5a server-backed** (the new path) and **5b static** (the existing `BuckarooStaticTable` path). Quick-chooser table updated.

## Test plan

- [x] `pnpm test` — 96/96 jest pass
- [x] `pnpm --filter buckaroo-js-core run build` — green, output gains 2 modules for the new server files
- [x] `pnpm --filter buckaroo-widget run build` / `build:standalone` / `build:static` — all green, `standalone.js` now picks up `WebSocketModel` via the workspace package import
- [ ] CI: full Checks run on this PR
- [ ] Manual: start `python -m buckaroo.server`, load a file, render `<BuckarooServerView wsUrl=...>` in a small React harness — best done as a follow-up integration test once #721 (npm-publishable package) lands

## Relationship to #721

This PR adds the API surface; #721 (open) makes the package npm-installable. Either can land first. After both: an npm consumer outside this monorepo can do `npm install buckaroo-js-core` and use `BuckarooServerView` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)