### PR TITLE
ci: require pyo3/polars panic signature before swallowing 134 (codex follow-up to #723)

### DIFF
--- a/scripts/run_pytest_tolerant.sh
+++ b/scripts/run_pytest_tolerant.sh
@@ -24,14 +24,18 @@
 #
 # This wrapper:
 #   1. Runs the command (passed as argv).
-#   2. If the command exited 134 AND the captured output shows a passing
-#      pytest summary with no `failed` / `error` lines, emits a CI
-#      ::warning:: and exits 0.
+#   2. Treats exit 134 as success ONLY when ALL of these hold:
+#        a. The captured output shows a passing pytest summary.
+#        b. No `failed` / `error` lines appear in the summary.
+#        c. The captured output contains a known signature of the
+#           polars-stream / pyo3 shutdown race (the FATAL line plus a
+#           pyo3/polars-stream panic frame). Without this signature
+#           guard, an unrelated native crash producing exit 134 after a
+#           passing summary would silently get reported as success.
 #   3. Otherwise propagates the original exit code unchanged.
 #
 # Real failures (pytest exit 1, crashes before the summary, errored
-# collection) are preserved because the summary line would either be
-# missing or include "failed" / "error".
+# collection, native crashes in other libraries) are preserved.
 
 set -uo pipefail
 
@@ -47,14 +51,24 @@ trap 'rm -f "$LOG"' EXIT
 "$@" 2>&1 | tee "$LOG"
 status=${PIPESTATUS[0]}
 
+# Signature of the known polars-stream / pyo3 shutdown race. We require
+# both the FATAL marker AND a Rust panic frame from pyo3 OR polars-stream.
+# An unrelated SIGABRT (e.g. malloc corruption, a different C extension
+# crashing) would not produce these strings.
+has_known_signature() {
+    grep -qE "FATAL: exception not rethrown" "$LOG" \
+        && grep -qE "panicked at .*(pyo3|polars-stream|polars_stream)" "$LOG"
+}
+
 if [ "$status" -eq 134 ] \
    && grep -qE "[0-9]+ passed" "$LOG" \
    && ! grep -qE "[0-9]+ failed" "$LOG" \
-   && ! grep -qE "[0-9]+ error" "$LOG"; then
+   && ! grep -qE "[0-9]+ error" "$LOG" \
+   && has_known_signature; then
     echo ""
-    echo "::warning::pytest exited 134 (SIGABRT) but the summary shows all tests passed."
-    echo "::warning::Known polars-stream / pyo3 shutdown race; treating as success."
-    echo "::warning::See scripts/run_pytest_tolerant.sh for context."
+    echo "::warning::pytest exited 134 (SIGABRT) but the summary shows all tests passed"
+    echo "::warning::AND the polars-stream / pyo3 shutdown signature was present in output."
+    echo "::warning::Treating as success. See scripts/run_pytest_tolerant.sh for context."
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Codex P2 follow-up to [#723](https://github.com/buckaroo-data/buckaroo/pull/723) (already merged):

> In these Linux pytest jobs, any command that aborts with exit 134 after pytest has printed a passing summary will now be reported as successful, even if the abort came from a different native crash than the polars/pyo3 shutdown race. Since the wrapper already documents the expected `FATAL: exception not rethrown` / pyo3 / polars panic text, please include that signature in the condition before exiting 0 so CI does not hide unrelated post-summary aborts.

Tightens `scripts/run_pytest_tolerant.sh` to require **both** of the following in the captured pytest output in addition to a clean summary, before treating exit 134 as success:

- `FATAL: exception not rethrown`
- A Rust panic frame mentioning `pyo3`, `polars-stream`, or `polars_stream`

The known polars-stream shutdown race emits both. An unrelated C-extension SIGABRT or a different crate's panic will not, so it propagates.

## Test plan

Smoke-tested the new condition locally against five scenarios:

| Scenario | Expected | Actual |
|---|---|---|
| Known polars/pyo3 race + passing summary | exit 0 + warning | 0 ✓ |
| 134 + passing summary, SEGV from some other library | propagate 134 | 134 ✓ |
| 134 + passing summary + FATAL + non-pyo3 panic | propagate 134 | 134 ✓ |
| 134 + summary contains "failed" | propagate 134 | 134 ✓ |
| Clean exit 0 | exit 0 | 0 ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)