### PR TITLE
ci: add Release npm workflow for buckaroo-js-core

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,91 @@
+name: Release npm
+
+# Standalone workflow that publishes packages/buckaroo-js-core to npm.
+# Kept separate from Release (PyPI) so we can iterate on it without
+# touching the wheel/PyPI pipeline. To keep buckaroo-js-core in lockstep
+# with the Python package, run this with `version` set to the same
+# semver as the matching Python release (e.g. the git tag created by
+# the Release workflow).
+#
+# Auth: npm Trusted Publishing via OIDC (no NPM_TOKEN secret). Register
+# this repo + workflow as a Trusted Publisher in the npm UI:
+#   https://www.npmjs.com/package/buckaroo-js-core/access
+# Repository:  buckaroo-data/buckaroo
+# Workflow:    release-npm.yml
+# Environment: npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish as (must match the buckaroo Python release, e.g. 0.13.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Run npm publish with --dry-run (no actual publish)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release-npm:
+    name: Publish buckaroo-js-core to npm
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.10.0
+
+      - name: Setup Node.js with npm registry
+        uses: actions/setup-node@v6
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: 'packages/pnpm-lock.yaml'
+
+      - name: Install pnpm dependencies
+        working-directory: packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        # Trusted Publishing requires npm >= 11.5.1
+        run: npm install -g npm@latest
+
+      - name: Set buckaroo-js-core version to ${{ inputs.version }}
+        working-directory: packages/buckaroo-js-core
+        run: npm version "${{ inputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Build buckaroo-js-core
+        working-directory: packages/buckaroo-js-core
+        run: pnpm run build
+
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION="${{ inputs.version }}"
+          if npm view "buckaroo-js-core@${VERSION}" version >/dev/null 2>&1; then
+            echo "buckaroo-js-core@${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (Trusted Publishing + provenance)
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/buckaroo-js-core
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm publish --access public --provenance --dry-run
+          else
+            npm publish --access public --provenance
+          fi

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -34,7 +34,10 @@ permissions:
 jobs:
   release-npm:
     name: Publish buckaroo-js-core to npm
-    runs-on: depot-ubuntu-latest
+    # GitHub-hosted runner required: npm Trusted Publishing OIDC is only
+    # supported on github-hosted runners (Depot's depot-ubuntu-latest is
+    # treated as self-hosted and won't receive npm OIDC credentials).
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: npm
     steps:


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release-npm.yml`, a standalone `workflow_dispatch` workflow that publishes `packages/buckaroo-js-core` to npm.
- Kept separate from the existing **Release** (PyPI) workflow so it can be iterated on independently while we get npm publishing working.
- Auth uses **npm Trusted Publishing via OIDC** — no `NPM_TOKEN` secret. Publishes with `--provenance`.

## Inputs

- `version` (required) — semver to publish as. Pass the same tag the **Release** workflow created (e.g. `0.11.0`) to keep buckaroo-js-core in lockstep with the Python `buckaroo` release.
- `dry_run` (default `false`) — runs `npm publish --dry-run` for safe iteration.

## One-time setup before first run

Register the Trusted Publisher at https://www.npmjs.com/package/buckaroo-js-core/access:

- Organization: `buckaroo-data`
- Repository: `buckaroo`
- Workflow filename: `release-npm.yml`
- Environment name: `npm`

Also create a GitHub environment named `npm` on this repo (Settings → Environments).

## How it works

1. Checkout, set up pnpm + Node with npm registry.
2. `pnpm install --frozen-lockfile` (devDeps for the build).
3. `npm install -g npm@latest` — Trusted Publishing needs npm ≥ 11.5.1.
4. `npm version <inputs.version> --no-git-tag-version --allow-same-version` — bump `packages/buckaroo-js-core/package.json`.
5. `pnpm run build`.
6. `npm view buckaroo-js-core@<version>` — skip publish if already on the registry (safe to re-run).
7. `npm publish --access public --provenance` (or `--dry-run` when set).

## Test plan

- [ ] Register the Trusted Publisher on npmjs.com with the values above.
- [ ] Create a GitHub `npm` environment on this repo.
- [ ] Trigger **Release npm** from the Actions tab with `version=0.11.0` and `dry_run=true`. Confirm logs show OIDC token exchange + provenance assertion.
- [ ] Re-trigger with `dry_run=false`. Confirm `buckaroo-js-core@0.11.0` appears on npm.
- [ ] Re-trigger the same version. Confirm it short-circuits via the `npm view` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)