### PR TITLE
ci(release-npm): sudo for global npm upgrade

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -61,8 +61,9 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Upgrade npm to a Trusted-Publishing-capable version
-        # Trusted Publishing requires npm >= 11.5.1
-        run: npm install -g npm@latest
+        # Trusted Publishing requires npm >= 11.5.1. The global npm dir
+        # on github-hosted runners is root-owned, so sudo is needed.
+        run: sudo npm install -g npm@latest
 
       - name: Set buckaroo-js-core version to ${{ inputs.version }}
         working-directory: packages/buckaroo-js-core


### PR DESCRIPTION
Stacked on top of #733.

## Summary

- `npm install -g npm@latest` on ubuntu-latest fails with EACCES because `/usr/local/lib/node_modules` is root-owned on github-hosted runners. Adds `sudo`.

## Why this is needed

First dry-run of #733 failed at the upgrade step:

```
npm error code EACCES
npm error syscall mkdir
npm error path /usr/local/share/man/man7
```

Trusted Publishing requires npm ≥ 11.5.1; the runner ships an older npm bundled with Node, so the upgrade has to succeed.

## Test plan

- [ ] Merge after #733 (or rebase + merge into main once #733 lands).
- [ ] Re-trigger **Release npm** with `version=0.11.0`, `dry_run=true`. Confirm the upgrade step succeeds and `npm publish --dry-run` prints provenance + tarball info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)