### PR TITLE
ci(release-npm): diagnose Trusted Publishing 404

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -65,6 +65,25 @@ jobs:
         # on github-hosted runners is root-owned, so sudo is needed.
         run: sudo npm install -g npm@latest
 
+      - name: OIDC diagnostics (compare against npm Trusted Publisher config)
+        # Prints the values npm checks against the Trusted Publisher
+        # config on the package. Compare these to what's registered at
+        # https://www.npmjs.com/package/buckaroo-js-core/access
+        run: |
+          echo "npm version:              $(npm --version)"
+          echo "GITHUB_REPOSITORY:        ${GITHUB_REPOSITORY}"
+          echo "GITHUB_WORKFLOW_REF:      ${GITHUB_WORKFLOW_REF}"
+          echo "GITHUB_REF:               ${GITHUB_REF}"
+          echo "GITHUB_REF_NAME:          ${GITHUB_REF_NAME}"
+          echo "GITHUB_JOB:               ${GITHUB_JOB}"
+          echo "Job environment (yaml):   npm"
+          echo
+          echo "On npmjs.com the Trusted Publisher must match:"
+          echo "  Owner:        $(echo "${GITHUB_REPOSITORY}" | cut -d/ -f1)"
+          echo "  Repository:   $(echo "${GITHUB_REPOSITORY}" | cut -d/ -f2)"
+          echo "  Workflow:     $(basename "${GITHUB_WORKFLOW_REF%@*}")"
+          echo "  Environment:  npm  (or leave blank if no environment configured)"
+
       - name: Set buckaroo-js-core version to ${{ inputs.version }}
         working-directory: packages/buckaroo-js-core
         run: npm version "${{ inputs.version }}" --no-git-tag-version --allow-same-version
@@ -89,7 +108,7 @@ jobs:
         working-directory: packages/buckaroo-js-core
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            npm publish --access public --provenance --dry-run
+            npm publish --access public --provenance --dry-run --loglevel=verbose
           else
-            npm publish --access public --provenance
+            npm publish --access public --provenance --loglevel=verbose
           fi


### PR DESCRIPTION
## Context

Previous run of **Release npm** got through:
- ✅ build (12.66s)
- ✅ tarball assembly (`buckaroo-js-core@0.11.3`)
- ✅ provenance statement signed via Sigstore
- ✅ provenance published to transparency log

…and then **404'd on the actual `PUT https://registry.npmjs.org/buckaroo-js-core`**.

`buckaroo-js-core` does exist on npm (currently `0.8.5`, owned by `paddy_mullen`) but `0.11.3` is not published. npm returning 404 here means the OIDC token was presented but the Trusted Publisher config on the package didn't recognize it as authorized — i.e. one of the registered fields (org/repo/workflow filename/environment) does not match what GitHub is putting into the OIDC claims.

## What this PR adds

1. A **diagnostics step** that prints the values npm checks against:
   - `GITHUB_REPOSITORY`, `GITHUB_WORKFLOW_REF`, `GITHUB_REF`, `GITHUB_REF_NAME`, `GITHUB_JOB`
   - the npm CLI version (must be ≥ 11.5.1)
   - a summary of what the Trusted Publisher fields should be
2. `--loglevel=verbose` on `npm publish` so the next failure shows the actual server response body instead of just a one-line 404.

No behaviour changes — just observability for the next run.

## How to use

Trigger **Release npm** again (e.g. with `version=0.11.3`, `dry_run=true`). Compare the printed values to the Trusted Publisher entry at:

https://www.npmjs.com/package/buckaroo-js-core/access

Common mismatches to check:
- Repository owner — workflow runs as `buckaroo-data/buckaroo`. If the npm-side config is `paddymul/buckaroo` (the old org), it won't match.
- Workflow filename — npm wants `release-npm.yml` (just the filename, no path).
- Environment — workflow has `environment: npm`. The npm config must either also say `npm` or be left blank; if it's set to a different name they won't match.

Once we know which field is mismatched, the follow-up PR will either edit the workflow to match or document the npm-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)