### PR TITLE
fix(buckaroo-js-core): point package.json at buckaroo-data/buckaroo

### DIFF
--- a/packages/buckaroo-js-core/package.json
+++ b/packages/buckaroo-js-core/package.json
@@ -13,14 +13,14 @@
   ],
   "license": "BSD-3-Clause",
   "author": "Paddy Mullen",
-  "homepage": "https://github.com/paddymul/buckaroo",
+  "homepage": "https://github.com/buckaroo-data/buckaroo",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/paddymul/buckaroo.git",
+    "url": "git+https://github.com/buckaroo-data/buckaroo.git",
     "directory": "packages/buckaroo-js-core"
   },
   "bugs": {
-    "url": "https://github.com/paddymul/buckaroo/issues"
+    "url": "https://github.com/buckaroo-data/buckaroo/issues"
   },
   "packageManager": "pnpm@9.0.0",
   "type": "module",


### PR DESCRIPTION
## Summary

Updates `packages/buckaroo-js-core/package.json` `repository.url`, `homepage`, and `bugs.url` from `paddymul/buckaroo` to `buckaroo-data/buckaroo` so npm Trusted Publishing's provenance check passes.

## Why

After configuring the Trusted Publisher on npmjs.com, the next publish attempt got past auth but failed at provenance validation:

```
422 Unprocessable Entity - PUT https://registry.npmjs.org/buckaroo-js-core
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/paddymul/buckaroo.git",
expected to match "https://github.com/buckaroo-data/buckaroo" from provenance
```

npm now cross-checks the `repository` field in `package.json` against the GitHub Actions provenance attestation (which says the build ran in `buckaroo-data/buckaroo`). The two have to agree.

## Test plan

- [ ] Merge.
- [ ] Re-trigger **Release npm** with `version=0.11.5` (or the next unused), `dry_run=false`.
- [ ] Confirm the publish succeeds and `buckaroo-js-core@<version>` appears on npm.
- [ ] Confirm the npm package page now links to `github.com/buckaroo-data/buckaroo` under "Repository".

🤖 Generated with [Claude Code](https://claude.com/claude-code)