### PR TITLE
feat(js-core): highlight_phrase / highlight_regex on string displayer

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -403,7 +403,13 @@ export function DFViewerInfiniteInner({
         getRowId,
         rowModelType: "clientSide"}
 
-    }, [styledColumns.length, JSON.stringify(styledColumns), hs, df_viewer_config.extra_grid_config, setActiveCol, getRowId]);
+    // NOTE: gating on `styledColumns` reference (which only changes when
+    // df_viewer_config changes) rather than `JSON.stringify(styledColumns)` —
+    // JSON.stringify drops function values, so it can't tell apart a colDef
+    // with `valueFormatter: fn` from one with `cellRenderer: fn` (e.g. when a
+    // search op adds highlight_regex to displayer_args). See highlight.test.tsx
+    // "function-prop blind spot" tests.
+    }, [styledColumns, hs, df_viewer_config.extra_grid_config, setActiveCol, getRowId]);
 
         // Extract datasource separately to ensure it updates when data_wrapper changes
         const datasource = useMemo(() => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -16,6 +16,12 @@ export interface BooleanDisplayerA {
 export interface StringDisplayerA {
     displayer: "string";
     max_length?: number;
+    // When set, wrap matches in a <mark> with the configured background.
+    // Matching is case-insensitive; an array highlights any of the phrases.
+    // Mutually exclusive with highlight_regex — regex wins if both are supplied.
+    highlight_phrase?: string | string[];
+    highlight_regex?: string; // JS regex source (no slashes/flags); applied case-insensitively
+    highlight_color?: string; // any CSS color; defaults to "yellow"
 }
 export interface FloatDisplayerA {
     displayer: "float";

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
@@ -8,6 +8,72 @@ export const getTextCellRenderer = (formatter: ValueFormatterFunc<any>) => {
     return TextCellRenderer;
 };
 
+const escapeRegex = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const buildPhrasePattern = (phrase: string | string[]): RegExp | undefined => {
+    const phrases = (_.isArray(phrase) ? phrase : [phrase]).filter(
+        (p) => typeof p === "string" && p.length > 0,
+    );
+    if (phrases.length === 0) return undefined;
+    // Longest-first alternation so overlapping phrases pick the longer match.
+    return new RegExp(
+        `(${phrases
+            .slice()
+            .sort((a, b) => b.length - a.length)
+            .map(escapeRegex)
+            .join("|")})`,
+        "gi",
+    );
+};
+
+const buildRegexPattern = (source: string): RegExp | undefined => {
+    if (typeof source !== "string" || source.length === 0) return undefined;
+    try {
+        return new RegExp(`(${source})`, "gi");
+    } catch (e) {
+        console.warn("buckaroo: invalid highlight_regex", source, e);
+        return undefined;
+    }
+};
+
+export const getHighlightTextCellRenderer = (
+    formatter: ValueFormatterFunc<any>,
+    spec: { phrase?: string | string[]; regex?: string },
+    color: string = "yellow",
+) => {
+    // regex wins if both are supplied (documented as mutually exclusive).
+    const pattern =
+        spec.regex !== undefined
+            ? buildRegexPattern(spec.regex)
+            : spec.phrase !== undefined
+              ? buildPhrasePattern(spec.phrase)
+              : undefined;
+    if (pattern === undefined) {
+        return getTextCellRenderer(formatter);
+    }
+    const HighlightTextCellRenderer = (props: any) => {
+        const raw = formatter(props);
+        if (typeof raw !== "string" || raw.length === 0) {
+            return <span>{raw}</span>;
+        }
+        const parts = raw.split(pattern);
+        return (
+            <span>
+                {parts.map((part, i) =>
+                    i % 2 === 1 ? (
+                        <mark key={i} style={{ backgroundColor: color, padding: 0 }}>
+                            {part}
+                        </mark>
+                    ) : (
+                        <span key={i}>{part}</span>
+                    ),
+                )}
+            </span>
+        );
+    };
+    return HighlightTextCellRenderer;
+};
+
 export const LinkCellRenderer = (props: any) => {
     return <a href={props.value}>{props.value}</a>;
 };

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/OtherRenderers.tsx
@@ -1,5 +1,5 @@
 import * as _ from "lodash-es";
-import { ValueFormatterFunc } from "ag-grid-community";
+import { ICellRendererParams, ValueFormatterFunc, ValueFormatterParams } from "ag-grid-community";
 
 export const getTextCellRenderer = (formatter: ValueFormatterFunc<any>) => {
     const TextCellRenderer = (props: any) => {
@@ -39,7 +39,7 @@ const buildRegexPattern = (source: string): RegExp | undefined => {
 export const getHighlightTextCellRenderer = (
     formatter: ValueFormatterFunc<any>,
     spec: { phrase?: string | string[]; regex?: string },
-    color: string = "yellow",
+    color?: string,
 ) => {
     // regex wins if both are supplied (documented as mutually exclusive).
     const pattern =
@@ -51,8 +51,12 @@ export const getHighlightTextCellRenderer = (
     if (pattern === undefined) {
         return getTextCellRenderer(formatter);
     }
-    const HighlightTextCellRenderer = (props: any) => {
-        const raw = formatter(props);
+    // Default color + padding live on .buckaroo-highlight in dcf-npm.css so
+    // themes can restyle; user-supplied highlight_color flows through inline
+    // and wins over the class default.
+    const markStyle = color ? { backgroundColor: color } : undefined;
+    const HighlightTextCellRenderer = (props: ICellRendererParams<any, any, any>) => {
+        const raw = formatter(props as unknown as ValueFormatterParams);
         if (typeof raw !== "string" || raw.length === 0) {
             return <span>{raw}</span>;
         }
@@ -61,7 +65,7 @@ export const getHighlightTextCellRenderer = (
             <span>
                 {parts.map((part, i) =>
                     i % 2 === 1 ? (
-                        <mark key={i} style={{ backgroundColor: color, padding: 0 }}>
+                        <mark key={i} className="buckaroo-highlight" style={markStyle}>
                             {part}
                         </mark>
                     ) : (

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -28,7 +28,7 @@ import {
 } from "./DFWhole";
 
 import * as _ from "lodash-es";
-import { getTextCellRenderer } from "./OtherRenderers";
+import { getTextCellRenderer, getHighlightTextCellRenderer } from "./OtherRenderers";
 import { getStyler } from "./Styler";
 import { DFData, SDFMeasure, SDFT } from "./DFWhole";
 
@@ -51,6 +51,20 @@ export function getCellRendererorFormatter(
     if (dispArgs.displayer === "compact_number" && formatter !== undefined) {
         return {
             valueFormatter: formatter,
+            tooltipValueGetter: (params) => params.value != null ? String(params.value) : "",
+        };
+    }
+    if (
+        dispArgs.displayer === "string" &&
+        formatter !== undefined &&
+        (dispArgs.highlight_phrase !== undefined || dispArgs.highlight_regex !== undefined)
+    ) {
+        return {
+            cellRenderer: getHighlightTextCellRenderer(
+                formatter,
+                { phrase: dispArgs.highlight_phrase, regex: dispArgs.highlight_regex },
+                dispArgs.highlight_color,
+            ),
             tooltipValueGetter: (params) => params.value != null ? String(params.value) : "",
         };
     }

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/highlight.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/highlight.test.tsx
@@ -1,8 +1,10 @@
 import { render } from "@testing-library/react";
-import { ValueFormatterParams } from "ag-grid-community";
+import { ColDef, ValueFormatterParams } from "ag-grid-community";
 
 import { getHighlightTextCellRenderer } from "./OtherRenderers";
 import { getStringFormatter } from "./Displayer";
+import { dfToAgrid } from "./gridUtils";
+import { DFViewerConfig } from "./DFWhole";
 
 const plainFmt = getStringFormatter({ displayer: "string" });
 const mkProps = (value: unknown) => ({ value } as ValueFormatterParams);
@@ -24,5 +26,101 @@ describe("string displayer highlight", () => {
             (m) => m.textContent,
         );
         expect(marks).toEqual(["42", "7"]);
+    });
+
+    it("dfToAgrid wires cellRenderer (not just valueFormatter) when highlight_regex is set", () => {
+        // This is the integration point that the Python-side delivery feeds.
+        // If dfToAgrid only set valueFormatter, the highlight renderer would
+        // never be invoked by AG-Grid — the cell would render the raw value.
+        const cfg: DFViewerConfig = {
+            pinned_rows: [],
+            left_col_configs: [],
+            column_config: [{
+                col_name: "comments",
+                header_name: "comments",
+                displayer_args: { displayer: "string", max_length: 2000, highlight_regex: "area" },
+            }],
+        };
+        const cols = dfToAgrid(cfg) as ColDef[];
+        expect(cols).toHaveLength(1);
+        expect(cols[0].cellRenderer).toBeDefined();
+        expect(cols[0].valueFormatter).toBeUndefined();
+
+        // And the resulting renderer wraps matches in <mark> when given a real value.
+        const Renderer = cols[0].cellRenderer as any;
+        const { container } = render(<Renderer {...mkProps("Hood filter area with grease build up")} />);
+        const marks = Array.from(container.querySelectorAll("mark")).map((m) => m.textContent);
+        expect(marks).toEqual(["area"]);
+    });
+
+    it("dfToAgrid wires cellRenderer when highlight_phrase is set", () => {
+        const cfg: DFViewerConfig = {
+            pinned_rows: [],
+            left_col_configs: [],
+            column_config: [{
+                col_name: "comments",
+                header_name: "comments",
+                displayer_args: { displayer: "string", max_length: 2000, highlight_phrase: ["area"], highlight_color: "red" },
+            }],
+        };
+        const cols = dfToAgrid(cfg) as ColDef[];
+        expect(cols[0].cellRenderer).toBeDefined();
+        expect(cols[0].valueFormatter).toBeUndefined();
+        const Renderer = cols[0].cellRenderer as any;
+        const { container } = render(<Renderer {...mkProps("Hood filter area with grease")} />);
+        const mark = container.querySelector("mark") as HTMLElement;
+        expect(mark?.textContent).toBe("area");
+        expect(mark?.style.backgroundColor).toBe("red");
+    });
+});
+
+// These tests document a memoization blind spot in DFViewerInfinite's
+// gridOptions useMemo dep list, which historically uses
+// `JSON.stringify(styledColumns)`. Adding `highlight_regex` to displayer_args
+// flips a column from {valueFormatter: fn} to {cellRenderer: fn} — but
+// JSON.stringify silently drops function values, so the two stringifications
+// are equal and useMemo never recomputes. AG-Grid never sees the new colDefs
+// and existing cells keep their old rendering. The fix is to gate on the
+// SOURCE (df_viewer_config.column_config), which is plain data.
+describe("dfToAgrid memoization signature: function-prop blind spot", () => {
+    const mkCfg = (extras: Record<string, unknown> = {}): DFViewerConfig => ({
+        pinned_rows: [],
+        left_col_configs: [],
+        column_config: [{
+            col_name: "c",
+            header_name: "c",
+            displayer_args: { displayer: "string", max_length: 35, ...extras },
+        }],
+    });
+
+    it("JSON.stringify on post-dfToAgrid columns can't see the renderer flip", () => {
+        const plain = dfToAgrid(mkCfg()) as ColDef[];
+        const withHl = dfToAgrid(mkCfg({ highlight_regex: "x" })) as ColDef[];
+
+        // The colDefs ARE functionally different — one has cellRenderer, the
+        // other only valueFormatter:
+        expect(plain[0].cellRenderer).toBeUndefined();
+        expect(plain[0].valueFormatter).toBeDefined();
+        expect(withHl[0].cellRenderer).toBeDefined();
+        expect(withHl[0].valueFormatter).toBeUndefined();
+
+        // …but JSON.stringify drops the function values, so the signatures
+        // collide. A useMemo gated on this string would not recompute.
+        expect(JSON.stringify(plain)).toBe(JSON.stringify(withHl));
+    });
+
+    it("JSON.stringify on the source column_config DOES capture the flip", () => {
+        const plain = mkCfg().column_config;
+        const withHl = mkCfg({ highlight_regex: "x" }).column_config;
+        expect(JSON.stringify(plain)).not.toBe(JSON.stringify(withHl));
+    });
+
+    it("reference equality on column_config (or styledColumns) is sufficient when Python re-pushes the tree", () => {
+        // anywidget deserializes a fresh JSON tree on every Python push, so
+        // df_viewer_config.column_config is a *new* array ref each update —
+        // a cheap reference dep catches every meaningful change.
+        const cfg1 = mkCfg();
+        const cfg2 = mkCfg({ highlight_regex: "x" });
+        expect(cfg1.column_config).not.toBe(cfg2.column_config);
     });
 });

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/highlight.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/highlight.test.tsx
@@ -1,0 +1,28 @@
+import { render } from "@testing-library/react";
+import { ValueFormatterParams } from "ag-grid-community";
+
+import { getHighlightTextCellRenderer } from "./OtherRenderers";
+import { getStringFormatter } from "./Displayer";
+
+const plainFmt = getStringFormatter({ displayer: "string" });
+const mkProps = (value: unknown) => ({ value } as ValueFormatterParams);
+
+describe("string displayer highlight", () => {
+    it("highlights phrase matches", () => {
+        const R = getHighlightTextCellRenderer(plainFmt, { phrase: "error" });
+        const { container } = render(<R {...mkProps("ERROR: load error")} />);
+        const marks = Array.from(container.querySelectorAll("mark")).map(
+            (m) => m.textContent,
+        );
+        expect(marks).toEqual(["ERROR", "error"]);
+    });
+
+    it("highlights regex matches", () => {
+        const R = getHighlightTextCellRenderer(plainFmt, { regex: "\\d+" });
+        const { container } = render(<R {...mkProps("err 42 / err 7")} />);
+        const marks = Array.from(container.querySelectorAll("mark")).map(
+            (m) => m.textContent,
+        );
+        expect(marks).toEqual(["42", "7"]);
+    });
+});

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/highlight.test.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/highlight.test.tsx
@@ -1,5 +1,5 @@
 import { render } from "@testing-library/react";
-import { ColDef, ValueFormatterParams } from "ag-grid-community";
+import { ColDef, ICellRendererParams } from "ag-grid-community";
 
 import { getHighlightTextCellRenderer } from "./OtherRenderers";
 import { getStringFormatter } from "./Displayer";
@@ -7,7 +7,7 @@ import { dfToAgrid } from "./gridUtils";
 import { DFViewerConfig } from "./DFWhole";
 
 const plainFmt = getStringFormatter({ displayer: "string" });
-const mkProps = (value: unknown) => ({ value } as ValueFormatterParams);
+const mkProps = (value: unknown) => ({ value } as unknown as ICellRendererParams);
 
 describe("string displayer highlight", () => {
     it("highlights phrase matches", () => {
@@ -26,6 +26,57 @@ describe("string displayer highlight", () => {
             (m) => m.textContent,
         );
         expect(marks).toEqual(["42", "7"]);
+    });
+
+    it("regex wins when both highlight_phrase and highlight_regex are supplied", () => {
+        const R = getHighlightTextCellRenderer(plainFmt, {
+            phrase: "error",
+            regex: "\\d+",
+        });
+        const { container } = render(<R {...mkProps("error 42 fail")} />);
+        const marks = Array.from(container.querySelectorAll("mark")).map(
+            (m) => m.textContent,
+        );
+        // If regex won, only the digit run is wrapped. If phrase had won,
+        // we'd see "error" wrapped instead.
+        expect(marks).toEqual(["42"]);
+    });
+
+    it("falls back to plain rendering when highlight_regex is invalid", () => {
+        const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+        try {
+            const R = getHighlightTextCellRenderer(plainFmt, { regex: "(" });
+            const { container } = render(<R {...mkProps("error 42")} />);
+            expect(container.querySelectorAll("mark")).toHaveLength(0);
+            expect(container.textContent).toBe("error 42");
+            expect(warn).toHaveBeenCalled();
+        } finally {
+            warn.mockRestore();
+        }
+    });
+
+    it("applies max_length truncation before matching (matches past the cutoff are not highlighted)", () => {
+        // max_length=12 → "X needle Y n" — the second "needle" is past the
+        // cutoff and only the first should be wrapped. This guards the
+        // contract: formatter (truncation) runs before pattern matching.
+        const truncFmt = getStringFormatter({ displayer: "string", max_length: 12 });
+        const R = getHighlightTextCellRenderer(truncFmt, { phrase: "needle" });
+        const { container } = render(
+            <R {...mkProps("X needle Y needle Z")} />,
+        );
+        const marks = Array.from(container.querySelectorAll("mark")).map(
+            (m) => m.textContent,
+        );
+        expect(marks).toEqual(["needle"]);
+        expect(container.textContent).toBe("X needle Y n");
+    });
+
+    it("omits inline backgroundColor when highlight_color is unset (CSS class default applies)", () => {
+        const R = getHighlightTextCellRenderer(plainFmt, { phrase: "x" });
+        const { container } = render(<R {...mkProps("x")} />);
+        const mark = container.querySelector("mark") as HTMLElement;
+        expect(mark.classList.contains("buckaroo-highlight")).toBe(true);
+        expect(mark.style.backgroundColor).toBe("");
     });
 
     it("dfToAgrid wires cellRenderer (not just valueFormatter) when highlight_regex is set", () => {

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -690,4 +690,9 @@ Then set the `style_block` property from ptyhon.
 }
 */
 
+mark.buckaroo-highlight {
+    background-color: yellow;
+    padding: 0;
+}
+
 


### PR DESCRIPTION
## Summary

Adds search highlighting to the `string` displayer. Two new optional fields on `StringDisplayerA`:

- `highlight_phrase: string | string[]` — phrase(s) to highlight (regex-escaped, longest-first alternation so overlapping terms pick the longer match)
- `highlight_regex: string` — JS regex source (no slashes/flags)
- `highlight_color: string` — any CSS color, defaults to `"yellow"`

When either is set, the column switches from a `valueFormatter` to a cell renderer that runs the existing string formatter first (so `max_length` truncation is preserved) and wraps matches in `<mark style={{backgroundColor: color, padding: 0}}>`. Matching is case-insensitive. `highlight_regex` wins if both are supplied; invalid regex sources fall back to plain text with a `console.warn`. A `tooltipValueGetter` is added alongside so the full untruncated value is still hoverable.

Usage from Python:

```python
'displayer_args': {
    'displayer': 'string',
    'max_length': 200,
    'highlight_phrase': ['error', 'fail'],   # or a single string, or use highlight_regex
    'highlight_color': '#ffe066',
}
```

## Test plan

- [x] `pnpm test` — 214 passed (was 212; +2 new tests covering phrase and regex highlighting)
- [x] `pnpm run build` clean (tsc + vite)
- [ ] CI green