### PR TITLE
feat(polars-search): plumb search term to JS as highlight_regex

### DIFF
--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -6,12 +6,19 @@ from ..jlisp.lisp_utils import s
 #from ..auto_clean.cleaning_commands import (to_bool, to_datetime, to_int, to_float, to_string)
 
 class Command(object):
-    @staticmethod 
+    """A Command's `transform` returns either the new df, or a 2-tuple
+    `(df, sd_updates)` where sd_updates is a partial SDType
+    ({col: {key: value}}) to be merged into cleaning_sd. The 2-tuple form
+    lets a Command thread styling-relevant metadata (e.g. a search term
+    that becomes a highlight phrase downstream) without round-tripping
+    through the df."""
+
+    @staticmethod
     def transform(df, col, val):
         return df.with_columns(pl.col(col).fill_null(val))
         return df
 
-    @staticmethod 
+    @staticmethod
     def transform_to_py(df, col, val):
         return "    df = df.with_columns(pl.col('%s').fill_null(%r))" % (col, val)
 
@@ -129,11 +136,11 @@ class Search(Command):
     command_pattern = [[3, 'term', 'type', 'string']]
     quick_args_pattern = [[3, 'term', 'type', 'string']]
 
-    @staticmethod 
+    @staticmethod
     def transform(df, col, val):
         return df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
 
 
-    @staticmethod 
+    @staticmethod
     def transform_to_py(df, col, val):
         return f"    df = df.filter(pl.any_horizontal(pl.col(pl.String).str.contains('{val}')))"

--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -138,7 +138,14 @@ class Search(Command):
 
     @staticmethod
     def transform(df, col, val):
-        return df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
+        filtered = df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
+        if not val:
+            return filtered
+        # `.str.contains(val)` treats val as a regex, so we expose it as
+        # highlight_regex (not _phrase) for consistent semantics on the JS side.
+        string_cols = [c for c, dt in zip(df.columns, df.dtypes) if dt == pl.String]
+        sd_updates = {c: {'highlight_regex': val} for c in string_cols}
+        return filtered, sd_updates
 
 
     @staticmethod

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -100,6 +100,12 @@ class DefaultMainStyling(StylingAnalysis):
         else:
             disp = {'displayer': 'obj'}
             base_config['tooltip_config'] = {'tooltip_type':'simple', 'val_column': str(col)}
+        # Lowcode ops (e.g. Search) can contribute highlight metadata via the
+        # summary dict; the JS string displayer reads these from displayer_args.
+        if disp.get('displayer') == 'string':
+            for k in ('highlight_phrase', 'highlight_regex', 'highlight_color'):
+                if k in column_metadata:
+                    disp[k] = column_metadata[k]
         base_config['displayer_args'] = disp
 
         # Compute content-aware minWidth

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -69,8 +69,10 @@ class DefaultMainStyling(StylingAnalysis):
     @classmethod
     def style_column(kls, col:str, column_metadata: Any) -> Any:
         #print(col, list(sd.keys()))
-        if len(column_metadata.keys()) == 0:
-            #I'm still having problems with index and polars
+        # `_type` is the discriminator for displayer choice. If it's absent
+        # (e.g. a transient sd entry contributed by a lowcode op before the
+        # summary stats land), fall back to obj rather than KeyError-ing.
+        if len(column_metadata.keys()) == 0 or '_type' not in column_metadata:
             return {'col_name':col, 'displayer_args': {'displayer': 'obj'}}
 
         digits = 3

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -199,6 +199,12 @@ class PandasAutocleaning:
 
 
         cleaned_df = self._run_df_interpreter(df, final_ops)
+        # Transforms that return (df, sd_updates) get their sd_updates collected
+        # by the interpreter wrapper; pull them out and merge into cleaning_sd.
+        op_sd_updates = getattr(self.df_interpreter, 'get_last_sd_updates', lambda: {})()
+        if op_sd_updates:
+            from .styling_core import merge_sds
+            cleaning_sd = merge_sds(cleaning_sd, op_sd_updates)
         merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
         generated_code = self._run_code_generator(final_ops)
         return [merged_cleaned_df, cleaning_sd, generated_code, final_ops]

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -199,13 +199,20 @@ class PandasAutocleaning:
 
 
         cleaned_df = self._run_df_interpreter(df, final_ops)
+        merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
         # Transforms that return (df, sd_updates) get their sd_updates collected
-        # by the interpreter wrapper; pull them out and merge into cleaning_sd.
+        # by the interpreter wrapper. Apply them *after* make_origs (which indexes
+        # cleaned_df by original column names) — and rewrite keys onto buckaroo's
+        # internal a/b/c names because the rest of the sd (summary_sd) is keyed
+        # that way; otherwise op contributions sit as orphans without a `_type`
+        # and trip the styling fallback.
         op_sd_updates = getattr(self.df_interpreter, 'get_last_sd_updates', lambda: {})()
         if op_sd_updates:
             from .styling_core import merge_sds
-            cleaning_sd = merge_sds(cleaning_sd, op_sd_updates)
-        merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
+            from ..df_util import old_col_new_col
+            rewrites = dict(old_col_new_col(cleaned_df))
+            renamed = {rewrites.get(col, col): kv for col, kv in op_sd_updates.items()}
+            cleaning_sd = merge_sds(cleaning_sd, renamed)
         generated_code = self._run_code_generator(final_ops)
         return [merged_cleaned_df, cleaning_sd, generated_code, final_ops]
 

--- a/buckaroo/jlisp/configure_utils.py
+++ b/buckaroo/jlisp/configure_utils.py
@@ -4,6 +4,22 @@ def configure_buckaroo(transforms):
     command_defaults = {}
     command_patterns = {}
 
+    # Accumulates sd_updates from transforms that return (df, sd_updates).
+    # Reset on each buckaroo_transform call; readable afterwards via
+    # buckaroo_transform.get_last_sd_updates().
+    sd_accumulator = {}
+
+    def _wrap_transform(orig):
+        def wrapped(*args, **kwargs):
+            result = orig(*args, **kwargs)
+            if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], dict):
+                df, sd_updates = result
+                for col, kv in sd_updates.items():
+                    sd_accumulator.setdefault(col, {}).update(kv)
+                return df
+            return result
+        return wrapped
+
     transform_lisp_primitives = {}
     to_py_lisp_primitives = {}
     for T in transforms:
@@ -11,18 +27,25 @@ def configure_buckaroo(transforms):
         transform_name = t.command_default[0]['symbol']
         command_defaults[transform_name] = t.command_default
         command_patterns[transform_name] = t.command_pattern
-        transform_lisp_primitives[transform_name] = T.transform
+        transform_lisp_primitives[transform_name] = _wrap_transform(T.transform)
         to_py_lisp_primitives[transform_name] = T.transform_to_py
-    
+
     buckaroo_eval, raw_parse = make_interpreter(transform_lisp_primitives)
 
     def buckaroo_transform(instructions, df):
+        sd_accumulator.clear()
         if isinstance(df, pd.DataFrame):
             df_copy = df.copy()
         else: # hack we know it's polars here... just getting something working for now
             df_copy = df.clone()
         ret_val =  buckaroo_eval(instructions, {'df':df_copy})
         return ret_val
+
+    def get_last_sd_updates():
+        # Snapshot — callers should not mutate the live accumulator.
+        return {col: dict(kv) for col, kv in sd_accumulator.items()}
+
+    buckaroo_transform.get_last_sd_updates = get_last_sd_updates
 
     convert_to_python, __unused = make_interpreter(to_py_lisp_primitives)
     def buckaroo_to_py(instructions):

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -6,8 +6,9 @@ from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
 from buckaroo.dataflow.autocleaning import merge_ops, format_ops, AutocleaningConfig
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
-    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp
+    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search
 )
+from buckaroo.customizations.styling import DefaultMainStyling
 from buckaroo.jlisp.lisp_utils import s
 
 

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -202,6 +202,50 @@ def test_transform_can_return_sd_updates_via_2tuple():
     assert cleaning_sd.get('a', {}).get('note') == 'hello'
 
 
+class SearchConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = []
+    command_klasses = [Search]
+    name = ""
+
+
+def test_search_threads_highlight_regex_into_cleaning_sd_under_rename():
+    """Search plumbs its search term into cleaning_sd as highlight_regex on
+    every polars-String column. The rest of the sd is keyed by buckaroo's
+    internal a/b/c names, so autocleaning rewrites the op-supplied keys to
+    match — otherwise the entries would sit alongside as orphans without
+    a `_type` and trip the styling fallback."""
+    ac = PolarsAutocleaning([SearchConf])
+    # 'businessname' becomes 'a', 'rating' becomes 'b' under buckaroo renaming.
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi'], 'rating': [5, 4]})
+    search_op = [{'symbol': 'search'}, s('df'), 'col', 'pizza']
+
+    _cleaned, cleaning_sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=[search_op])
+
+    # keyed by the *renamed* col, not by 'businessname'
+    assert cleaning_sd.get('a', {}).get('highlight_regex') == 'pizza'
+    assert 'businessname' not in cleaning_sd
+    # non-string column ('b' / 'rating') must not receive the highlight
+    assert 'highlight_regex' not in cleaning_sd.get('b', {})
+
+
+def test_default_main_styling_emits_highlight_regex_into_displayer_args():
+    """style_column copies highlight_regex out of col_meta and into the
+    string displayer_args, where the JS-side displayer reads it."""
+    col_meta = {'_type': 'string', 'highlight_regex': 'pizza', 'orig_col_name': 'a'}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert cc['displayer_args']['displayer'] == 'string'
+    assert cc['displayer_args']['highlight_regex'] == 'pizza'
+
+
+def test_style_column_handles_col_meta_missing_type():
+    """A col_meta lacking `_type` (e.g. a stray sd entry contributed by an
+    op when the matching summary-stats entry is keyed differently) should
+    fall back to obj rather than KeyError."""
+    cc = DefaultMainStyling.style_column('whatever', {'highlight_regex': 'x'})
+    assert cc['displayer_args']['displayer'] == 'obj'
+
+
 def test_autoclean_codegen():
     ac = PolarsAutocleaning([ACConf, NoCleaning])
     df = pl.DataFrame({'a': ["30", "40"]})

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -6,8 +6,9 @@ from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
 from buckaroo.dataflow.autocleaning import merge_ops, format_ops, AutocleaningConfig
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
-    PlSafeInt, DropCol, FillNA, GroupBy, NoOp
+    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp
 )
+from buckaroo.jlisp.lisp_utils import s
 
 
 dirty_df = pl.DataFrame(
@@ -167,6 +168,39 @@ def test_handle_clean_df():
 EXPECTED_GEN_CODE = """def clean(df):
     df = df.with_columns(pl.col('a').cast(pl.Int64, strict=False))
     return df"""
+
+class TaggingCommand(Command):
+    """A Command whose transform returns the 2-tuple (df, sd_updates)."""
+    command_default = [s('tag'), s('df'), 'col', '']
+    command_pattern = [[3, 'tag', 'type', 'string']]
+
+    @staticmethod
+    def transform(df, col, val):
+        return df, {col: {'note': val}}
+
+    @staticmethod
+    def transform_to_py(df, col, val):
+        return "    # tag"
+
+
+class TagConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = []
+    command_klasses = [TaggingCommand]
+    name = ""
+
+
+def test_transform_can_return_sd_updates_via_2tuple():
+    """A Command's transform may return (df, sd_updates); the interpreter
+    accumulates sd_updates and autocleaning merges them into cleaning_sd."""
+    ac = PolarsAutocleaning([TagConf])
+    df = pl.DataFrame({'a': [1, 2, 3]})
+    op = [{'symbol': 'tag'}, s('df'), 'a', 'hello']
+
+    _df, cleaning_sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=[op])
+
+    assert cleaning_sd.get('a', {}).get('note') == 'hello'
+
 
 def test_autoclean_codegen():
     ac = PolarsAutocleaning([ACConf, NoCleaning])

--- a/tests/unit/dataflow/dataflow_polars_test.py
+++ b/tests/unit/dataflow/dataflow_polars_test.py
@@ -1,7 +1,8 @@
 from buckaroo.dataflow.dataflow import StylingAnalysis
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
-from buckaroo.polars_buckaroo import PolarsBuckarooWidget
-import polars as pl 
+from buckaroo.polars_buckaroo import PolarsBuckarooWidget, PolarsBuckarooInfiniteWidget
+from buckaroo.jlisp.lisp_utils import s
+import polars as pl
 from polars.testing import assert_frame_equal
 
 
@@ -243,3 +244,64 @@ def test_column_config_override():
     int_cc_after = cc_after[0]
     assert int_cc_after['col_name'] == 'a' #make sure we found the right row
     assert int_cc_after['header_name'] == 'int_col' #make sure we found the right row
+
+
+def _find_cc(column_config, col_name):
+    for entry in column_config:
+        if entry.get('col_name') == col_name:
+            return entry
+    raise AssertionError(f"col_name {col_name!r} not in column_config")
+
+
+def test_search_op_delivers_highlight_regex_into_displayer_args():
+    """End-to-end: a `search` operation on the widget should plumb its
+    search term into `displayer_args.highlight_regex` for every polars-String
+    column in the final df_viewer_config that gets sent to the JS side."""
+    df = pl.DataFrame({
+        'businessname': ['pizza', 'sushi', 'taco'],
+        'comments': ['area code', 'no match', 'area zone'],
+        'rating': [5, 4, 3],
+    })
+    w = PolarsBuckarooInfiniteWidget(df)
+    w.dataflow.operations = [[{'symbol': 'search'}, s('df'), 'col', 'area']]
+
+    cc = w.df_display_args['main']['df_viewer_config']['column_config']
+    # 'a' is businessname (string) -- gets highlighted
+    a_args = _find_cc(cc, 'a')['displayer_args']
+    assert a_args['displayer'] == 'string'
+    assert a_args['highlight_regex'] == 'area'
+    # 'b' is comments (string) -- gets highlighted
+    b_args = _find_cc(cc, 'b')['displayer_args']
+    assert b_args['displayer'] == 'string'
+    assert b_args['highlight_regex'] == 'area'
+    # 'c' is rating (integer) -- no highlight (highlight only applies to string displayer)
+    c_args = _find_cc(cc, 'c')['displayer_args']
+    assert 'highlight_regex' not in c_args
+
+
+def test_column_config_overrides_preserves_highlight_phrase_and_color():
+    """End-to-end: a user-supplied column_config_overrides carrying
+    highlight_phrase + highlight_color should survive the merge_column_config
+    step and land in the final displayer_args."""
+    df = pl.DataFrame({
+        'businessname': ['pizza', 'sushi'],
+        'comments': ['area code', 'no match'],
+    })
+    overrides = {
+        'comments': {
+            'displayer_args': {
+                'displayer': 'string',
+                'max_length': 2000,
+                'highlight_phrase': ['area'],
+                'highlight_color': 'red',
+            },
+        },
+    }
+    w = PolarsBuckarooInfiniteWidget(df, column_config_overrides=overrides)
+
+    cc = w.df_display_args['main']['df_viewer_config']['column_config']
+    b_args = _find_cc(cc, 'b')['displayer_args']
+    assert b_args['displayer'] == 'string'
+    assert b_args['max_length'] == 2000
+    assert b_args['highlight_phrase'] == ['area']
+    assert b_args['highlight_color'] == 'red'

--- a/tests/unit/dataflow/dataflow_polars_test.py
+++ b/tests/unit/dataflow/dataflow_polars_test.py
@@ -257,11 +257,8 @@ def test_search_op_delivers_highlight_regex_into_displayer_args():
     """End-to-end: a `search` operation on the widget should plumb its
     search term into `displayer_args.highlight_regex` for every polars-String
     column in the final df_viewer_config that gets sent to the JS side."""
-    df = pl.DataFrame({
-        'businessname': ['pizza', 'sushi', 'taco'],
-        'comments': ['area code', 'no match', 'area zone'],
-        'rating': [5, 4, 3],
-    })
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi', 'taco'], 'comments': ['area code', 'no match', 'area zone'],
+        'rating': [5, 4, 3]})
     w = PolarsBuckarooInfiniteWidget(df)
     w.dataflow.operations = [[{'symbol': 'search'}, s('df'), 'col', 'area']]
 
@@ -283,20 +280,9 @@ def test_column_config_overrides_preserves_highlight_phrase_and_color():
     """End-to-end: a user-supplied column_config_overrides carrying
     highlight_phrase + highlight_color should survive the merge_column_config
     step and land in the final displayer_args."""
-    df = pl.DataFrame({
-        'businessname': ['pizza', 'sushi'],
-        'comments': ['area code', 'no match'],
-    })
-    overrides = {
-        'comments': {
-            'displayer_args': {
-                'displayer': 'string',
-                'max_length': 2000,
-                'highlight_phrase': ['area'],
-                'highlight_color': 'red',
-            },
-        },
-    }
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi'], 'comments': ['area code', 'no match']})
+    overrides = {'comments': {'displayer_args': {'displayer': 'string', 'max_length': 2000,
+        'highlight_phrase': ['area'], 'highlight_color': 'red'}}}
     w = PolarsBuckarooInfiniteWidget(df, column_config_overrides=overrides)
 
     cc = w.df_display_args['main']['df_viewer_config']['column_config']


### PR DESCRIPTION
## Summary

Polars `Search.transform` now returns `(filtered_df, sd_updates)` so the search term flows into `cleaning_sd` as `highlight_regex` on every polars-String column. `DefaultMainStyling.style_column` reads `highlight_phrase` / `highlight_regex` / `highlight_color` off `col_meta` and threads them into the string `displayer_args`, where the JS side already renders matches as `<mark>`.

This is the first concrete consumer of the `(df, sd_updates)` 2-tuple transform contract from **#744**.

## Depends on

**#744** — the jlisp interpreter contract change must merge first. CI here will fail until that lands; after it does, this PR will rebase and the duplicate commit drops via patch-id.

## Pieces

- **`feat(jlisp)`** — temporarily included; drops on rebase after #744.
- **`fix: rename op-contributed sd keys + harden style_column against missing _type`** — autocleaning rewrites the op-supplied keys via `old_col_new_col(cleaned_df)` so they line up with buckaroo's internal a/b/c names; `style_column` falls back to obj when `_type` is absent.
- **`feat(polars-search): plumb search term to JS highlight via sd`** — the Search transform change + styling-layer extraction.
- **`test(polars): end-to-end highlight delivery into df_viewer_config`** — integration test asserting the full pipeline lands `highlight_regex` on the correct column in `df_viewer_config`.

## Test plan

- [x] `pytest tests/unit/dataflow/ tests/unit/commands/polars_command_test.py` — 117 pass
- [ ] CI green (after #744 merges + rebase)