### PR TITLE
chore(widget): batch — wrapText CSS, pinnedRowHeight knob, sample bump

### DIFF
--- a/buckaroo/polars_buckaroo.py
+++ b/buckaroo/polars_buckaroo.py
@@ -18,6 +18,7 @@ from .dataflow.widget_extension_utils import configure_buckaroo
 
 class PLSampling(Sampling):
     pre_limit = False
+    serialize_limit = 1_000_000
 
 local_analysis_klasses = list(PL_ANALYSIS_V2) + [DefaultSummaryStatsStyling, DefaultMainStyling]
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -374,8 +374,14 @@ export function DFViewerInfiniteInner({
             : { backgroundColor: themeConfig?.backgroundColor || "#ffffff", oddRowBackgroundColor: themeConfig?.oddRowBackgroundColor || '#f0f0f0' }),
     }), [resolvedScheme, themeConfig]);
     const gridOptions: GridOptions = useMemo( () => {
+        // pinnedRowHeight is a buckaroo-only knob (not a real AG-Grid option); synthesize getRowHeight from it.
+        const pinnedRowHeight = (df_viewer_config.extra_grid_config as any)?.pinnedRowHeight;
+        const getRowHeight = pinnedRowHeight !== undefined
+            ? (params: any) => params.node.rowPinned ? pinnedRowHeight : null
+            : undefined;
         return {
         ...outerGridOptions(setActiveCol, df_viewer_config.extra_grid_config),
+        ...(getRowHeight ? { getRowHeight } : {}),
         domLayout:  hs.domLayout,
         autoSizeStrategy: df_viewer_config.extra_grid_config?.autoSizeStrategy || getAutoSize(styledColumns.length),
         onFirstDataRendered: (_params) => {

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -379,6 +379,11 @@ div.dependent-tabs ul.tabs li.active {
     font-family: monospace;
     white-space: pre;
 }
+/* AG-Grid adds .ag-cell-wrap-text when wrapText: true is set on a column;
+   defer to its wrapping rules instead of the global `white-space: pre`. */
+.ag-row .ag-cell.ag-cell-wrap-text {
+    white-space: normal;
+}
 .left-menu {
     color:black;
 }


### PR DESCRIPTION
## Summary

Three small independent polish changes, batched.

### 1. `fix(js-core): defer to AG-Grid's wrapText class on cell white-space`

The widget's global cell CSS forced `white-space: nowrap`, which overrode AG-Grid's built-in `wrapText: true` colDef behavior. Drop the rule on the wrap-text class so wrapping works when an embedder sets `wrapText` in `ag_grid_specs`.

### 2. `feat(js-core): pinnedRowHeight knob for separate pinned-row heights`

Pinned rows (dtype labels, histograms, summary stats) previously inherited the main row height. New `pinnedRowHeight` knob on the grid options lets embedders set them independently — useful when the main row needs to stay tight but pinned rows want vertical breathing room for the histogram cells.

### 3. `chore(polars): bump PLSampling.serialize_limit to 1_000_000`

Old limit was 100k rows. Bumping to 1M better matches what users actually load into the standalone server in practice; the IPC payload is still well under any sensible bandwidth ceiling.

## Test plan

- [x] `pnpm test` — 212 pass
- [x] `pytest tests/unit/serialization_utils_test.py` — 12 pass
- [ ] CI green