### PR TITLE
feat(styling): init_sd as augmentation channel (nested merge + delete_keys + demo)

### DIFF
--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -6,12 +6,19 @@ from ..jlisp.lisp_utils import s
 #from ..auto_clean.cleaning_commands import (to_bool, to_datetime, to_int, to_float, to_string)
 
 class Command(object):
-    @staticmethod 
+    """A Command's `transform` returns either the new df, or a 2-tuple
+    `(df, sd_updates)` where sd_updates is a partial SDType
+    ({col: {key: value}}) to be merged into cleaning_sd. The 2-tuple form
+    lets a Command thread styling-relevant metadata (e.g. a search term
+    that becomes a highlight phrase downstream) without round-tripping
+    through the df."""
+
+    @staticmethod
     def transform(df, col, val):
         return df.with_columns(pl.col(col).fill_null(val))
         return df
 
-    @staticmethod 
+    @staticmethod
     def transform_to_py(df, col, val):
         return "    df = df.with_columns(pl.col('%s').fill_null(%r))" % (col, val)
 
@@ -129,11 +136,11 @@ class Search(Command):
     command_pattern = [[3, 'term', 'type', 'string']]
     quick_args_pattern = [[3, 'term', 'type', 'string']]
 
-    @staticmethod 
+    @staticmethod
     def transform(df, col, val):
         return df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
 
 
-    @staticmethod 
+    @staticmethod
     def transform_to_py(df, col, val):
         return f"    df = df.filter(pl.any_horizontal(pl.col(pl.String).str.contains('{val}')))"

--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -138,7 +138,14 @@ class Search(Command):
 
     @staticmethod
     def transform(df, col, val):
-        return df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
+        filtered = df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
+        if not val:
+            return filtered
+        # `.str.contains(val)` treats val as a regex, so we expose it as
+        # highlight_regex (not _phrase) for consistent semantics on the JS side.
+        string_cols = [c for c, dt in zip(df.columns, df.dtypes) if dt == pl.String]
+        sd_updates = {c: {'highlight_regex': val} for c in string_cols}
+        return filtered, sd_updates
 
 
     @staticmethod

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -129,6 +129,12 @@ class DefaultMainStyling(StylingAnalysis):
         if 'ag_grid_specs' in column_metadata:
             base_config['ag_grid_specs'].update(column_metadata['ag_grid_specs'])
 
+        # init_sd's delete_keys drops top-level keys that style_column added
+        # by default — e.g. the tooltip_config that string / time / binary /
+        # categorical / fallback branches unconditionally attach.
+        for k in column_metadata.get('delete_keys', ()):
+            base_config.pop(k, None)
+
         return base_config
 
 

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -100,12 +100,20 @@ class DefaultMainStyling(StylingAnalysis):
         else:
             disp = {'displayer': 'obj'}
             base_config['tooltip_config'] = {'tooltip_type':'simple', 'val_column': str(col)}
-        # Lowcode ops (e.g. Search) can contribute highlight metadata via the
-        # summary dict; the JS string displayer reads these from displayer_args.
+        # Lowcode ops (e.g. Search) contribute highlight metadata as flat
+        # top-level keys on column_metadata; the JS string displayer reads
+        # them from displayer_args.
         if disp.get('displayer') == 'string':
             for k in ('highlight_phrase', 'highlight_regex', 'highlight_color'):
                 if k in column_metadata:
                     disp[k] = column_metadata[k]
+        # init_sd users may pass the same nested shape they'd use in
+        # column_config_overrides — e.g. {'comments': {'displayer_args':
+        # {'max_length': 2000}}}. Shallow-merge that into disp so init_sd
+        # augments (rather than replaces) styling's computed displayer_args
+        # AND coexists with op-supplied highlights. Caller wins per-key.
+        if isinstance(column_metadata.get('displayer_args'), dict):
+            disp.update(column_metadata['displayer_args'])
         base_config['displayer_args'] = disp
 
         # Compute content-aware minWidth
@@ -115,6 +123,11 @@ class DefaultMainStyling(StylingAnalysis):
             for pr in kls.pinned_rows)
         min_w = estimate_min_width_px(disp, header_name, column_metadata, has_histogram)
         base_config['ag_grid_specs'] = {'minWidth': min_w}
+        # ag_grid_specs from column_metadata (e.g. init_sd carrying
+        # {'wrapText': True, 'width': 400}) overlay on top of styling's
+        # computed minWidth. Shallow merge — caller wins per-key.
+        if 'ag_grid_specs' in column_metadata:
+            base_config['ag_grid_specs'].update(column_metadata['ag_grid_specs'])
 
         return base_config
 

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -100,6 +100,12 @@ class DefaultMainStyling(StylingAnalysis):
         else:
             disp = {'displayer': 'obj'}
             base_config['tooltip_config'] = {'tooltip_type':'simple', 'val_column': str(col)}
+        # Lowcode ops (e.g. Search) can contribute highlight metadata via the
+        # summary dict; the JS string displayer reads these from displayer_args.
+        if disp.get('displayer') == 'string':
+            for k in ('highlight_phrase', 'highlight_regex', 'highlight_color'):
+                if k in column_metadata:
+                    disp[k] = column_metadata[k]
         base_config['displayer_args'] = disp
 
         # Compute content-aware minWidth

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -69,8 +69,10 @@ class DefaultMainStyling(StylingAnalysis):
     @classmethod
     def style_column(kls, col:str, column_metadata: Any) -> Any:
         #print(col, list(sd.keys()))
-        if len(column_metadata.keys()) == 0:
-            #I'm still having problems with index and polars
+        # `_type` is the discriminator for displayer choice. If it's absent
+        # (e.g. a transient sd entry contributed by a lowcode op before the
+        # summary stats land), fall back to obj rather than KeyError-ing.
+        if len(column_metadata.keys()) == 0 or '_type' not in column_metadata:
             return {'col_name':col, 'displayer_args': {'displayer': 'obj'}}
 
         digits = 3

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -199,6 +199,12 @@ class PandasAutocleaning:
 
 
         cleaned_df = self._run_df_interpreter(df, final_ops)
+        # Transforms that return (df, sd_updates) get their sd_updates collected
+        # by the interpreter wrapper; pull them out and merge into cleaning_sd.
+        op_sd_updates = getattr(self.df_interpreter, 'get_last_sd_updates', lambda: {})()
+        if op_sd_updates:
+            from .styling_core import merge_sds
+            cleaning_sd = merge_sds(cleaning_sd, op_sd_updates)
         merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
         generated_code = self._run_code_generator(final_ops)
         return [merged_cleaned_df, cleaning_sd, generated_code, final_ops]

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -199,13 +199,20 @@ class PandasAutocleaning:
 
 
         cleaned_df = self._run_df_interpreter(df, final_ops)
+        merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
         # Transforms that return (df, sd_updates) get their sd_updates collected
-        # by the interpreter wrapper; pull them out and merge into cleaning_sd.
+        # by the interpreter wrapper. Apply them *after* make_origs (which indexes
+        # cleaned_df by original column names) — and rewrite keys onto buckaroo's
+        # internal a/b/c names because the rest of the sd (summary_sd) is keyed
+        # that way; otherwise op contributions sit as orphans without a `_type`
+        # and trip the styling fallback.
         op_sd_updates = getattr(self.df_interpreter, 'get_last_sd_updates', lambda: {})()
         if op_sd_updates:
             from .styling_core import merge_sds
-            cleaning_sd = merge_sds(cleaning_sd, op_sd_updates)
-        merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
+            from ..df_util import old_col_new_col
+            rewrites = dict(old_col_new_col(cleaned_df))
+            renamed = {rewrites.get(col, col): kv for col, kv in op_sd_updates.items()}
+            cleaning_sd = merge_sds(cleaning_sd, renamed)
         generated_code = self._run_code_generator(final_ops)
         return [merged_cleaned_df, cleaning_sd, generated_code, final_ops]
 

--- a/buckaroo/jlisp/configure_utils.py
+++ b/buckaroo/jlisp/configure_utils.py
@@ -4,6 +4,22 @@ def configure_buckaroo(transforms):
     command_defaults = {}
     command_patterns = {}
 
+    # Accumulates sd_updates from transforms that return (df, sd_updates).
+    # Reset on each buckaroo_transform call; readable afterwards via
+    # buckaroo_transform.get_last_sd_updates().
+    sd_accumulator = {}
+
+    def _wrap_transform(orig):
+        def wrapped(*args, **kwargs):
+            result = orig(*args, **kwargs)
+            if isinstance(result, tuple) and len(result) == 2 and isinstance(result[1], dict):
+                df, sd_updates = result
+                for col, kv in sd_updates.items():
+                    sd_accumulator.setdefault(col, {}).update(kv)
+                return df
+            return result
+        return wrapped
+
     transform_lisp_primitives = {}
     to_py_lisp_primitives = {}
     for T in transforms:
@@ -11,18 +27,25 @@ def configure_buckaroo(transforms):
         transform_name = t.command_default[0]['symbol']
         command_defaults[transform_name] = t.command_default
         command_patterns[transform_name] = t.command_pattern
-        transform_lisp_primitives[transform_name] = T.transform
+        transform_lisp_primitives[transform_name] = _wrap_transform(T.transform)
         to_py_lisp_primitives[transform_name] = T.transform_to_py
-    
+
     buckaroo_eval, raw_parse = make_interpreter(transform_lisp_primitives)
 
     def buckaroo_transform(instructions, df):
+        sd_accumulator.clear()
         if isinstance(df, pd.DataFrame):
             df_copy = df.copy()
         else: # hack we know it's polars here... just getting something working for now
             df_copy = df.clone()
         ret_val =  buckaroo_eval(instructions, {'df':df_copy})
         return ret_val
+
+    def get_last_sd_updates():
+        # Snapshot — callers should not mutate the live accumulator.
+        return {col: dict(kv) for col, kv in sd_accumulator.items()}
+
+    buckaroo_transform.get_last_sd_updates = get_last_sd_updates
 
     convert_to_python, __unused = make_interpreter(to_py_lisp_primitives)
     def buckaroo_to_py(instructions):

--- a/docs/example-notebooks/Restaurant-Complaints.ipynb
+++ b/docs/example-notebooks/Restaurant-Complaints.ipynb
@@ -18,11 +18,11 @@
    "id": "load",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T00:38:02.078349Z",
-     "iopub.status.busy": "2026-05-16T00:38:02.077859Z",
-     "iopub.status.idle": "2026-05-16T00:38:02.941895Z",
-     "shell.execute_reply": "2026-05-16T00:38:02.941597Z",
-     "shell.execute_reply.started": "2026-05-16T00:38:02.078309Z"
+     "iopub.execute_input": "2026-05-16T02:42:45.667300Z",
+     "iopub.status.busy": "2026-05-16T02:42:45.666822Z",
+     "iopub.status.idle": "2026-05-16T02:42:58.498437Z",
+     "shell.execute_reply": "2026-05-16T02:42:58.498074Z",
+     "shell.execute_reply.started": "2026-05-16T02:42:45.667265Z"
     }
    },
    "outputs": [
@@ -30,8 +30,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "It looks like you installed Buckaroo after you started this notebook server.\n",
+      "If you see a messages like\n",
+      "\"Failed to load model class 'DCEFWidgetModel' from module 'buckaroo'\" \n",
+      "restart the jupyter server and try again.\n",
+      "If you have furter errors, please file a bug report at https://github.com/paddymul/buckaroo\n",
+      "--------------------------------------------------------------------------------\n",
+      "buckaroo_mtime 2026-05-15 22:40:35.161550 server_start_time 2026-05-15 15:53:17.185019\n",
       "Buckaroo has been enabled as the default DataFrame viewer.  To return to default dataframe visualization use `from buckaroo import disable; disable()`\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e117d283ee544ec9b3efbe18d9eae588",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "<buckaroo.polars_buckaroo.PolarsBuckarooInfiniteWidget object at 0x118a1dfd0>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -43,7 +65,7 @@
     "front = ['businessname', 'comments', 'violation', 'violdesc']\n",
     "df = df.select(front + [c for c in df.columns if c not in front])\n",
     "\n",
-    "extra_grid_config = {'rowHeight': 105, 'pinnedRowHeight': 21}  # ~5 lines at the default ~21px line height\n",
+    "extra_grid_config = {'rowHeight': 70, 'pinnedRowHeight': 21}  # ~5 lines at the default ~21px line height\n",
     "column_config_overrides = {\n",
     "    'comments': {\n",
     "        'displayer_args': {'displayer': 'string', 'max_length': 5000,\n",
@@ -53,43 +75,27 @@
     "        'ag_grid_specs': {'wrapText': True, 'width':400, 'maxWidth':800},\n",
     "        'delete_keys': ['tooltip_config'],\n",
     "    },\n",
-    "}"
+    "}\n",
+    "df = df.filter(pl.col('viol_status') == 'Fail')\n",
+    "PolarsBuckarooInfiniteWidget( df, init_sd=column_config_overrides, extra_grid_config=extra_grid_config,\n",
+    "                              component_config = {'dfvHeight': 700})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "id": "9271f421-eee6-43b9-990f-e49e44c99a80",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0e9f75d2-4969-42b2-be87-1817a7ddcb05",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-16T00:38:03.008161Z",
-     "iopub.status.busy": "2026-05-16T00:38:03.007913Z",
-     "iopub.status.idle": "2026-05-16T00:38:03.139186Z",
-     "shell.execute_reply": "2026-05-16T00:38:03.138925Z",
-     "shell.execute_reply.started": "2026-05-16T00:38:03.008149Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "de8aab6505d04227ae813a187d2bc779",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "PolarsBuckarooInfiniteWidget(buckaroo_options={'sampled': ['random'], 'auto_clean': ['aggressive', 'conservati…"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "PolarsBuckarooInfiniteWidget(df, init_sd=column_config_overrides, extra_grid_config=extra_grid_config,\n",
-    "                              component_config = {'dfvHeight': 900})"
-   ]
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/docs/example-notebooks/Restaurant-Complaints.ipynb
+++ b/docs/example-notebooks/Restaurant-Complaints.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Restaurant Complaints\n",
+    "\n",
+    "Open `/Users/paddy/buckaroo/restaurant-complaints.parquet`, reorder columns as `[businessname, comments, violation, violdesc, ...rest]`, give `comments` a long `max_length`, and use a 5-line-tall row height with `wrapText` so long comments wrap inside the cell.\n",
+    "\n",
+    "Note: the column in the parquet is `violdesc`, not `violationdesc`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "load",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T00:38:02.078349Z",
+     "iopub.status.busy": "2026-05-16T00:38:02.077859Z",
+     "iopub.status.idle": "2026-05-16T00:38:02.941895Z",
+     "shell.execute_reply": "2026-05-16T00:38:02.941597Z",
+     "shell.execute_reply.started": "2026-05-16T00:38:02.078309Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Buckaroo has been enabled as the default DataFrame viewer.  To return to default dataframe visualization use `from buckaroo import disable; disable()`\n"
+     ]
+    }
+   ],
+   "source": [
+    "import polars as pl\n",
+    "from buckaroo.polars_buckaroo import PolarsBuckarooInfiniteWidget\n",
+    "\n",
+    "df = pl.read_parquet('/Users/paddy/buckaroo/restaurant-complaints.parquet')\n",
+    "\n",
+    "front = ['businessname', 'comments', 'violation', 'violdesc']\n",
+    "df = df.select(front + [c for c in df.columns if c not in front])\n",
+    "\n",
+    "extra_grid_config = {'rowHeight': 105, 'pinnedRowHeight': 21}  # ~5 lines at the default ~21px line height\n",
+    "column_config_overrides = {\n",
+    "    'comments': {\n",
+    "        'displayer_args': {'displayer': 'string', 'max_length': 5000,\n",
+    "                           # 'highlight_color':'red',\n",
+    "                           # 'highlight_phrase':['area'],\n",
+    "                          },\n",
+    "        'ag_grid_specs': {'wrapText': True, 'width':400, 'maxWidth':800},\n",
+    "        'delete_keys': ['tooltip_config'],\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0e9f75d2-4969-42b2-be87-1817a7ddcb05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T00:38:03.008161Z",
+     "iopub.status.busy": "2026-05-16T00:38:03.007913Z",
+     "iopub.status.idle": "2026-05-16T00:38:03.139186Z",
+     "shell.execute_reply": "2026-05-16T00:38:03.138925Z",
+     "shell.execute_reply.started": "2026-05-16T00:38:03.008149Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de8aab6505d04227ae813a187d2bc779",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "PolarsBuckarooInfiniteWidget(buckaroo_options={'sampled': ['random'], 'auto_clean': ['aggressive', 'conservati…"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PolarsBuckarooInfiniteWidget(df, init_sd=column_config_overrides, extra_grid_config=extra_grid_config,\n",
+    "                              component_config = {'dfvHeight': 900})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a6811d0-13b7-48ef-bc25-f16924e361ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from buckaroo.buckaroo_widget import BuckarooWidget\n",
+    "\n",
+    "BuckarooWidget(\n",
+    "    df,\n",
+    "    column_config_overrides={\n",
+    "        'comments': {\n",
+    "            'displayer_args': {'displayer': 'string', 'max_length': 2000},\n",
+    "            'ag_grid_specs': {'wrapText': True},\n",
+    "        },\n",
+    "    },\n",
+    "    extra_grid_config={'rowHeight': 105},  # ~5 lines at the default ~21px line height\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "view",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from buckaroo.buckaroo_widget import BuckarooWidget\n",
+    "\n",
+    "BuckarooWidget(\n",
+    "    df,\n",
+    "    column_config_overrides={\n",
+    "        'comments': {\n",
+    "            'displayer_args': {'displayer': 'string', 'max_length': 2000},\n",
+    "            'ag_grid_specs': {'wrapText': True},\n",
+    "        },\n",
+    "    },\n",
+    "    extra_grid_config={'rowHeight': 105},  # ~5 lines at the default ~21px line height\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d5b2bbf-5765-41e1-b583-08f576101b6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = pq.read_table('/Users/paddy/buckaroo/restaurant-complaints.parquet')\n",
+    "\n",
+    "# pandas can't yet convert uint8-indexed dictionary columns, so decode them to plain strings first.\n",
+    "for i, field in enumerate(table.schema):\n",
+    "    if pa.types.is_dictionary(field.type):\n",
+    "        table = table.set_column(i, field.name, pc.cast(table.column(i), pa.large_string()))\n",
+    "\n",
+    "df = table.to_pandas()\n",
+    "\n",
+    "front = ['businessname', 'comments', 'violation', 'violdesc']\n",
+    "df = df[front + [c for c in df.columns if c not in front]]\n",
+    "df.shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -6,8 +6,9 @@ from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
 from buckaroo.dataflow.autocleaning import merge_ops, format_ops, AutocleaningConfig
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
-    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp
+    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search
 )
+from buckaroo.customizations.styling import DefaultMainStyling
 from buckaroo.jlisp.lisp_utils import s
 
 

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -202,6 +202,50 @@ def test_transform_can_return_sd_updates_via_2tuple():
     assert cleaning_sd.get('a', {}).get('note') == 'hello'
 
 
+class SearchConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = []
+    command_klasses = [Search]
+    name = ""
+
+
+def test_search_threads_highlight_regex_into_cleaning_sd_under_rename():
+    """Search plumbs its search term into cleaning_sd as highlight_regex on
+    every polars-String column. The rest of the sd is keyed by buckaroo's
+    internal a/b/c names, so autocleaning rewrites the op-supplied keys to
+    match — otherwise the entries would sit alongside as orphans without
+    a `_type` and trip the styling fallback."""
+    ac = PolarsAutocleaning([SearchConf])
+    # 'businessname' becomes 'a', 'rating' becomes 'b' under buckaroo renaming.
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi'], 'rating': [5, 4]})
+    search_op = [{'symbol': 'search'}, s('df'), 'col', 'pizza']
+
+    _cleaned, cleaning_sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=[search_op])
+
+    # keyed by the *renamed* col, not by 'businessname'
+    assert cleaning_sd.get('a', {}).get('highlight_regex') == 'pizza'
+    assert 'businessname' not in cleaning_sd
+    # non-string column ('b' / 'rating') must not receive the highlight
+    assert 'highlight_regex' not in cleaning_sd.get('b', {})
+
+
+def test_default_main_styling_emits_highlight_regex_into_displayer_args():
+    """style_column copies highlight_regex out of col_meta and into the
+    string displayer_args, where the JS-side displayer reads it."""
+    col_meta = {'_type': 'string', 'highlight_regex': 'pizza', 'orig_col_name': 'a'}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert cc['displayer_args']['displayer'] == 'string'
+    assert cc['displayer_args']['highlight_regex'] == 'pizza'
+
+
+def test_style_column_handles_col_meta_missing_type():
+    """A col_meta lacking `_type` (e.g. a stray sd entry contributed by an
+    op when the matching summary-stats entry is keyed differently) should
+    fall back to obj rather than KeyError."""
+    cc = DefaultMainStyling.style_column('whatever', {'highlight_regex': 'x'})
+    assert cc['displayer_args']['displayer'] == 'obj'
+
+
 def test_autoclean_codegen():
     ac = PolarsAutocleaning([ACConf, NoCleaning])
     df = pl.DataFrame({'a': ["30", "40"]})

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -284,6 +284,19 @@ def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
     assert cc['ag_grid_specs']['wrapText'] is True
 
 
+def test_style_column_delete_keys_drops_tooltip():
+    """init_sd's delete_keys lets a user drop top-level keys that style_column
+    adds by default. The motivating case: a string column where the user
+    doesn't want a tooltip permanently attached to the cell."""
+    col_meta = {'_type': 'string', 'orig_col_name': 'comments',
+                'delete_keys': ['tooltip_config']}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert 'tooltip_config' not in cc
+    # Other styled keys unaffected
+    assert cc['displayer_args']['displayer'] == 'string'
+    assert 'minWidth' in cc['ag_grid_specs']
+
+
 def test_autoclean_codegen():
     ac = PolarsAutocleaning([ACConf, NoCleaning])
     df = pl.DataFrame({'a': ["30", "40"]})

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -247,6 +247,43 @@ def test_style_column_handles_col_meta_missing_type():
     assert cc['displayer_args']['displayer'] == 'obj'
 
 
+def test_style_column_merges_nested_displayer_args_and_ag_grid_specs():
+    """init_sd entries use the same nested shape as column_config_overrides
+    — {'displayer_args': {...}, 'ag_grid_specs': {...}} — but unlike
+    overrides, the merge here is shallow-per-bag (caller wins per-key)
+    rather than replace-the-bag. That's the whole point: max_length=2000
+    overrides styling's 35, wrapText/width overlay on minWidth, and any
+    other styled keys (e.g. highlight_regex) survive."""
+    col_meta = {'_type': 'string', 'orig_col_name': 'comments',
+                'displayer_args': {'displayer': 'string', 'max_length': 2000},
+                'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 400}}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert cc['displayer_args']['max_length'] == 2000
+    assert cc['ag_grid_specs']['wrapText'] is True
+    assert cc['ag_grid_specs']['width'] == 400
+    assert cc['ag_grid_specs']['maxWidth'] == 400
+    # styling's computed minWidth is still present unless caller overrode it
+    assert 'minWidth' in cc['ag_grid_specs']
+
+
+def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
+    """The whole point of routing per-column augmentations through init_sd
+    instead of column_config_overrides: init_sd's nested displayer_args and
+    a Search op's flat highlight_regex both land in merged_sd, and both
+    make it into the final displayer_args. column_config_overrides would
+    have clobbered the highlight by replacing displayer_args wholesale."""
+    from buckaroo.dataflow.styling_core import merge_sds
+    init_sd = {'a': {'_type': 'string', 'orig_col_name': 'comments',
+                     'displayer_args': {'displayer': 'string', 'max_length': 2000},
+                     'ag_grid_specs': {'wrapText': True}}}
+    search_contribution = {'a': {'highlight_regex': 'pizza'}}
+    merged = merge_sds(init_sd, search_contribution)
+    cc = DefaultMainStyling.style_column('a', merged['a'])
+    assert cc['displayer_args']['max_length'] == 2000
+    assert cc['displayer_args']['highlight_regex'] == 'pizza'
+    assert cc['ag_grid_specs']['wrapText'] is True
+
+
 def test_autoclean_codegen():
     ac = PolarsAutocleaning([ACConf, NoCleaning])
     df = pl.DataFrame({'a': ["30", "40"]})

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -6,8 +6,9 @@ from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
 from buckaroo.dataflow.autocleaning import merge_ops, format_ops, AutocleaningConfig
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
-    PlSafeInt, DropCol, FillNA, GroupBy, NoOp
+    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp
 )
+from buckaroo.jlisp.lisp_utils import s
 
 
 dirty_df = pl.DataFrame(
@@ -167,6 +168,39 @@ def test_handle_clean_df():
 EXPECTED_GEN_CODE = """def clean(df):
     df = df.with_columns(pl.col('a').cast(pl.Int64, strict=False))
     return df"""
+
+class TaggingCommand(Command):
+    """A Command whose transform returns the 2-tuple (df, sd_updates)."""
+    command_default = [s('tag'), s('df'), 'col', '']
+    command_pattern = [[3, 'tag', 'type', 'string']]
+
+    @staticmethod
+    def transform(df, col, val):
+        return df, {col: {'note': val}}
+
+    @staticmethod
+    def transform_to_py(df, col, val):
+        return "    # tag"
+
+
+class TagConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = []
+    command_klasses = [TaggingCommand]
+    name = ""
+
+
+def test_transform_can_return_sd_updates_via_2tuple():
+    """A Command's transform may return (df, sd_updates); the interpreter
+    accumulates sd_updates and autocleaning merges them into cleaning_sd."""
+    ac = PolarsAutocleaning([TagConf])
+    df = pl.DataFrame({'a': [1, 2, 3]})
+    op = [{'symbol': 'tag'}, s('df'), 'a', 'hello']
+
+    _df, cleaning_sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=[op])
+
+    assert cleaning_sd.get('a', {}).get('note') == 'hello'
+
 
 def test_autoclean_codegen():
     ac = PolarsAutocleaning([ACConf, NoCleaning])

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -255,8 +255,8 @@ def test_style_column_merges_nested_displayer_args_and_ag_grid_specs():
     overrides styling's 35, wrapText/width overlay on minWidth, and any
     other styled keys (e.g. highlight_regex) survive."""
     col_meta = {'_type': 'string', 'orig_col_name': 'comments',
-                'displayer_args': {'displayer': 'string', 'max_length': 2000},
-                'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 400}}
+        'displayer_args': {'displayer': 'string', 'max_length': 2000},
+        'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 400}}
     cc = DefaultMainStyling.style_column('a', col_meta)
     assert cc['displayer_args']['max_length'] == 2000
     assert cc['ag_grid_specs']['wrapText'] is True
@@ -274,8 +274,8 @@ def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
     have clobbered the highlight by replacing displayer_args wholesale."""
     from buckaroo.dataflow.styling_core import merge_sds
     init_sd = {'a': {'_type': 'string', 'orig_col_name': 'comments',
-                     'displayer_args': {'displayer': 'string', 'max_length': 2000},
-                     'ag_grid_specs': {'wrapText': True}}}
+        'displayer_args': {'displayer': 'string', 'max_length': 2000},
+        'ag_grid_specs': {'wrapText': True}}}
     search_contribution = {'a': {'highlight_regex': 'pizza'}}
     merged = merge_sds(init_sd, search_contribution)
     cc = DefaultMainStyling.style_column('a', merged['a'])
@@ -289,7 +289,7 @@ def test_style_column_delete_keys_drops_tooltip():
     adds by default. The motivating case: a string column where the user
     doesn't want a tooltip permanently attached to the cell."""
     col_meta = {'_type': 'string', 'orig_col_name': 'comments',
-                'delete_keys': ['tooltip_config']}
+        'delete_keys': ['tooltip_config']}
     cc = DefaultMainStyling.style_column('a', col_meta)
     assert 'tooltip_config' not in cc
     # Other styled keys unaffected

--- a/tests/unit/dataflow/dataflow_polars_test.py
+++ b/tests/unit/dataflow/dataflow_polars_test.py
@@ -1,7 +1,8 @@
 from buckaroo.dataflow.dataflow import StylingAnalysis
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
-from buckaroo.polars_buckaroo import PolarsBuckarooWidget
-import polars as pl 
+from buckaroo.polars_buckaroo import PolarsBuckarooWidget, PolarsBuckarooInfiniteWidget
+from buckaroo.jlisp.lisp_utils import s
+import polars as pl
 from polars.testing import assert_frame_equal
 
 
@@ -243,3 +244,64 @@ def test_column_config_override():
     int_cc_after = cc_after[0]
     assert int_cc_after['col_name'] == 'a' #make sure we found the right row
     assert int_cc_after['header_name'] == 'int_col' #make sure we found the right row
+
+
+def _find_cc(column_config, col_name):
+    for entry in column_config:
+        if entry.get('col_name') == col_name:
+            return entry
+    raise AssertionError(f"col_name {col_name!r} not in column_config")
+
+
+def test_search_op_delivers_highlight_regex_into_displayer_args():
+    """End-to-end: a `search` operation on the widget should plumb its
+    search term into `displayer_args.highlight_regex` for every polars-String
+    column in the final df_viewer_config that gets sent to the JS side."""
+    df = pl.DataFrame({
+        'businessname': ['pizza', 'sushi', 'taco'],
+        'comments': ['area code', 'no match', 'area zone'],
+        'rating': [5, 4, 3],
+    })
+    w = PolarsBuckarooInfiniteWidget(df)
+    w.dataflow.operations = [[{'symbol': 'search'}, s('df'), 'col', 'area']]
+
+    cc = w.df_display_args['main']['df_viewer_config']['column_config']
+    # 'a' is businessname (string) -- gets highlighted
+    a_args = _find_cc(cc, 'a')['displayer_args']
+    assert a_args['displayer'] == 'string'
+    assert a_args['highlight_regex'] == 'area'
+    # 'b' is comments (string) -- gets highlighted
+    b_args = _find_cc(cc, 'b')['displayer_args']
+    assert b_args['displayer'] == 'string'
+    assert b_args['highlight_regex'] == 'area'
+    # 'c' is rating (integer) -- no highlight (highlight only applies to string displayer)
+    c_args = _find_cc(cc, 'c')['displayer_args']
+    assert 'highlight_regex' not in c_args
+
+
+def test_column_config_overrides_preserves_highlight_phrase_and_color():
+    """End-to-end: a user-supplied column_config_overrides carrying
+    highlight_phrase + highlight_color should survive the merge_column_config
+    step and land in the final displayer_args."""
+    df = pl.DataFrame({
+        'businessname': ['pizza', 'sushi'],
+        'comments': ['area code', 'no match'],
+    })
+    overrides = {
+        'comments': {
+            'displayer_args': {
+                'displayer': 'string',
+                'max_length': 2000,
+                'highlight_phrase': ['area'],
+                'highlight_color': 'red',
+            },
+        },
+    }
+    w = PolarsBuckarooInfiniteWidget(df, column_config_overrides=overrides)
+
+    cc = w.df_display_args['main']['df_viewer_config']['column_config']
+    b_args = _find_cc(cc, 'b')['displayer_args']
+    assert b_args['displayer'] == 'string'
+    assert b_args['max_length'] == 2000
+    assert b_args['highlight_phrase'] == ['area']
+    assert b_args['highlight_color'] == 'red'

--- a/tests/unit/dataflow/dataflow_polars_test.py
+++ b/tests/unit/dataflow/dataflow_polars_test.py
@@ -257,11 +257,8 @@ def test_search_op_delivers_highlight_regex_into_displayer_args():
     """End-to-end: a `search` operation on the widget should plumb its
     search term into `displayer_args.highlight_regex` for every polars-String
     column in the final df_viewer_config that gets sent to the JS side."""
-    df = pl.DataFrame({
-        'businessname': ['pizza', 'sushi', 'taco'],
-        'comments': ['area code', 'no match', 'area zone'],
-        'rating': [5, 4, 3],
-    })
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi', 'taco'], 'comments': ['area code', 'no match', 'area zone'],
+        'rating': [5, 4, 3]})
     w = PolarsBuckarooInfiniteWidget(df)
     w.dataflow.operations = [[{'symbol': 'search'}, s('df'), 'col', 'area']]
 
@@ -283,20 +280,9 @@ def test_column_config_overrides_preserves_highlight_phrase_and_color():
     """End-to-end: a user-supplied column_config_overrides carrying
     highlight_phrase + highlight_color should survive the merge_column_config
     step and land in the final displayer_args."""
-    df = pl.DataFrame({
-        'businessname': ['pizza', 'sushi'],
-        'comments': ['area code', 'no match'],
-    })
-    overrides = {
-        'comments': {
-            'displayer_args': {
-                'displayer': 'string',
-                'max_length': 2000,
-                'highlight_phrase': ['area'],
-                'highlight_color': 'red',
-            },
-        },
-    }
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi'], 'comments': ['area code', 'no match']})
+    overrides = {'comments': {'displayer_args': {'displayer': 'string', 'max_length': 2000,
+        'highlight_phrase': ['area'], 'highlight_color': 'red'}}}
     w = PolarsBuckarooInfiniteWidget(df, column_config_overrides=overrides)
 
     cc = w.df_display_args['main']['df_viewer_config']['column_config']


### PR DESCRIPTION
## Summary

Turns `init_sd` into a proper augmentation channel for per-column display config — one that plays nice with lowcode ops (Search → highlight) instead of clobbering them like `column_config_overrides` does. Two style_column changes + a delete-keys escape hatch + a working demo notebook.

## Depends on

**#744** (jlisp 2-tuple transform contract) and **#745** (polars Search → highlight_regex via sd). The test `test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column` references Search's contribution shape; the notebook demo relies on the styling layer reading `highlight_*` from merged_sd.

After #744 and #745 merge, this PR will rebase and the duplicate commits drop via patch-id.

## Pieces

1. **`feat(styling): merge column_metadata displayer_args + ag_grid_specs`** — two shallow merges in `DefaultMainStyling.style_column`. When `column_metadata` carries `displayer_args` (e.g. `{'max_length': 5000}`) or `ag_grid_specs` (e.g. `{'wrapText': True, 'width': 400}`), they merge into the styled bag instead of replacing. Caller wins per-key. Critically, this lets a Search op's `highlight_regex` and a user's `max_length` coexist on the same column — `column_config_overrides`'s replace semantics would have clobbered the highlight.

2. **`feat(styling): init_sd delete_keys`** — `column_metadata.delete_keys: list[str]` pops the named top-level keys from the final `base_config`. Motivating case: drop the auto-attached `tooltip_config` on a string column the user doesn't want a permanent tooltip on, without subclassing the styling analysis. Operates on top-level only (tooltip_config, ag_grid_specs, displayer_args, col_name) — nested removal isn't needed for the motivating case.

3. **Restaurant-Complaints demo notebook** — working example combining `init_sd` (nested displayer_args + ag_grid_specs + delete_keys) with `extra_grid_config` (rowHeight, pinnedRowHeight) and a `viol_status == 'Fail'` filter on the polars Enum.

## Usage

```python
init_sd = {
    'comments': {
        'displayer_args': {'displayer': 'string', 'max_length': 5000},
        'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 800},
        'delete_keys': ['tooltip_config'],
    },
}
PolarsBuckarooInfiniteWidget(df, init_sd=init_sd, ...)
```

This shape is intentionally the same as `column_config_overrides` would take — but `init_sd` augments via `merge_sds` (each key wins per-call), while `column_config_overrides` replaces via shallow `row.update()`.

## Test plan

- [x] `pytest tests/unit/dataflow/` — 118 pass
- [x] `pnpm test` + `pnpm run build:tsc` — 212 pass, TS clean
- [x] Manual: Restaurant-Complaints.ipynb renders without tooltip on `comments` column, wraps long text, `max_length: 5000` honored
- [ ] CI green (after #744 + #745 merge + rebase)