### PR TITLE
fix(widget): register ScrollApiModule + scroll to row 0 after filter purge

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -24,6 +24,7 @@ import {
     RowSelectionModule,
     TooltipModule,
     TextFilterModule,
+    ScrollApiModule,
     SortChangedEvent,
     CellClassParams,
     RefreshCellsParams,
@@ -47,6 +48,7 @@ ModuleRegistry.registerModules([
     RowSelectionModule,
     TooltipModule,
     TextFilterModule,
+    ScrollApiModule,
 ]);
 
 const AccentColor = "#2196F3"
@@ -510,8 +512,13 @@ export function DFViewerInfiniteInner({
             try {
                 api.purgeInfiniteCache();
                 bkLog("outsideDFSig effect — purgeInfiniteCache called");
+                // Scroll back to row 0 — AG-Grid's infinite model doesn't
+                // auto-adjust scroll when row count drops, so a viewport
+                // sitting deep in the unfiltered df keeps requesting rows
+                // past the new filter's end and the user sees blank rows.
+                api.ensureIndexVisible(0, 'top');
             } catch (e) {
-                bkLog("outsideDFSig effect — purgeInfiniteCache threw", { error: String(e) });
+                bkLog("outsideDFSig effect — purge/scroll threw", { error: String(e) });
             }
         }, [outsideDFSig, data_wrapper.data_type]);
 


### PR DESCRIPTION
## Summary

Search keystroke shrinks the row count, but the viewport stays where it was — AG-Grid keeps requesting rows past the new end of the filtered df and the user sees blank rows until they scroll.

The fix is a single `api.ensureIndexVisible(0, 'top')` after `purgeInfiniteCache` in the `outsideDFSig` effect. AG-Grid v33 made the scroll API a separate module, so it also requires registering `ScrollApiModule` — without it the call throws AG-Grid error #200.

## Scope changes

This PR was originally a three-thing bundle (bk-flash tracing + ScrollApiModule + `debugger;` removal). The tracing and `debugger;` cleanup were extracted to #761; the polars Search guard, meta.quick_command filtering, mainDs/effectiveDataframeId fixes, and flash matrix tests all landed on main via #743 / #747 in the meantime. What's left here is just the ScrollApiModule fix.

## Test plan

- [x] `pnpm run build:tsc` clean
- [x] `pnpm test` — 233 pass
- [ ] Manual: filter the df, confirm the viewport snaps back to row 0 instead of showing blanks

🤖 Generated with [Claude Code](https://claude.com/claude-code)