### PR TITLE
ci: make Max-versions flakes reliable (timing slack + tolerant-wrapper relaxation)

### DIFF
--- a/scripts/run_pytest_tolerant.sh
+++ b/scripts/run_pytest_tolerant.sh
@@ -28,10 +28,13 @@
 #        a. The captured output shows a passing pytest summary.
 #        b. No `failed` / `error` lines appear in the summary.
 #        c. The captured output contains a known signature of the
-#           polars-stream / pyo3 shutdown race (the FATAL line plus a
-#           pyo3/polars-stream panic frame). Without this signature
-#           guard, an unrelated native crash producing exit 134 after a
-#           passing summary would silently get reported as success.
+#           polars-stream / pyo3 shutdown race — either the pyo3 FATAL
+#           line OR a Rust panic frame from pyo3/polars-stream. We've
+#           seen runs where the panic frame is lost from the captured
+#           output (process is racing SIGABRT against tee), so requiring
+#           both was too strict. Either one alone is still specific
+#           enough to rule out unrelated SIGABRTs (malloc corruption,
+#           other C-extension crashes) that produce neither string.
 #   3. Otherwise propagates the original exit code unchanged.
 #
 # Real failures (pytest exit 1, crashes before the summary, errored
@@ -51,13 +54,15 @@ trap 'rm -f "$LOG"' EXIT
 "$@" 2>&1 | tee "$LOG"
 status=${PIPESTATUS[0]}
 
-# Signature of the known polars-stream / pyo3 shutdown race. We require
-# both the FATAL marker AND a Rust panic frame from pyo3 OR polars-stream.
-# An unrelated SIGABRT (e.g. malloc corruption, a different C extension
-# crashing) would not produce these strings.
+# Signature of the known polars-stream / pyo3 shutdown race. Either the
+# pyo3 FATAL marker OR a Rust panic frame from pyo3/polars-stream is
+# sufficient — observed runs lose one or the other from captured output
+# depending on which fd flushes first before SIGABRT. An unrelated SIGABRT
+# (malloc corruption, a different C extension crashing) would produce
+# neither string.
 has_known_signature() {
     grep -qE "FATAL: exception not rethrown" "$LOG" \
-        && grep -qE "panicked at .*(pyo3|polars-stream|polars_stream)" "$LOG"
+        || grep -qE "panicked at .*(pyo3|polars-stream|polars_stream)" "$LOG"
 }
 
 if [ "$status" -eq 134 ] \
@@ -67,7 +72,7 @@ if [ "$status" -eq 134 ] \
    && has_known_signature; then
     echo ""
     echo "::warning::pytest exited 134 (SIGABRT) but the summary shows all tests passed"
-    echo "::warning::AND the polars-stream / pyo3 shutdown signature was present in output."
+    echo "::warning::AND a polars-stream / pyo3 shutdown signature was present in output."
     echo "::warning::Treating as success. See scripts/run_pytest_tolerant.sh for context."
     exit 0
 fi

--- a/tests/unit/widgets/test_lazy_widget_init_blocking.py
+++ b/tests/unit/widgets/test_lazy_widget_init_blocking.py
@@ -42,8 +42,11 @@ def test_lazy_widget_init_should_not_block_but_does_with_mp_and_slow_exec():
     )
     elapsed = time.time() - t0
 
-    # We want this to be fast if computations are backgrounded; set a tight bound that will fail now.
-    assert elapsed < 0.3, f"Widget init blocked for {elapsed:.2f}s; should compute stats in background"
+    # We want this to be fast if computations are backgrounded. SlowPAFColumnExecutor sleeps 1.0s
+    # per column group, so anything well below 1.0s still proves we are not blocking on it. A tighter
+    # 0.3s bound has flaked on the Max-versions matrix; 0.8s leaves CI-jitter slack while still
+    # catching real blocking.
+    assert elapsed < 0.8, f"Widget init blocked for {elapsed:.2f}s; should compute stats in background"
     #FIXME: this took 53 seconds, it's a really simple DF.  something with the column analytics is broken
     
 


### PR DESCRIPTION
## Summary
Two flake fixes that together make the Max-versions matrix reliable:

1. **`tests/unit/widgets/test_lazy_widget_init_blocking.py`** — widen `assert elapsed < 0.3` → `< 0.8`. The injected `SlowPAFColumnExecutor` sleeps 1.0s per column group, so any bound well under 1.0s still proves we are not blocking on it. 0.3s flaked at 0.37s on PR #747 Max 3.13.
2. **`scripts/run_pytest_tolerant.sh`** — change the polars/pyo3 shutdown signature gate from `FATAL AND panic-frame` to `FATAL OR panic-frame`. We've seen multiple runs (#743 Max 3.12, #747 Max 3.11, #752 Max 3.12) where SIGABRT races against \`tee\` and only one of the two strings makes it into captured output. The \"all tests passed + no failed/error\" guards remain, so this can't mask a real test failure.

## Test plan
- [ ] CI green on this branch — especially `Python / Test (Max Versions) (*)`.
- [ ] If a future run shows neither FATAL nor panic-frame in the log on a 134 exit, the wrapper will still propagate the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)