### PR TITLE
build: add tauri-essentials extra for buckaroo.server runtime deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,20 @@ xorq = [
     "xorq>=0.1.0 ; python_version < '3.14'",
 ]
 mcp = ["mcp", "tornado>=6.0", "polars"]
+
+# Runtime deps the buckaroo.server sidecar needs to start under the
+# buckaroo-tauri integration. NOT the Tauri shim itself (that lives at
+# buckaroo-data/buckaroo-tauri) — this is the Python-side runtime its
+# README's `pip install buckaroo[tauri-essentials]` instruction depends
+# on. Top-level imports in buckaroo.server require tornado (HTTP + WS
+# server) and both pandas and polars (data_loading.py imports both
+# unconditionally).
+tauri-essentials = [
+    "tornado>=6.0",
+    "polars>=1.24.0",
+    "pandas; python_version >= '3.13'",
+    "pandas>=1.3.5; python_version < '3.13'",
+]
 marimo = [
     "marimo>=0.19.7",
     "pandas; python_version >= '3.13'",


### PR DESCRIPTION
## Summary

Closes #751. Adds `[tauri-essentials]` — the Python-side runtime deps the buckaroo-tauri integration's sidecar needs to start. Resolves the gap where `pip install 'buckaroo[xorq]'` (per buckaroo-tauri's README) installs `xorq` but leaves `buckaroo.server` unable to import `tornado`, which #751 walks through in detail.

Distinct from the two existing related extras:
- `[xorq]` — stat-pipeline only; scoped to `XorqStatPipeline` per the comment above it. Intentionally does not pull `tornado`.
- `[mcp]` — has `tornado` + `polars` but not `pandas`; the sidecar's `data_loading.py` and `session.py` both import pandas unconditionally, so `[mcp]` only "works" today when something else (e.g. the `mcp` package, or `xorq` installed alongside) pulls pandas in transitively.

`[tauri-essentials]` is the minimal explicit set for the sidecar:

```toml
tauri-essentials = [
    "tornado>=6.0",
    "polars>=1.24.0",
    "pandas; python_version >= '3.13'",
    "pandas>=1.3.5; python_version < '3.13'",
]
```

Polars pin matches the existing `[polars]` extra. Pandas pin matches the existing dual-line pattern from `[dev]` / `[test]` / `[marimo]`.

### Import audit

`buckaroo.server`'s third-party top-level imports — verified by grepping `^import |^from ` over `buckaroo/server/*.py`:

| dep | imported by |
|---|---|
| `tornado` (ioloop, web, websocket) | `__main__.py`, `app.py`, `handlers.py`, `websocket_handler.py` |
| `pandas` | `data_loading.py:4`, `session.py:6` |
| `polars` | `data_loading.py:5` |

No other third-party deps. Everything else is stdlib or `buckaroo.*` internal.

### Naming

The name reflects "the Python runtime deps the Tauri integration needs to function" — not the Tauri shim itself (that's `buckaroo-data/buckaroo-tauri`), and not a dependency on the Tauri framework. See #751 for the discussion.

## Test plan

Verified in a fresh 3.12 venv against this branch:

```sh
uv venv --python 3.12 /tmp/verify
VIRTUAL_ENV=/tmp/verify uv pip install -e '.[tauri-essentials]' --python /tmp/verify/bin/python
/tmp/verify/bin/python -m buckaroo.server --help
# usage: __main__.py [-h] [--port PORT] [--no-browser]
# Buckaroo data server
```

- [x] `python -c "import tornado, pandas, polars, buckaroo"` — all four importable post-install
- [x] `python -m buckaroo.server --help` — returns clean usage (was `ModuleNotFoundError: No module named 'tornado'` without the extra)
- [x] `tornado==6.5.5`, `pandas==3.0.3`, `polars==1.40.1` resolved on 3.12
- [ ] CI green

### Out of scope (separate follow-ups)

- buckaroo-tauri README update to recommend `pip install 'buckaroo[tauri-essentials]'` — needs a release of this first.
- Possible deprecation / rename of `[mcp]` (the contents are generic server deps, the name suggests Model Context Protocol). Flagged in #751 as a bonus consideration; not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)