### PR TITLE
fix(deps): regenerate uv.lock for tauri-essentials extra

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -295,6 +295,12 @@ polars = [
     { name = "pl-series-hash" },
     { name = "polars", extra = ["timezone"] },
 ]
+tauri-essentials = [
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "polars" },
+    { name = "tornado" },
+]
 test = [
     { name = "anywidget" },
     { name = "codecov" },
@@ -373,9 +379,11 @@ requires-dist = [
     { name = "packaging", marker = "extra == 'test'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'dev'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'marimo'" },
+    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'tauri-essentials'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'test'" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'marimo'", specifier = ">=1.3.5" },
+    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'tauri-essentials'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'test'", specifier = ">=1.3.5" },
     { name = "pandera", marker = "extra == 'test'" },
     { name = "pl-series-hash", marker = "extra == 'dev'", specifier = "==0.2.1" },
@@ -384,6 +392,7 @@ requires-dist = [
     { name = "polars", marker = "extra == 'mcp'" },
     { name = "polars", marker = "extra == 'polars'" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.24.0" },
+    { name = "polars", marker = "extra == 'tauri-essentials'", specifier = ">=1.24.0" },
     { name = "polars", extras = ["timezone"], marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "python_full_version < '3.13'", specifier = ">=18.0.0" },
     { name = "pyarrow", marker = "python_full_version == '3.13.*'" },
@@ -403,11 +412,12 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "tornado", marker = "extra == 'mcp'", specifier = ">=6.0" },
+    { name = "tornado", marker = "extra == 'tauri-essentials'", specifier = ">=6.0" },
     { name = "twine", marker = "extra == 'packaging-tools'" },
     { name = "watchfiles", marker = "extra == 'dev'" },
     { name = "xorq", marker = "python_full_version < '3.14' and extra == 'xorq'", specifier = ">=0.1.0" },
 ]
-provides-extras = ["dev", "jupyterlab", "marimo", "mcp", "notebook", "packaging-tools", "polars", "test", "xorq"]
+provides-extras = ["dev", "jupyterlab", "marimo", "mcp", "notebook", "packaging-tools", "polars", "tauri-essentials", "test", "xorq"]
 
 [package.metadata.requires-dev]
 datacompy = [{ name = "datacompy", specifier = ">=0.15.0" }]


### PR DESCRIPTION
## Summary
- #753 added the `tauri-essentials` extras group to `pyproject.toml` but didn't regenerate `uv.lock`, so `uv sync --locked` rejects the tree as inconsistent.
- Every PR's `Python / Lint` and `Docs / Build + Check Links` jobs currently fail because `pull_request` CI runs against `merge(main, head)` and inherits main's drifted state. Main's own post-merge run for #753 (run `25992822079`) is failing for the same reason.
- Re-running `uv lock` against current `pyproject.toml` adds the resolved entry for `tauri-essentials` (pandas + polars + tornado markers); no other resolutions change.

## Test plan
- [x] `uv sync --locked --dev --no-install-project` passes locally with uv 0.11.14 (same version CI uses)
- [ ] CI `Python / Lint` passes on this PR
- [ ] CI `Docs / Build + Check Links` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)