### PR TITLE
feat(polars-search): plumb search term to JS as highlight_regex via SDResult

### DIFF
--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -139,7 +139,12 @@ class Search(Command):
         # row.
         if val is None or val == "":
             return df
-        return df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
+        filtered = df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
+        # `.str.contains(val)` treats val as a regex, so expose it as
+        # highlight_regex (not _phrase) for consistent semantics on the JS side.
+        string_cols = [c for c, dt in zip(df.columns, df.dtypes) if dt == pl.String]
+        sd_updates = {c: {'highlight_regex': val} for c in string_cols}
+        return SDResult(filtered, sd_updates)
 
 
     @staticmethod 

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -68,9 +68,11 @@ class DefaultMainStyling(StylingAnalysis):
 
     @classmethod
     def style_column(kls, col:str, column_metadata: Any) -> Any:
-        #print(col, list(sd.keys()))
-        if len(column_metadata.keys()) == 0:
-            #I'm still having problems with index and polars
+        # `_type` is the discriminator for displayer choice. If column_metadata
+        # is empty (polars/index edge case) or arrives without `_type` — e.g.
+        # a no-cleaning run where only an op-contributed entry (highlight_*)
+        # landed in cleaning_sd — fall back to obj rather than KeyError-ing.
+        if len(column_metadata.keys()) == 0 or '_type' not in column_metadata:
             return {'col_name':col, 'displayer_args': {'displayer': 'obj'}}
 
         digits = 3
@@ -98,6 +100,12 @@ class DefaultMainStyling(StylingAnalysis):
         else:
             disp = {'displayer': 'obj'}
             base_config['tooltip_config'] = {'tooltip_type':'simple', 'val_column': str(col)}
+        # Lowcode ops (e.g. Search) contribute highlight metadata via SDResult;
+        # the JS string displayer reads these from displayer_args.
+        if disp.get('displayer') == 'string':
+            for k in ('highlight_phrase', 'highlight_regex', 'highlight_color'):
+                if k in column_metadata:
+                    disp[k] = column_metadata[k]
         base_config['displayer_args'] = disp
 
         # Compute content-aware minWidth

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -12,16 +12,22 @@ def _rekey_op_sd_to_internal(cleaning_sd, cleaned_df):
     matching analysis entry instead of sitting alongside as orphans.
 
     A Command's transform only sees orig column names, so an SDResult it
-    returns is keyed by those. The rest of cleaning_sd is keyed by the
-    positional letter the analysis pipeline assigns. Without this pass the
-    styling layer would receive two entries per touched column — one with
-    _type/orig_col_name and one with the op contribution — and the op
-    contribution would never reach the displayer_args.
+    returns is keyed by those. Analysis entries are keyed by the positional
+    letter assigned by the analysis pipeline and always carry
+    `rewritten_col_name` (set by both pandas and polars analysis
+    management). The marker lets us skip analysis entries even when their
+    key happens to equal an orig name elsewhere in the frame — e.g. cols
+    ['b', 'foo'] yield internal a='b' and b='foo'; without the check, the
+    analysis entry for internal 'b' would get merged into 'a' because
+    rewrites['b']=='a', corrupting metadata.
     """
     rewrites = dict(old_col_new_col(cleaned_df))
     out = {}
     for col, kv in cleaning_sd.items():
-        target = rewrites.get(col, col)
+        if 'rewritten_col_name' in kv:
+            target = col
+        else:
+            target = rewrites.get(col, col)
         if target in out:
             out[target] = merge_sds({target: out[target]}, {target: kv})[target]
         else:

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -2,6 +2,31 @@ import pandas as pd
 from buckaroo.jlisp.lisp_utils import s, sQ, merge_ops, format_ops, ops_eq
 from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
 from ..customizations.all_transforms import configure_buckaroo, DefaultCommandKlsList
+from ..df_util import old_col_new_col
+from .styling_core import merge_sds
+
+
+def _rekey_op_sd_to_internal(cleaning_sd, cleaned_df):
+    """Rewrite orig-name keys (from op-contributed SDResult entries) onto
+    buckaroo's internal a/b/c letter keys, so the updates merge into the
+    matching analysis entry instead of sitting alongside as orphans.
+
+    A Command's transform only sees orig column names, so an SDResult it
+    returns is keyed by those. The rest of cleaning_sd is keyed by the
+    positional letter the analysis pipeline assigns. Without this pass the
+    styling layer would receive two entries per touched column — one with
+    _type/orig_col_name and one with the op contribution — and the op
+    contribution would never reach the displayer_args.
+    """
+    rewrites = dict(old_col_new_col(cleaned_df))
+    out = {}
+    for col, kv in cleaning_sd.items():
+        target = rewrites.get(col, col)
+        if target in out:
+            out[target] = merge_sds({target: out[target]}, {target: kv})[target]
+        else:
+            out[target] = kv
+    return out
 
 def dumb_merge_ops(existing_ops, cleaning_ops):
     """ strip cleaning_ops from existing_ops, reinsert cleaning_ops at the beginning """
@@ -220,6 +245,12 @@ class PandasAutocleaning:
 
         cleaned_df, cleaning_sd = self._run_df_interpreter(df, final_ops, cleaning_sd)
         merged_cleaned_df = self.make_origs(df, cleaned_df, cleaning_sd)
+        # Run rekey AFTER make_origs: the polars make_origs walks cleaning_sd
+        # keys as actual column names on cleaned_df, so it needs op-supplied
+        # entries to still be keyed by orig col name. After make_origs is
+        # done with the df, rewrite the orig-keyed entries onto buckaroo's
+        # internal a/b/c keys for the styling layer.
+        cleaning_sd = _rekey_op_sd_to_internal(cleaning_sd, cleaned_df)
         generated_code = self._run_code_generator(final_ops)
         return [merged_cleaned_df, cleaning_sd, generated_code, final_ops]
 

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -6,8 +6,10 @@ from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
 from buckaroo.dataflow.autocleaning import merge_ops, format_ops, AutocleaningConfig
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
-    PlSafeInt, DropCol, FillNA, GroupBy, NoOp
+    Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search, SDResult
 )
+from buckaroo.customizations.styling import DefaultMainStyling
+from buckaroo.jlisp.lisp_utils import s
 
 
 dirty_df = pl.DataFrame(
@@ -176,3 +178,78 @@ def test_autoclean_codegen():
     cleaned_df, cleaning_sd, generated_code, merged_operations = cleaning_result
 
     assert generated_code == EXPECTED_GEN_CODE
+
+
+class TaggingCommand(Command):
+    """A Command whose transform returns SDResult(df, sd_updates)."""
+    command_default = [s('tag'), s('df'), 'col', '']
+    command_pattern = [[3, 'tag', 'type', 'string']]
+
+    @staticmethod
+    def transform(df, col, val):
+        return SDResult(df, {col: {'note': val}})
+
+    @staticmethod
+    def transform_to_py(df, col, val):
+        return "    # tag"
+
+
+class TagConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = []
+    command_klasses = [TaggingCommand]
+    name = ""
+
+
+def test_sdresult_lands_in_cleaning_sd_through_handle_ops_and_clean():
+    ac = PolarsAutocleaning([TagConf])
+    df = pl.DataFrame({'a': [1, 2, 3]})
+    op = [{'symbol': 'tag'}, s('df'), 'a', 'hello']
+
+    _df, cleaning_sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=[op])
+
+    assert cleaning_sd.get('a', {}).get('note') == 'hello'
+
+
+class SearchConf(AutocleaningConfig):
+    autocleaning_analysis_klasses = []
+    command_klasses = [Search]
+    name = ""
+
+
+def test_search_threads_highlight_regex_into_cleaning_sd_under_rename():
+    """Search plumbs its search term into cleaning_sd as highlight_regex on
+    every polars-String column. The rest of the sd is keyed by buckaroo's
+    internal a/b/c names, so autocleaning rewrites the op-supplied keys to
+    match — otherwise the entries would sit alongside as orphans without
+    a `_type` and trip the styling fallback."""
+    ac = PolarsAutocleaning([SearchConf])
+    # 'businessname' becomes 'a', 'rating' becomes 'b' under buckaroo renaming.
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi'], 'rating': [5, 4]})
+    search_op = [{'symbol': 'search'}, s('df'), 'col', 'pizza']
+
+    _cleaned, cleaning_sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=[search_op])
+
+    # keyed by the *renamed* col, not by 'businessname'
+    assert cleaning_sd.get('a', {}).get('highlight_regex') == 'pizza'
+    assert 'businessname' not in cleaning_sd
+    # non-string column ('b' / 'rating') must not receive the highlight
+    assert 'highlight_regex' not in cleaning_sd.get('b', {})
+
+
+def test_default_main_styling_emits_highlight_regex_into_displayer_args():
+    """style_column copies highlight_regex out of col_meta and into the
+    string displayer_args, where the JS-side displayer reads it."""
+    col_meta = {'_type': 'string', 'highlight_regex': 'pizza', 'orig_col_name': 'a'}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert cc['displayer_args']['displayer'] == 'string'
+    assert cc['displayer_args']['highlight_regex'] == 'pizza'
+
+
+def test_style_column_handles_col_meta_missing_type():
+    """A col_meta lacking `_type` (e.g. a stray sd entry contributed by an
+    op when no cleaning_method ran so no analysis entry exists for the
+    column) should fall back to obj rather than KeyError."""
+    cc = DefaultMainStyling.style_column('whatever', {'highlight_regex': 'x'})
+    assert cc['displayer_args']['displayer'] == 'obj'

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -3,7 +3,9 @@ from buckaroo.customizations.polars_analysis import (
     VCAnalysis, PLCleaningStats, BasicAnalysis)
 from buckaroo.pluggable_analysis_framework.polars_analysis_management import PlDfStats
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
-from buckaroo.dataflow.autocleaning import merge_ops, format_ops, AutocleaningConfig
+from buckaroo.dataflow.autocleaning import (
+    merge_ops, format_ops, AutocleaningConfig, _rekey_op_sd_to_internal,
+)
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
     Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search, SDResult
@@ -245,6 +247,32 @@ def test_default_main_styling_emits_highlight_regex_into_displayer_args():
     cc = DefaultMainStyling.style_column('a', col_meta)
     assert cc['displayer_args']['displayer'] == 'string'
     assert cc['displayer_args']['highlight_regex'] == 'pizza'
+
+
+def test_rekey_preserves_analysis_entries_when_orig_names_collide_with_letters():
+    """Regression for codex review on #758. If an orig col name happens
+    to equal an internal letter (e.g. df cols ['b', 'foo'] → internal
+    a='b', b='foo'), the rekey must not merge the analysis entry for
+    internal 'b' into 'a' just because rewrites['b']=='a'. Analysis
+    entries (marked by `rewritten_col_name`) pass through untouched;
+    only op-contributed (orig-keyed) entries get rekeyed."""
+    cleaned_df = pl.DataFrame({'b': [1], 'foo': [2]})
+    cleaning_sd = {
+        'a': {'rewritten_col_name': 'a', 'orig_col_name': 'b', '_type': 'integer'},
+        'b': {'rewritten_col_name': 'b', 'orig_col_name': 'foo', '_type': 'integer'},
+        # op-contributed entry keyed by orig name 'foo'
+        'foo': {'highlight_regex': 'x'},
+    }
+    out = _rekey_op_sd_to_internal(cleaning_sd, cleaned_df)
+    # analysis entries untouched, in place
+    assert out['a']['orig_col_name'] == 'b'
+    assert out['a']['_type'] == 'integer'
+    assert out['b']['orig_col_name'] == 'foo'
+    assert out['b']['_type'] == 'integer'
+    # op-contributed entry rekeyed onto the matching internal letter
+    assert out['b']['highlight_regex'] == 'x'
+    # no stray orig-keyed entry left behind
+    assert 'foo' not in out
 
 
 def test_style_column_handles_col_meta_missing_type():

--- a/tests/unit/dataflow/dataflow_polars_test.py
+++ b/tests/unit/dataflow/dataflow_polars_test.py
@@ -1,7 +1,8 @@
 from buckaroo.dataflow.dataflow import StylingAnalysis
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
-from buckaroo.polars_buckaroo import PolarsBuckarooWidget
-import polars as pl 
+from buckaroo.polars_buckaroo import PolarsBuckarooWidget, PolarsBuckarooInfiniteWidget
+from buckaroo.jlisp.lisp_utils import s
+import polars as pl
 from polars.testing import assert_frame_equal
 
 
@@ -243,3 +244,50 @@ def test_column_config_override():
     int_cc_after = cc_after[0]
     assert int_cc_after['col_name'] == 'a' #make sure we found the right row
     assert int_cc_after['header_name'] == 'int_col' #make sure we found the right row
+
+
+def _find_cc(column_config, col_name):
+    for entry in column_config:
+        if entry.get('col_name') == col_name:
+            return entry
+    raise AssertionError(f"col_name {col_name!r} not in column_config")
+
+
+def test_search_op_delivers_highlight_regex_into_displayer_args():
+    """End-to-end: a `search` operation on the widget should plumb its
+    search term into `displayer_args.highlight_regex` for every polars-String
+    column in the final df_viewer_config that gets sent to the JS side."""
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi', 'taco'], 'comments': ['area code', 'no match', 'area zone'],
+        'rating': [5, 4, 3]})
+    w = PolarsBuckarooInfiniteWidget(df)
+    w.dataflow.operations = [[{'symbol': 'search'}, s('df'), 'col', 'area']]
+
+    cc = w.df_display_args['main']['df_viewer_config']['column_config']
+    # 'a' is businessname (string) -- gets highlighted
+    a_args = _find_cc(cc, 'a')['displayer_args']
+    assert a_args['displayer'] == 'string'
+    assert a_args['highlight_regex'] == 'area'
+    # 'b' is comments (string) -- gets highlighted
+    b_args = _find_cc(cc, 'b')['displayer_args']
+    assert b_args['displayer'] == 'string'
+    assert b_args['highlight_regex'] == 'area'
+    # 'c' is rating (integer) -- no highlight (highlight only applies to string displayer)
+    c_args = _find_cc(cc, 'c')['displayer_args']
+    assert 'highlight_regex' not in c_args
+
+
+def test_column_config_overrides_preserves_highlight_phrase_and_color():
+    """End-to-end: a user-supplied column_config_overrides carrying
+    highlight_phrase + highlight_color should survive the merge_column_config
+    step and land in the final displayer_args."""
+    df = pl.DataFrame({'businessname': ['pizza', 'sushi'], 'comments': ['area code', 'no match']})
+    overrides = {'comments': {'displayer_args': {'displayer': 'string', 'max_length': 2000,
+        'highlight_phrase': ['area'], 'highlight_color': 'red'}}}
+    w = PolarsBuckarooInfiniteWidget(df, column_config_overrides=overrides)
+
+    cc = w.df_display_args['main']['df_viewer_config']['column_config']
+    b_args = _find_cc(cc, 'b')['displayer_args']
+    assert b_args['displayer'] == 'string'
+    assert b_args['max_length'] == 2000
+    assert b_args['highlight_phrase'] == ['area']
+    assert b_args['highlight_color'] == 'red'


### PR DESCRIPTION
## Summary

Polars `Search.transform` returns `SDResult(filtered_df, sd_updates)` so the search term flows into `cleaning_sd` as `highlight_regex` on every polars-String column. `DefaultMainStyling.style_column` reads `highlight_phrase` / `highlight_regex` / `highlight_color` off `col_meta` and threads them into the string `displayer_args`, where the JS side already renders matches as `<mark>`.

First concrete consumer of the SDResult channel from **#755** (which superseded #744).

Replaces **#745** — rebased onto main after #755 merged, with the obsolete `(df, sd_updates)` tuple commit dropped and `Search` ported to return `SDResult` instead.

## Supporting changes

- `autocleaning.handle_ops_and_clean` rekeys op-supplied sd entries from orig col names onto buckaroo's internal a/b/c letter keys, so they merge into the matching analysis entry instead of sitting alongside as orphans. Runs **after** `make_origs` (which uses the keys as column names on `cleaned_df`).
- `style_column` falls back to `obj` when `_type` is absent, so a stray op-only entry (no analysis ran for that column) can't `KeyError` the styling pass.

## Test plan

- [x] `pytest tests/unit/dataflow/ tests/unit/jlisp/ tests/unit/commands/polars_command_test.py` — 147 pass
- [x] Full unit suite (excluding contrib/file_cache): 825 passed, 7 skipped
- [ ] CI green

## Tests added

- `test_sdresult_lands_in_cleaning_sd_through_handle_ops_and_clean` — wiring of `SDResult.sd_updates` into `cleaning_sd` via `handle_ops_and_clean`
- `test_search_threads_highlight_regex_into_cleaning_sd_under_rename` — Search contributes `highlight_regex` keyed by the *renamed* (a/b/c) column, not the orig name
- `test_default_main_styling_emits_highlight_regex_into_displayer_args` — `style_column` copies `highlight_regex` into the string `displayer_args`
- `test_style_column_handles_col_meta_missing_type` — fallback to `obj` when `_type` absent
- `test_search_op_delivers_highlight_regex_into_displayer_args` — e2e through `PolarsBuckarooInfiniteWidget` into `df_viewer_config.column_config`
- `test_column_config_overrides_preserves_highlight_phrase_and_color` — user-supplied overrides survive the merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)