### PR TITLE
feat(js-core): split BuckarooView from BuckarooServerView for injectable IModel (#759)

### DIFF
--- a/packages/buckaroo-js-core/src/index.ts
+++ b/packages/buckaroo-js-core/src/index.ts
@@ -16,6 +16,7 @@ import { parquetRead, parquetMetadata } from 'hyparquet';
 import { resolveDFData, resolveDFDataAsync, preResolveDFDataDict } from './components/DFViewerParts/resolveDFData';
 import { BuckarooStaticTable } from './components/BuckarooStaticTable';
 import { BuckarooServerView, buckarooWsUrl } from './server/BuckarooServerView';
+import { BuckarooView } from './server/BuckarooView';
 import { WebSocketModel } from './server/WebSocketModel';
 
 import { HistogramCell } from "./components/DFViewerParts/HistogramCell";
@@ -57,6 +58,7 @@ export default {
     preResolveDFDataDict,
     BuckarooStaticTable,
     BuckarooServerView,
+    BuckarooView,
     buckarooWsUrl,
     WebSocketModel,
 };
@@ -86,6 +88,11 @@ export {
     preResolveDFDataDict,
     BuckarooStaticTable,
     BuckarooServerView,
+    BuckarooView,
     buckarooWsUrl,
     WebSocketModel,
 };
+
+export type { IModel } from './server/IModel';
+export type { BuckarooViewProps, BuckarooServerMode, BuckarooServerMetadata } from './server/BuckarooView';
+export type { BuckarooServerViewProps } from './server/BuckarooServerView';

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
@@ -1,36 +1,17 @@
 import * as React from "react";
 
-import { BuckarooInfiniteWidget, DFViewerInfiniteDS, getKeySmartRowCache } from "../components/BuckarooWidgetInfinite";
 import { preResolveDFDataDict } from "../components/DFViewerParts/resolveDFData";
 import { WebSocketModel } from "./WebSocketModel";
-import { DFMeta, BuckarooState, BuckarooOptions } from "../components/WidgetTypes";
-import { CommandConfigT } from "../components/CommandUtils";
-import { Operation } from "../components/OperationUtils";
-import { OperationResult, baseOperationResults } from "../components/DependentTabs";
-import { DFData, DFDataOrPayload } from "../components/DFViewerParts/DFWhole";
-import { IDisplayArgs } from "../components/DFViewerParts/gridUtils";
+import {
+    BuckarooView,
+    BuckarooServerMetadata,
+    BuckarooServerMode,
+    pickMode,
+} from "./BuckarooView";
 
-// Defaults are only visible to the widgets if the server sends partial
-// initial_state (it should always send these keys, but useState wants a
-// fully-typed initializer, and the render guard below means the widgets
-// never actually see these values).
-const DEFAULT_DF_META: DFMeta = { total_rows: 0, columns: 0, filtered_rows: 0, rows_shown: 0 };
-const DEFAULT_BUCKAROO_STATE: BuckarooState = {
-    sampled: false,
-    cleaning_method: false,
-    quick_command_args: {},
-    post_processing: false,
-    df_display: "main",
-    show_commands: false,
-};
-const DEFAULT_BUCKAROO_OPTIONS: BuckarooOptions = {
-    sampled: [],
-    cleaning_method: [],
-    post_processing: [],
-    df_display: [],
-    show_commands: [],
-};
-const DEFAULT_COMMAND_CONFIG: CommandConfigT = { argspecs: {}, defaultArgs: {} };
+// Re-export the shared types so existing `import { BuckarooServerMode } from
+// ".../BuckarooServerView"` paths keep working.
+export type { BuckarooServerMetadata, BuckarooServerMode };
 
 /**
  * BuckarooServerView — embed a Buckaroo server session inside a React tree.
@@ -38,27 +19,18 @@ const DEFAULT_COMMAND_CONFIG: CommandConfigT = { argspecs: {}, defaultArgs: {} }
  * This is the npm-module alternative to iframing `/s/<session-id>` from the
  * Buckaroo server. The component opens a WebSocket to the server, waits for
  * the `initial_state` message, builds the same model + row cache the
- * standalone bundle uses, and renders the appropriate widget based on the
- * server-reported `mode`.
+ * standalone bundle uses, and delegates rendering to {@link BuckarooView}.
  *
  *   import { BuckarooServerView } from "buckaroo-js-core";
  *   import "buckaroo-js-core/style.css";
  *
  *   <BuckarooServerView wsUrl="ws://localhost:8700/ws/my-session" />
  *
- * The server's session decides the widget — pass `mode="viewer"` to
- * /load for DFViewerInfiniteDS, `mode="buckaroo"` for the full UI. The host
- * app does no widget-class selection; it only cares about which session to
- * connect to.
+ * Hosts that need to keep WebSockets out of the renderer (Tauri, Electron,
+ * Wails) should instead construct an {@link IModel} via their IPC adapter
+ * and mount {@link BuckarooView} directly — see the docstring on that
+ * component for the no-WebSocket path.
  */
-
-export type BuckarooServerMode = "viewer" | "buckaroo";
-
-export interface BuckarooServerMetadata {
-    path?: string;
-    rows?: number;
-    [k: string]: unknown;
-}
 
 export interface BuckarooServerViewProps {
     /** Full WebSocket URL (ws:// or wss://). For a server at host H serving
@@ -90,17 +62,8 @@ export interface BuckarooServerViewProps {
 
 interface ReadyState {
     model: WebSocketModel;
-    src: ReturnType<typeof getKeySmartRowCache>;
     mode: BuckarooServerMode;
     initialState: Record<string, unknown>;
-}
-
-function pickMode(rawMode: unknown): BuckarooServerMode {
-    if (rawMode === "buckaroo" || rawMode === "viewer") return rawMode;
-    if (rawMode !== undefined && rawMode !== null) {
-        console.warn(`[BuckarooServerView] unknown mode ${JSON.stringify(rawMode)} — falling back to "viewer".`);
-    }
-    return "viewer";
 }
 
 /** Derive a Buckaroo server WebSocket URL from an HTTP server URL + session
@@ -121,21 +84,6 @@ export function BuckarooServerView({
 }: BuckarooServerViewProps): React.ReactElement {
     const [ready, setReady] = React.useState<ReadyState | null>(null);
     const [error, setError] = React.useState<Error | null>(null);
-
-    // Re-fired state values so React re-renders when the model emits change events.
-    const [dfMeta, setDfMeta] = React.useState<DFMeta>(DEFAULT_DF_META);
-    const [dfDataDict, setDfDataDict] = React.useState<Record<string, DFData>>({});
-    const [dfDisplayArgs, setDfDisplayArgs] = React.useState<Record<string, IDisplayArgs>>({});
-    const [buckarooState, setBuckarooStateLocal] = React.useState<BuckarooState>(DEFAULT_BUCKAROO_STATE);
-    const [buckarooOptions, setBuckarooOptions] = React.useState<BuckarooOptions>(DEFAULT_BUCKAROO_OPTIONS);
-    const [commandConfig, setCommandConfig] = React.useState<CommandConfigT>(DEFAULT_COMMAND_CONFIG);
-    const [operationResults, setOperationResults] = React.useState<OperationResult>(baseOperationResults);
-    const [operations, setOperations] = React.useState<Operation[]>([]);
-
-    // Keep the latest onMetadata in a ref so we don't reconnect when the
-    // host passes a fresh callback identity each render.
-    const onMetadataRef = React.useRef(onMetadata);
-    React.useEffect(() => { onMetadataRef.current = onMetadata; }, [onMetadata]);
 
     React.useEffect(() => {
         let cancelled = false;
@@ -187,21 +135,9 @@ export function BuckarooServerView({
                 }
 
                 const model = new WebSocketModel(ws, initialState);
-                const src = getKeySmartRowCache(model, (a: unknown, b: unknown) => console.error("[BuckarooServerView] cache error:", a, b));
                 const mode: BuckarooServerMode = pickMode(initialState.mode);
 
-                setDfMeta((initialState.df_meta as DFMeta) ?? DEFAULT_DF_META);
-                setDfDataDict((initialState.df_data_dict as Record<string, DFData>) ?? {});
-                setDfDisplayArgs((initialState.df_display_args as Record<string, IDisplayArgs>) ?? {});
-                setBuckarooStateLocal((initialState.buckaroo_state as BuckarooState) ?? DEFAULT_BUCKAROO_STATE);
-                setBuckarooOptions((initialState.buckaroo_options as BuckarooOptions) ?? DEFAULT_BUCKAROO_OPTIONS);
-                setCommandConfig((initialState.command_config as CommandConfigT) ?? DEFAULT_COMMAND_CONFIG);
-                setOperationResults((initialState.operation_results as OperationResult) ?? baseOperationResults);
-                setOperations((initialState.operations as Operation[]) ?? []);
-
-                if (initialState.metadata) onMetadataRef.current?.(initialState.metadata as BuckarooServerMetadata, initialState.prompt as string | undefined);
-
-                setReady({ model, src, mode, initialState });
+                setReady({ model, mode, initialState });
             } catch (e) {
                 if (cancelled) return;
                 setError(e instanceof Error ? e : new Error(String(e)));
@@ -215,72 +151,6 @@ export function BuckarooServerView({
         };
     }, [wsUrl]);
 
-    // Wire model change-events → React state once ready.
-    React.useEffect(() => {
-        if (!ready) return;
-        const { model } = ready;
-
-        const onMeta = (metadata: BuckarooServerMetadata, prompt?: string) => {
-            onMetadataRef.current?.(metadata, prompt);
-            setDfMeta((model.get("df_meta") as DFMeta | undefined) ?? { ...DEFAULT_DF_META, total_rows: metadata?.rows ?? 0 });
-            preResolveDFDataDict((model.get("df_data_dict") as Record<string, DFDataOrPayload> | undefined) ?? {})
-                .then((d) => setDfDataDict(d as Record<string, DFData>));
-            setDfDisplayArgs((model.get("df_display_args") as Record<string, IDisplayArgs> | undefined) ?? {});
-            setBuckarooStateLocal((model.get("buckaroo_state") as BuckarooState | undefined) ?? DEFAULT_BUCKAROO_STATE);
-            setBuckarooOptions((model.get("buckaroo_options") as BuckarooOptions | undefined) ?? DEFAULT_BUCKAROO_OPTIONS);
-            setCommandConfig((model.get("command_config") as CommandConfigT | undefined) ?? DEFAULT_COMMAND_CONFIG);
-            setOperationResults((model.get("operation_results") as OperationResult | undefined) ?? baseOperationResults);
-            setOperations((model.get("operations") as Operation[] | undefined) ?? []);
-        };
-        const onDfMeta = (v: DFMeta) => setDfMeta(v);
-        const onDfDataDict = (v: Record<string, DFDataOrPayload>) => {
-            preResolveDFDataDict(v).then((d) => setDfDataDict(d as Record<string, DFData>));
-        };
-        const onDfDisplayArgs = (v: Record<string, IDisplayArgs>) => setDfDisplayArgs(v);
-        const onBState = (v: BuckarooState) => setBuckarooStateLocal(v);
-        const onBOpts = (v: BuckarooOptions) => setBuckarooOptions(v);
-        const onCmdCfg = (v: CommandConfigT) => setCommandConfig(v);
-        const onOpRes = (v: OperationResult) => setOperationResults(v);
-        const onOps = (v: Operation[]) => setOperations(v);
-
-        model.on("metadata", onMeta);
-        model.on("change:df_meta", onDfMeta);
-        model.on("change:df_data_dict", onDfDataDict);
-        model.on("change:df_display_args", onDfDisplayArgs);
-        model.on("change:buckaroo_state", onBState);
-        model.on("change:buckaroo_options", onBOpts);
-        model.on("change:command_config", onCmdCfg);
-        model.on("change:operation_results", onOpRes);
-        model.on("change:operations", onOps);
-
-        return () => {
-            model.off("metadata", onMeta);
-            model.off("change:df_meta", onDfMeta);
-            model.off("change:df_data_dict", onDfDataDict);
-            model.off("change:df_display_args", onDfDisplayArgs);
-            model.off("change:buckaroo_state", onBState);
-            model.off("change:buckaroo_options", onBOpts);
-            model.off("change:command_config", onCmdCfg);
-            model.off("change:operation_results", onOpRes);
-            model.off("change:operations", onOps);
-        };
-    }, [ready]);
-
-    const onBuckarooState = React.useCallback<React.Dispatch<React.SetStateAction<BuckarooState>>>((newState) => {
-        if (!ready) return;
-        const resolved = typeof newState === "function"
-            ? (newState as (prev: BuckarooState) => BuckarooState)(buckarooState)
-            : newState;
-        ready.model.set("buckaroo_state", resolved);
-        ready.model.save_changes();
-    }, [ready, buckarooState]);
-
-    const onOperations = React.useCallback((newOps: Operation[]) => {
-        if (!ready) return;
-        ready.model.set("operations", newOps);
-        ready.model.save_changes();
-    }, [ready]);
-
     const wrapperStyle: React.CSSProperties = { width: "100%", height: "100%", ...(style ?? {}) };
 
     if (error) {
@@ -290,7 +160,7 @@ export function BuckarooServerView({
             </div>
         );
     }
-    if (!ready || !dfDisplayArgs?.main) {
+    if (!ready) {
         return (
             <div className={className} style={wrapperStyle}>
                 {renderConnecting ? renderConnecting() : <div style={{ padding: 20, fontFamily: "sans-serif" }}>Connecting…</div>}
@@ -299,30 +169,13 @@ export function BuckarooServerView({
     }
 
     return (
-        <div className={["buckaroo_anywidget", className].filter(Boolean).join(" ")} style={wrapperStyle}>
-            {ready.mode === "buckaroo" ? (
-                <BuckarooInfiniteWidget
-                    df_meta={dfMeta}
-                    df_data_dict={dfDataDict}
-                    df_display_args={dfDisplayArgs}
-                    operations={operations}
-                    on_operations={onOperations}
-                    operation_results={operationResults}
-                    command_config={commandConfig}
-                    buckaroo_state={buckarooState}
-                    on_buckaroo_state={onBuckarooState}
-                    buckaroo_options={buckarooOptions}
-                    src={ready.src}
-                />
-            ) : (
-                <DFViewerInfiniteDS
-                    df_meta={dfMeta}
-                    df_data_dict={dfDataDict}
-                    df_display_args={dfDisplayArgs}
-                    src={ready.src}
-                    df_id={"server"}
-                />
-            )}
-        </div>
+        <BuckarooView
+            model={ready.model}
+            initialState={ready.initialState}
+            mode={ready.mode}
+            onMetadata={onMetadata}
+            style={style}
+            className={className}
+        />
     );
 }

--- a/packages/buckaroo-js-core/src/server/BuckarooView.test.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.test.tsx
@@ -65,6 +65,27 @@ describe("BuckarooView (injectable IModel — #759)", () => {
         expect(events.get("metadata")?.size).toBe(1);
     });
 
+    it("does not hand raw parquet_b64 payloads to the widget on first render (codex P2)", () => {
+        const { model } = makeFakeModel();
+        const initialState = {
+            df_meta: { total_rows: 1, columns: 1, filtered_rows: 1, rows_shown: 1 },
+            // Raw payload — what a host adapter would pass straight from the wire.
+            df_data_dict: { main: { format: "parquet_b64", data: "ZmFrZQ==" } },
+            df_display_args: { main: { df_viewer_config: { pinned_rows: [], left_col_configs: [], column_config: [] }, summary_stats_key: "all_stats" } },
+        };
+
+        // Render synchronously — no act() wrapper. We want to see the very
+        // first commit, before the resolve effect fires.
+        const { queryByTestId, getByText } = render(
+            <BuckarooView model={model} initialState={initialState} mode="viewer" />,
+        );
+
+        // The widget must NOT receive the raw payload — otherwise
+        // makeStaticInfiniteDs crashes on data.slice(...).
+        expect(queryByTestId("viewer-widget-stub")).toBeNull();
+        expect(getByText(/Preparing/)).toBeTruthy();
+    });
+
     it("fires onMetadata for the initial payload", async () => {
         const { model } = makeFakeModel();
         const onMetadata = jest.fn();

--- a/packages/buckaroo-js-core/src/server/BuckarooView.test.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * BuckarooView — transport-agnostic embed.
+ *
+ * Pins the contract from #759: a host can mount BuckarooView with a fake
+ * IModel and a pre-collected initial_state, and the component renders
+ * without ever opening a WebSocket. This is the path Tauri/Electron hosts
+ * use when relaying through IPC.
+ */
+import { render, cleanup, act } from "@testing-library/react";
+import { BuckarooView } from "./BuckarooView";
+import type { IModel } from "./IModel";
+
+// Stub the heavy widget surfaces — this test exercises the injection
+// wiring, not AG-Grid. The widget components instantiate AgGridReact which
+// is fragile under jsdom; the stub keeps the test focused on the model
+// contract.
+jest.mock("../components/BuckarooWidgetInfinite", () => ({
+    BuckarooInfiniteWidget: () => <div data-testid="buckaroo-widget-stub" />,
+    DFViewerInfiniteDS: () => <div data-testid="viewer-widget-stub" />,
+    getKeySmartRowCache: jest.fn(() => ({ __stub: "row-cache" })),
+}));
+
+function makeFakeModel(): { model: IModel; events: Map<string, Set<Function>>; sent: any[] } {
+    const events = new Map<string, Set<Function>>();
+    const state: Record<string, unknown> = {};
+    const sent: any[] = [];
+    const model: IModel = {
+        send: (msg) => { sent.push(msg); },
+        get: (k) => state[k],
+        set: (k, v) => { state[k] = v; },
+        save_changes: () => { /* noop */ },
+        on: (e, h) => {
+            if (!events.has(e)) events.set(e, new Set());
+            events.get(e)!.add(h);
+        },
+        off: (e, h) => { events.get(e)?.delete(h); },
+    };
+    return { model, events, sent };
+}
+
+afterEach(() => cleanup());
+
+describe("BuckarooView (injectable IModel — #759)", () => {
+    it("renders the viewer widget when given a fake IModel + initialState — no WebSocket needed", async () => {
+        const { model, events } = makeFakeModel();
+        const initialState = {
+            df_meta: { total_rows: 1, columns: 1, filtered_rows: 1, rows_shown: 1 },
+            df_data_dict: {},
+            df_display_args: { main: { df_viewer_config: { pinned_rows: [], left_col_configs: [], column_config: [] }, summary_stats_key: "all_stats" } },
+        };
+
+        let result: ReturnType<typeof render>;
+        await act(async () => {
+            result = render(<BuckarooView model={model} initialState={initialState} mode="viewer" />);
+        });
+        const { getByTestId } = result!;
+
+        // Renders the viewer (not the full buckaroo widget) per mode prop.
+        expect(getByTestId("viewer-widget-stub")).toBeTruthy();
+
+        // The change-event wiring subscribed via the injected model — proves
+        // the model is the one driving updates, not an internal WebSocket.
+        expect(events.get("change:df_meta")?.size).toBe(1);
+        expect(events.get("change:buckaroo_state")?.size).toBe(1);
+        expect(events.get("metadata")?.size).toBe(1);
+    });
+
+    it("fires onMetadata for the initial payload", async () => {
+        const { model } = makeFakeModel();
+        const onMetadata = jest.fn();
+        const initialState = {
+            df_display_args: { main: { df_viewer_config: { pinned_rows: [], left_col_configs: [], column_config: [] }, summary_stats_key: "all_stats" } },
+            metadata: { path: "/data/sales.parquet", rows: 42 },
+            prompt: "tell me about sales",
+        };
+
+        await act(async () => {
+            render(<BuckarooView model={model} initialState={initialState} mode="viewer" onMetadata={onMetadata} />);
+        });
+
+        expect(onMetadata).toHaveBeenCalledWith({ path: "/data/sales.parquet", rows: 42 }, "tell me about sales");
+    });
+});

--- a/packages/buckaroo-js-core/src/server/BuckarooView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.tsx
@@ -1,0 +1,248 @@
+import * as React from "react";
+
+import { BuckarooInfiniteWidget, DFViewerInfiniteDS, getKeySmartRowCache } from "../components/BuckarooWidgetInfinite";
+import { preResolveDFDataDict } from "../components/DFViewerParts/resolveDFData";
+import { DFMeta, BuckarooState, BuckarooOptions } from "../components/WidgetTypes";
+import { CommandConfigT } from "../components/CommandUtils";
+import { Operation } from "../components/OperationUtils";
+import { OperationResult, baseOperationResults } from "../components/DependentTabs";
+import { DFData, DFDataOrPayload } from "../components/DFViewerParts/DFWhole";
+import { IDisplayArgs } from "../components/DFViewerParts/gridUtils";
+import { IModel } from "./IModel";
+
+export type BuckarooServerMode = "viewer" | "buckaroo";
+
+export interface BuckarooServerMetadata {
+    path?: string;
+    rows?: number;
+    [k: string]: unknown;
+}
+
+const DEFAULT_DF_META: DFMeta = { total_rows: 0, columns: 0, filtered_rows: 0, rows_shown: 0 };
+const DEFAULT_BUCKAROO_STATE: BuckarooState = {
+    sampled: false,
+    cleaning_method: false,
+    quick_command_args: {},
+    post_processing: false,
+    df_display: "main",
+    show_commands: false,
+};
+const DEFAULT_BUCKAROO_OPTIONS: BuckarooOptions = {
+    sampled: [],
+    cleaning_method: [],
+    post_processing: [],
+    df_display: [],
+    show_commands: [],
+};
+const DEFAULT_COMMAND_CONFIG: CommandConfigT = { argspecs: {}, defaultArgs: {} };
+
+export interface BuckarooViewProps {
+    /** An already-connected model implementing {@link IModel}. The caller is
+     *  responsible for transport setup (WebSocket, Tauri IPC, etc.) and for
+     *  having received `initial_state` from the backend before mounting. */
+    model: IModel;
+
+    /** The first `initial_state` payload the model produced. Used to seed
+     *  React state without waiting for `change:*` events. If `df_data_dict`
+     *  contains base64-encoded parquet payloads they will be resolved on
+     *  mount; pre-resolved values pass through unchanged. */
+    initialState: Record<string, unknown>;
+
+    /** Which widget to render — `"viewer"` for `DFViewerInfiniteDS`,
+     *  `"buckaroo"` for the full `BuckarooInfiniteWidget`. */
+    mode: BuckarooServerMode;
+
+    /** Called when the backend pushes a `metadata` event (e.g. a new file
+     *  was loaded). Useful for host apps that mirror the filename into a
+     *  title bar. */
+    onMetadata?: (metadata: BuckarooServerMetadata, prompt?: string) => void;
+
+    /** Optional inline style applied to the wrapping div. The component
+     *  defaults to `width:100%, height:100%`. */
+    style?: React.CSSProperties;
+
+    /** Optional className on the wrapping div. */
+    className?: string;
+}
+
+export function pickMode(rawMode: unknown): BuckarooServerMode {
+    if (rawMode === "buckaroo" || rawMode === "viewer") return rawMode;
+    if (rawMode !== undefined && rawMode !== null) {
+        console.warn(`[BuckarooView] unknown mode ${JSON.stringify(rawMode)} — falling back to "viewer".`);
+    }
+    return "viewer";
+}
+
+/**
+ * BuckarooView — transport-agnostic Buckaroo widget renderer.
+ *
+ * Takes an already-connected {@link IModel} plus the `initial_state` payload
+ * it produced, and renders the appropriate widget. Use this when the caller
+ * owns transport setup and wants to keep WebSockets out of the renderer
+ * (e.g. Tauri/Electron hosts relaying through IPC). For the common case
+ * where you just want a WebSocket connection from the React tree, use
+ * {@link BuckarooServerView}, which is a thin wrapper around this component.
+ */
+export function BuckarooView({
+    model,
+    initialState,
+    mode,
+    onMetadata,
+    style,
+    className,
+}: BuckarooViewProps): React.ReactElement {
+    const [dfMeta, setDfMeta] = React.useState<DFMeta>(
+        (initialState.df_meta as DFMeta) ?? DEFAULT_DF_META,
+    );
+    const [dfDataDict, setDfDataDict] = React.useState<Record<string, DFData>>(
+        (initialState.df_data_dict as Record<string, DFData>) ?? {},
+    );
+    const [dfDisplayArgs, setDfDisplayArgs] = React.useState<Record<string, IDisplayArgs>>(
+        (initialState.df_display_args as Record<string, IDisplayArgs>) ?? {},
+    );
+    const [buckarooState, setBuckarooStateLocal] = React.useState<BuckarooState>(
+        (initialState.buckaroo_state as BuckarooState) ?? DEFAULT_BUCKAROO_STATE,
+    );
+    const [buckarooOptions, setBuckarooOptions] = React.useState<BuckarooOptions>(
+        (initialState.buckaroo_options as BuckarooOptions) ?? DEFAULT_BUCKAROO_OPTIONS,
+    );
+    const [commandConfig, setCommandConfig] = React.useState<CommandConfigT>(
+        (initialState.command_config as CommandConfigT) ?? DEFAULT_COMMAND_CONFIG,
+    );
+    const [operationResults, setOperationResults] = React.useState<OperationResult>(
+        (initialState.operation_results as OperationResult) ?? baseOperationResults,
+    );
+    const [operations, setOperations] = React.useState<Operation[]>(
+        (initialState.operations as Operation[]) ?? [],
+    );
+
+    const onMetadataRef = React.useRef(onMetadata);
+    React.useEffect(() => { onMetadataRef.current = onMetadata; }, [onMetadata]);
+
+    // Resolve any parquet-encoded payloads in df_data_dict. Pre-resolved
+    // dicts (e.g. when BuckarooServerView already ran preResolveDFDataDict)
+    // pass through unchanged, so this is cheap in the common case.
+    React.useEffect(() => {
+        let cancelled = false;
+        const dict = initialState.df_data_dict as Record<string, DFDataOrPayload> | undefined;
+        if (!dict) return;
+        preResolveDFDataDict(dict).then((d) => {
+            if (!cancelled) setDfDataDict(d as Record<string, DFData>);
+        });
+        return () => { cancelled = true; };
+    }, [initialState]);
+
+    // Fire onMetadata for the initial payload, matching BuckarooServerView's
+    // pre-split behavior.
+    React.useEffect(() => {
+        if (initialState.metadata) {
+            onMetadataRef.current?.(
+                initialState.metadata as BuckarooServerMetadata,
+                initialState.prompt as string | undefined,
+            );
+        }
+    }, [initialState]);
+
+    const src = React.useMemo(
+        () => getKeySmartRowCache(model, (a: unknown, b: unknown) => console.error("[BuckarooView] cache error:", a, b)),
+        [model],
+    );
+
+    React.useEffect(() => {
+        const onMeta = (metadata: BuckarooServerMetadata, prompt?: string) => {
+            onMetadataRef.current?.(metadata, prompt);
+            setDfMeta((model.get("df_meta") as DFMeta | undefined) ?? { ...DEFAULT_DF_META, total_rows: metadata?.rows ?? 0 });
+            preResolveDFDataDict((model.get("df_data_dict") as Record<string, DFDataOrPayload> | undefined) ?? {})
+                .then((d) => setDfDataDict(d as Record<string, DFData>));
+            setDfDisplayArgs((model.get("df_display_args") as Record<string, IDisplayArgs> | undefined) ?? {});
+            setBuckarooStateLocal((model.get("buckaroo_state") as BuckarooState | undefined) ?? DEFAULT_BUCKAROO_STATE);
+            setBuckarooOptions((model.get("buckaroo_options") as BuckarooOptions | undefined) ?? DEFAULT_BUCKAROO_OPTIONS);
+            setCommandConfig((model.get("command_config") as CommandConfigT | undefined) ?? DEFAULT_COMMAND_CONFIG);
+            setOperationResults((model.get("operation_results") as OperationResult | undefined) ?? baseOperationResults);
+            setOperations((model.get("operations") as Operation[] | undefined) ?? []);
+        };
+        const onDfMeta = (v: DFMeta) => setDfMeta(v);
+        const onDfDataDict = (v: Record<string, DFDataOrPayload>) => {
+            preResolveDFDataDict(v).then((d) => setDfDataDict(d as Record<string, DFData>));
+        };
+        const onDfDisplayArgs = (v: Record<string, IDisplayArgs>) => setDfDisplayArgs(v);
+        const onBState = (v: BuckarooState) => setBuckarooStateLocal(v);
+        const onBOpts = (v: BuckarooOptions) => setBuckarooOptions(v);
+        const onCmdCfg = (v: CommandConfigT) => setCommandConfig(v);
+        const onOpRes = (v: OperationResult) => setOperationResults(v);
+        const onOps = (v: Operation[]) => setOperations(v);
+
+        model.on("metadata", onMeta);
+        model.on("change:df_meta", onDfMeta);
+        model.on("change:df_data_dict", onDfDataDict);
+        model.on("change:df_display_args", onDfDisplayArgs);
+        model.on("change:buckaroo_state", onBState);
+        model.on("change:buckaroo_options", onBOpts);
+        model.on("change:command_config", onCmdCfg);
+        model.on("change:operation_results", onOpRes);
+        model.on("change:operations", onOps);
+
+        return () => {
+            model.off("metadata", onMeta);
+            model.off("change:df_meta", onDfMeta);
+            model.off("change:df_data_dict", onDfDataDict);
+            model.off("change:df_display_args", onDfDisplayArgs);
+            model.off("change:buckaroo_state", onBState);
+            model.off("change:buckaroo_options", onBOpts);
+            model.off("change:command_config", onCmdCfg);
+            model.off("change:operation_results", onOpRes);
+            model.off("change:operations", onOps);
+        };
+    }, [model]);
+
+    const onBuckarooState = React.useCallback<React.Dispatch<React.SetStateAction<BuckarooState>>>((newState) => {
+        const resolved = typeof newState === "function"
+            ? (newState as (prev: BuckarooState) => BuckarooState)(buckarooState)
+            : newState;
+        model.set("buckaroo_state", resolved);
+        model.save_changes();
+    }, [model, buckarooState]);
+
+    const onOperations = React.useCallback((newOps: Operation[]) => {
+        model.set("operations", newOps);
+        model.save_changes();
+    }, [model]);
+
+    const wrapperStyle: React.CSSProperties = { width: "100%", height: "100%", ...(style ?? {}) };
+
+    if (!dfDisplayArgs?.main) {
+        return (
+            <div className={className} style={wrapperStyle}>
+                <div style={{ padding: 20, fontFamily: "sans-serif" }}>Preparing…</div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={["buckaroo_anywidget", className].filter(Boolean).join(" ")} style={wrapperStyle}>
+            {mode === "buckaroo" ? (
+                <BuckarooInfiniteWidget
+                    df_meta={dfMeta}
+                    df_data_dict={dfDataDict}
+                    df_display_args={dfDisplayArgs}
+                    operations={operations}
+                    on_operations={onOperations}
+                    operation_results={operationResults}
+                    command_config={commandConfig}
+                    buckaroo_state={buckarooState}
+                    on_buckaroo_state={onBuckarooState}
+                    buckaroo_options={buckarooOptions}
+                    src={src}
+                />
+            ) : (
+                <DFViewerInfiniteDS
+                    df_meta={dfMeta}
+                    df_data_dict={dfDataDict}
+                    df_display_args={dfDisplayArgs}
+                    src={src}
+                    df_id={"server"}
+                />
+            )}
+        </div>
+    );
+}

--- a/packages/buckaroo-js-core/src/server/BuckarooView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.tsx
@@ -36,6 +36,24 @@ const DEFAULT_BUCKAROO_OPTIONS: BuckarooOptions = {
 };
 const DEFAULT_COMMAND_CONFIG: CommandConfigT = { argspecs: {}, defaultArgs: {} };
 
+// Inline check — mirrors the (module-private) guard in resolveDFData.ts.
+// We can't import it directly without widening that module's API surface.
+function hasUnresolvedParquet(dict: unknown): boolean {
+    if (!dict || typeof dict !== "object") return false;
+    for (const v of Object.values(dict as Record<string, unknown>)) {
+        if (
+            v !== null &&
+            typeof v === "object" &&
+            !Array.isArray(v) &&
+            (v as any).format === "parquet_b64" &&
+            typeof (v as any).data === "string"
+        ) {
+            return true;
+        }
+    }
+    return false;
+}
+
 export interface BuckarooViewProps {
     /** An already-connected model implementing {@link IModel}. The caller is
      *  responsible for transport setup (WebSocket, Tauri IPC, etc.) and for
@@ -91,12 +109,26 @@ export function BuckarooView({
     style,
     className,
 }: BuckarooViewProps): React.ReactElement {
+    // If the caller passed raw initial_state straight off the wire,
+    // df_data_dict may still contain parquet_b64 payload objects. Those
+    // would crash makeStaticInfiniteDs (data.slice on a payload object),
+    // so block the widget render until the async resolution effect has
+    // populated dfDataDict. The BuckarooServerView wrapper pre-resolves
+    // before mounting, so it skips this path.
+    const initialNeedsResolution = React.useMemo(
+        () => hasUnresolvedParquet(initialState.df_data_dict),
+        [initialState],
+    );
+
     const [dfMeta, setDfMeta] = React.useState<DFMeta>(
         (initialState.df_meta as DFMeta) ?? DEFAULT_DF_META,
     );
     const [dfDataDict, setDfDataDict] = React.useState<Record<string, DFData>>(
-        (initialState.df_data_dict as Record<string, DFData>) ?? {},
+        initialNeedsResolution
+            ? {}
+            : ((initialState.df_data_dict as Record<string, DFData>) ?? {}),
     );
+    const [dataReady, setDataReady] = React.useState<boolean>(!initialNeedsResolution);
     const [dfDisplayArgs, setDfDisplayArgs] = React.useState<Record<string, IDisplayArgs>>(
         (initialState.df_display_args as Record<string, IDisplayArgs>) ?? {},
     );
@@ -121,16 +153,24 @@ export function BuckarooView({
 
     // Resolve any parquet-encoded payloads in df_data_dict. Pre-resolved
     // dicts (e.g. when BuckarooServerView already ran preResolveDFDataDict)
-    // pass through unchanged, so this is cheap in the common case.
+    // pass through unchanged, so this is cheap in the common case. Skip
+    // entirely when no resolution is needed — avoids a spurious re-render
+    // for the BuckarooServerView path.
     React.useEffect(() => {
+        if (!initialNeedsResolution) return;
         let cancelled = false;
         const dict = initialState.df_data_dict as Record<string, DFDataOrPayload> | undefined;
-        if (!dict) return;
+        if (!dict) {
+            setDataReady(true);
+            return;
+        }
         preResolveDFDataDict(dict).then((d) => {
-            if (!cancelled) setDfDataDict(d as Record<string, DFData>);
+            if (cancelled) return;
+            setDfDataDict(d as Record<string, DFData>);
+            setDataReady(true);
         });
         return () => { cancelled = true; };
-    }, [initialState]);
+    }, [initialState, initialNeedsResolution]);
 
     // Fire onMetadata for the initial payload, matching BuckarooServerView's
     // pre-split behavior.
@@ -210,7 +250,7 @@ export function BuckarooView({
 
     const wrapperStyle: React.CSSProperties = { width: "100%", height: "100%", ...(style ?? {}) };
 
-    if (!dfDisplayArgs?.main) {
+    if (!dfDisplayArgs?.main || !dataReady) {
         return (
             <div className={className} style={wrapperStyle}>
                 <div style={{ padding: 20, fontFamily: "sans-serif" }}>Preparing…</div>

--- a/packages/buckaroo-js-core/src/server/IModel.ts
+++ b/packages/buckaroo-js-core/src/server/IModel.ts
@@ -1,0 +1,23 @@
+/**
+ * IModel — minimal transport-agnostic model interface that BuckarooView
+ * depends on. Implemented by WebSocketModel (this package) and by host
+ * adapters that relay buckaroo's server protocol through a non-WebSocket
+ * transport (e.g. buckaroo-tauri-adapter's TauriIPCModel).
+ *
+ * This is the same surface anywidget exposes for traitlet sync, narrowed
+ * to what getKeySmartRowCache and the BuckarooView state hooks call:
+ *
+ *   send(msg)               → ship a JSON message to the backend
+ *   get(key) / set(key, v)  → read/write local state
+ *   save_changes()          → flush set() calls back to the backend
+ *   on(event, fn)           → subscribe to "change:<key>", "metadata", "msg:custom"
+ *   off(event, fn)
+ */
+export interface IModel {
+    send(msg: any): void;
+    get(key: string): any;
+    set(key: string, value: any): void;
+    save_changes(): void;
+    on(event: string, handler: (...args: any[]) => void): void;
+    off(event: string, handler: (...args: any[]) => void): void;
+}

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -3,9 +3,7 @@ from buckaroo.customizations.polars_analysis import (
     VCAnalysis, PLCleaningStats, BasicAnalysis)
 from buckaroo.pluggable_analysis_framework.polars_analysis_management import PlDfStats
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
-from buckaroo.dataflow.autocleaning import (
-    merge_ops, format_ops, AutocleaningConfig, _rekey_op_sd_to_internal,
-)
+from buckaroo.dataflow.autocleaning import (merge_ops, format_ops, AutocleaningConfig, _rekey_op_sd_to_internal)
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
     Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search, SDResult
@@ -261,8 +259,7 @@ def test_rekey_preserves_analysis_entries_when_orig_names_collide_with_letters()
         'a': {'rewritten_col_name': 'a', 'orig_col_name': 'b', '_type': 'integer'},
         'b': {'rewritten_col_name': 'b', 'orig_col_name': 'foo', '_type': 'integer'},
         # op-contributed entry keyed by orig name 'foo'
-        'foo': {'highlight_regex': 'x'},
-    }
+        'foo': {'highlight_regex': 'x'}}
     out = _rekey_op_sd_to_internal(cleaning_sd, cleaned_df)
     # analysis entries untouched, in place
     assert out['a']['orig_col_name'] == 'b'


### PR DESCRIPTION
## Summary

- Extract a transport-agnostic \`BuckarooView\` from \`BuckarooServerView\`. Existing \`BuckarooServerView\` API is unchanged — it's now a thin wrapper that opens the WebSocket, awaits \`initial_state\`, and delegates rendering to \`BuckarooView\`.
- Add an \`IModel\` interface — the minimal model surface (\`send\`/\`get\`/\`set\`/\`save_changes\`/\`on\`/\`off\`) that \`BuckarooView\` consumes. \`WebSocketModel\` is structurally assignable to it; host adapters like \`buckaroo-tauri-adapter\`'s \`TauriIPCModel\` can now drive \`BuckarooView\` directly without opening a renderer-side WebSocket.

Closes #759.

## Why

For Tauri / Electron / Wails hosts that explicitly avoid renderer-side network sockets (CSP tightening, sandbox compat, no-listening-port property), \`BuckarooServerView\` was a non-starter — it constructs its own \`WebSocketModel\` internally. The two prior options were both bad trades: widen CSP \`connect-src\` to \`ws://\`, or rebuild the row-cache / mode-dispatch / pre-resolution wiring by hand. This PR makes the wiring a first-class export so host adapters can inject a pre-connected model.

## API

\`\`\`tsx
import { BuckarooView, IModel } from \"buckaroo-js-core\";

const initial = await waitForInitialState();      // adapter helper
const model: IModel = new TauriIPCModel(initial); // your IPC-backed adapter

<BuckarooView
  model={model}
  initialState={initial}
  mode={initial.mode}                             // \"viewer\" | \"buckaroo\"
  onMetadata={(m) => console.log(m.path)}
/>
\`\`\`

No webview WS, CSP can stay tight, and \`buckaroo-tauri\`'s \"renderer never opens a socket\" property holds.

## Backwards compatibility

- \`BuckarooServerView\` API surface unchanged: same props (\`wsUrl\`, \`renderConnecting\`, \`renderError\`, \`onMetadata\`, \`style\`, \`className\`), same connect → wait-for-initial_state → render flow.
- Re-exports \`BuckarooServerMode\` and \`BuckarooServerMetadata\` from the same path they shipped at, so existing imports keep resolving.

## Test plan

- [x] \`pnpm test\` — 235 tests pass (includes new \`BuckarooView.test.tsx\` covering the IModel injection path with a fake model)
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm run build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)