### PR TITLE
chore(widget): cross-stream bk-flash tracing + console cleanup

### DIFF
--- a/buckaroo/buckaroo_widget.py
+++ b/buckaroo/buckaroo_widget.py
@@ -7,7 +7,10 @@
 """
 TODO: Add module docstring
 """
+import os
+import sys
 import traceback
+from datetime import datetime
 from typing import Literal, Union
 import pandas as pd
 import json
@@ -34,6 +37,21 @@ from .dataflow.autocleaning import PandasAutocleaning
 from pathlib import Path
 
 logger = logging.getLogger()
+
+# Opt-in cross-boundary tracing. Set BUCKAROO_BK_FLASH=1 in the kernel
+# environment AND globalThis.__BK_FLASH__ = true in the browser before
+# bundle load to see Python `[bk-flash-py HH:MM:SS.mmm]` and JS
+# `[bk-flash …]` lines interleaved for the same widget interaction.
+_BK_FLASH_ENABLED = os.environ.get("BUCKAROO_BK_FLASH", "").lower() in ("1", "true", "yes")
+
+
+def _bk_flash(event, **extra):
+    if not _BK_FLASH_ENABLED:
+        return
+    ts = datetime.now().strftime('%H:%M:%S.%f')[:-3]
+    extras = ' '.join(f"{k}={v!r}" for k, v in extra.items())
+    suffix = f" {extras}" if extras else ""
+    print(f"[bk-flash-py {ts}] {event}{suffix}", file=sys.stderr, flush=True)
 
 class PdSampling(Sampling):
     @classmethod
@@ -201,6 +219,11 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
     @exception_protect('buckaroo_state-protector')
     def _buckaroo_state(self, change):
         old, new = change['old'], change['new']
+        if _BK_FLASH_ENABLED:
+            changed = [k for k in new if old.get(k) != new.get(k)]
+            if changed:
+                _bk_flash("buckaroo_state ← JS", changed=changed,
+                    quick_command_args=new.get('quick_command_args'))
         if not old['post_processing'] == new['post_processing']:
             self.dataflow.post_processing_method = new['post_processing']
         if not old['cleaning_method'] == new['cleaning_method']:
@@ -321,8 +344,10 @@ class BuckarooInfiniteWidget(BuckarooWidget):
         """
        put together df_dict for consumption by the frontend
         """
+        _bk_flash("_handle_widget_change ENTER")
         _unused, processed_df, merged_sd = self.dataflow.widget_args_tuple
         if processed_df is None:
+            _bk_flash("_handle_widget_change EXIT — processed_df is None")
             return
 
         # df_data_dict is still hardcoded for now
@@ -358,6 +383,7 @@ class BuckarooInfiniteWidget(BuckarooWidget):
             temp_display_args['main']['df_viewer_config']['component_config'] = self.dataflow.component_config
 
         self.df_display_args = temp_display_args
+        _bk_flash("_handle_widget_change EXIT (df_display_args → JS)")
 
 
     def __init__(self, orig_df, debug=False,
@@ -381,8 +407,11 @@ class BuckarooInfiniteWidget(BuckarooWidget):
 
     def _handle_payload_args(self, new_payload_args):
         start, end = new_payload_args['start'], new_payload_args['end']
+        _bk_flash("infinite_request ← JS", start=start, end=end,
+            sort=new_payload_args.get('sort'))
         _unused, processed_df, merged_sd = self.dataflow.widget_args_tuple
         if processed_df is None:
+            _bk_flash("infinite_request — processed_df is None, no resp sent")
             return
 
         try:
@@ -396,15 +425,21 @@ class BuckarooInfiniteWidget(BuckarooWidget):
                 slice_df = sorted_df[start:end]
                 self.send({ "type": "infinite_resp", 'key':new_payload_args, 'data':[], 'length':len(processed_df)},
                     [to_parquet(slice_df)])
+                if _BK_FLASH_ENABLED:
+                    _bk_flash("infinite_resp → JS (sorted)", rows=len(slice_df),
+                        total=len(processed_df))
             else:
                 slice_df = processed_df[start:end]
                 self.send({ "type": "infinite_resp", 'key':new_payload_args,
                     'data': [], 'length':len(processed_df)}, [to_parquet(slice_df) ])
-    
+                if _BK_FLASH_ENABLED:
+                    _bk_flash("infinite_resp → JS", rows=len(slice_df),
+                        total=len(processed_df))
+
                 second_pa = new_payload_args.get('second_request')
                 if not second_pa:
                     return
-                
+
                 extra_start, extra_end = second_pa.get('start'), second_pa.get('end')
                 extra_df = processed_df[extra_start:extra_end]
                 self.send(
@@ -414,6 +449,7 @@ class BuckarooInfiniteWidget(BuckarooWidget):
             logger.error(e)
             stack_trace = traceback.format_exc()
             self.send({ "type": "infinite_resp", 'key':new_payload_args, 'data':[], 'error_info':stack_trace, 'length':0})
+            _bk_flash("infinite_resp → JS (ERROR)", error=str(e))
             raise
 
 

--- a/buckaroo/polars_buckaroo.py
+++ b/buckaroo/polars_buckaroo.py
@@ -4,7 +4,7 @@ import traceback
 import polars as pl
 from traitlets import Unicode
 
-from buckaroo.buckaroo_widget import BuckarooWidget, BuckarooInfiniteWidget, RawDFViewerWidget
+from buckaroo.buckaroo_widget import BuckarooWidget, BuckarooInfiniteWidget, RawDFViewerWidget, _bk_flash, _BK_FLASH_ENABLED
 from buckaroo.df_util import old_col_new_col
 from .pluggable_analysis_framework.df_stats_v2 import PlDfStatsV2
 from .pluggable_analysis_framework.polars_analysis_management import PlDfStats
@@ -91,8 +91,11 @@ def to_parquet(df):
 class PolarsBuckarooInfiniteWidget(PolarsBuckarooWidget, BuckarooInfiniteWidget):
     def _handle_payload_args(self, new_payload_args):
         start, end = new_payload_args['start'], new_payload_args['end']
+        _bk_flash("infinite_request ← JS", start=start, end=end,
+            sort=new_payload_args.get('sort'))
         _unused, processed_df, merged_sd = self.dataflow.widget_args_tuple
         if processed_df is None:
+            _bk_flash("infinite_request — processed_df is None, no resp sent")
             return
 
         try:
@@ -104,29 +107,36 @@ class PolarsBuckarooInfiniteWidget(PolarsBuckarooWidget, BuckarooInfiniteWidget)
                 converted_sort_column = processed_sd[sort]['orig_col_name']
                 sorted_df = processed_df.with_row_index().sort(converted_sort_column, descending=not ascending)
                 slice_df = sorted_df[start:end]
-                #slice_df['index'] = slice_df.index
                 self.send({ "type": "infinite_resp", 'key':new_payload_args, 'data':[], 'length':len(processed_df)},
                     [to_parquet(slice_df)])
+                if _BK_FLASH_ENABLED:
+                    _bk_flash("infinite_resp → JS (sorted)", rows=len(slice_df),
+                        total=len(processed_df))
             else:
                 slice_df = processed_df.with_row_index()[start:end]
-                #slice_df['index'] = slice_df.index
                 self.send({ "type": "infinite_resp", 'key':new_payload_args,
                     'data': [], 'length':len(processed_df)}, [to_parquet(slice_df) ])
-    
+                if _BK_FLASH_ENABLED:
+                    _bk_flash("infinite_resp → JS", rows=len(slice_df),
+                        total=len(processed_df))
+
                 second_pa = new_payload_args.get('second_request')
                 if not second_pa:
                     return
-                
+
                 extra_start, extra_end = second_pa.get('start'), second_pa.get('end')
                 extra_df = processed_df.with_row_index()[extra_start:extra_end]
                 extra_df['index'] = extra_df.index
                 self.send(
                     {"type": "infinite_resp", 'key':second_pa, 'data':[], 'length':len(processed_df)},
                     [to_parquet(extra_df)])
+                if _BK_FLASH_ENABLED:
+                    _bk_flash("infinite_resp → JS (second)", rows=len(extra_df))
         except Exception as e:
             print(e)
             stack_trace = traceback.format_exc()
             self.send({ "type": "infinite_resp", 'key':new_payload_args, 'data':[], 'error_info':stack_trace, 'length':0})
+            _bk_flash("infinite_resp → JS (ERROR)", error=str(e))
             raise
 
 

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -20,16 +20,26 @@ import { KeyAwareSmartRowCache, PayloadArgs, PayloadResponse, RequestFN } from "
 import { parquetRead, parquetMetadata } from 'hyparquet'
 import { MessageBox } from "./MessageBox";
 
-// Trace memo/render boundaries on the search + df_display toggle paths. Opt-in:
-// set `globalThis.__BK_FLASH__ = true` before bundle load to enable. Grep
-// "[bk-flash]" in the console to see the timeline.
-const BK_FLASH = typeof globalThis !== "undefined" && (globalThis as { __BK_FLASH__?: boolean }).__BK_FLASH__ === true;
-const bkLog: (event: string, extra?: Record<string, unknown>) => void = BK_FLASH
-    ? (event, extra) => {
-          // eslint-disable-next-line no-console
-          console.log(`[bk-flash ${performance.now().toFixed(1)}ms] ${event}`, extra ?? "");
-      }
-    : () => {};
+// Trace memo/render boundaries on the search + df_display toggle paths.
+// Opt-in: flip `globalThis.__BK_FLASH__ = true` in DevTools at any time
+// (gate is checked per-call, no reload needed). Wall-clock HH:MM:SS.mmm
+// timestamps so the browser timeline can be correlated with Python's
+// [bk-flash-py …] prints across the anywidget sync boundary
+// (BUCKAROO_BK_FLASH=1 in the kernel env). grep "[bk-flash" in the
+// browser console + kernel output.
+export const bkTs = (): string => {
+    const d = new Date();
+    const p2 = (n: number) => String(n).padStart(2, "0");
+    const p3 = (n: number) => String(n).padStart(3, "0");
+    return `${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}.${p3(d.getMilliseconds())}`;
+};
+const bkFlashOn = (): boolean =>
+    typeof globalThis !== "undefined" && (globalThis as { __BK_FLASH__?: boolean }).__BK_FLASH__ === true;
+const bkLog = (event: string, extra?: Record<string, unknown>): void => {
+    if (!bkFlashOn()) return;
+    // eslint-disable-next-line no-console
+    console.log(`[bk-flash ${bkTs()}] ${event}`, extra ?? "");
+};
 
 // Wrap a static DFData array in a fake IDatasource. Used for summary stats
 // and other small pre-loaded datasets so they can share the same AG-Grid
@@ -37,24 +47,12 @@ const bkLog: (event: string, extra?: Record<string, unknown>) => void = BK_FLASH
 // df_display from "main" to "summary" flips data_wrapper.data_type from
 // DataSource to Raw and forces an AG-Grid remount (rowModelType can't be
 // reconfigured live). With this, headers stay mounted across the swap.
-export const makeStaticInfiniteDs = (data: DFData, label?: string): IDatasource => {
-    bkLog("makeStaticInfiniteDs constructed", { label, dataLen: data.length });
+export const makeStaticInfiniteDs = (data: DFData, _label?: string): IDatasource => {
     return {
         rowCount: data.length,
         getRows: (params: IGetRowsParams) => {
-            // Static data is always available — respond synchronously, no loading
-            // state, no network round-trip.
             const slice = data.slice(params.startRow, params.endRow);
-            bkLog("fakeDs.getRows ENTER", {
-                label,
-                startRow: params.startRow,
-                endRow: params.endRow,
-                sortModel: params.sortModel,
-                sliceLen: slice.length,
-                lastRow: data.length,
-            });
             params.successCallback(slice, data.length);
-            bkLog("fakeDs.getRows EXIT (successCallback called)", { label });
         },
     };
 };
@@ -65,11 +63,6 @@ export const getDataWrapper = (
     ds: IDatasource,
     total_rows?: number
 ): DatasourceOrRaw => {
-    bkLog("getDataWrapper called", {
-        data_key,
-        hasKeyInDict: df_data_dict[data_key] !== undefined,
-        total_rows,
-    });
     if (data_key === "main") {
         return {
             data_type: "DataSource",
@@ -100,6 +93,7 @@ const gensym = () => {
 export const getKeySmartRowCache = (model: any, setRespError:any) => {
     //const symNum = counter();
     const reqFn: RequestFN = (pa: PayloadArgs) => {
+        bkLog("model.send infinite_request → Python", { start: pa.start, end: pa.end });
         model.send({ type: 'infinite_request', payload_args: pa })
     }
     const src = new KeyAwareSmartRowCache(reqFn)
@@ -112,6 +106,12 @@ export const getKeySmartRowCache = (model: any, setRespError:any) => {
             return
         }
         const payload_response = msg as PayloadResponse;
+        bkLog("model.on infinite_resp ← Python", {
+            start: payload_response.key?.start,
+            end: payload_response.key?.end,
+            length: payload_response.length,
+            hasError: payload_response.error_info !== undefined,
+        });
         if (payload_response.error_info !== undefined) {
             src.addErrorResponse(payload_response);
             console.error("[buckaroo] infinite_resp error:", payload_response.error_info)
@@ -178,14 +178,6 @@ export function BuckarooInfiniteWidget({
         // still get the in-place update path.
         dataframe_id?: string;
     }) {
-    bkLog("BuckarooInfiniteWidget render", {
-        df_display: buckaroo_state.df_display,
-        post_processing: buckaroo_state.post_processing,
-        cleaning_method: buckaroo_state.cleaning_method,
-        quick_command_args: buckaroo_state.quick_command_args,
-        dataframe_id,
-        opsLen: operations.length,
-    });
         // we only want to create KeyAwareSmartRowCache once, it caches sourceName too
         // so having it live between relaods is key
         //const [respError, setRespError] = useState<string | undefined>(undefined);

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFViewerInfinite.tsx
@@ -51,16 +51,25 @@ ModuleRegistry.registerModules([
 
 const AccentColor = "#2196F3"
 
-// Trace memo/render boundaries on the search + df_display toggle paths. Opt-in:
-// set `globalThis.__BK_FLASH__ = true` before bundle load to enable. Grep
-// "[bk-flash]" in the console to see the timeline.
-const BK_FLASH = typeof globalThis !== "undefined" && (globalThis as { __BK_FLASH__?: boolean }).__BK_FLASH__ === true;
-const bkLog: (event: string, extra?: Record<string, unknown>) => void = BK_FLASH
-    ? (event, extra) => {
-          // eslint-disable-next-line no-console
-          console.log(`[bk-flash ${performance.now().toFixed(1)}ms] ${event}`, extra ?? "");
-      }
-    : () => {};
+// Trace memo/render boundaries on the search + df_display toggle paths.
+// Opt-in: flip `globalThis.__BK_FLASH__ = true` in DevTools at any time
+// (gate is checked per-call). Wall-clock HH:MM:SS.mmm for cross-stream
+// correlation with Python's [bk-flash-py …] prints (kernel: BUCKAROO_BK_FLASH=1).
+// grep "[bk-flash" in the browser console + kernel output to assemble the
+// round-trip.
+const bkTs = (): string => {
+    const d = new Date();
+    const p2 = (n: number) => String(n).padStart(2, "0");
+    const p3 = (n: number) => String(n).padStart(3, "0");
+    return `${p2(d.getHours())}:${p2(d.getMinutes())}:${p2(d.getSeconds())}.${p3(d.getMilliseconds())}`;
+};
+const bkFlashOn = (): boolean =>
+    typeof globalThis !== "undefined" && (globalThis as { __BK_FLASH__?: boolean }).__BK_FLASH__ === true;
+const bkLog = (event: string, extra?: Record<string, unknown>): void => {
+    if (!bkFlashOn()) return;
+    // eslint-disable-next-line no-console
+    console.log(`[bk-flash ${bkTs()}] ${event}`, extra ?? "");
+};
 
 export interface DatasourceWrapper {
     datasource: IDatasource;
@@ -163,12 +172,6 @@ export function DFViewerInfinite({
     // different record than row 0 in summary).
     data_key?: string;
 }) {
-    bkLog("DFViewerInfinite render", {
-        view_name,
-        data_key,
-        data_type: data_wrapper.data_type,
-        length: data_wrapper.length,
-    });
     /*
     The idea is to do some pre-setup here for
     */
@@ -262,15 +265,6 @@ export function DFViewerInfiniteInner({
     view_name?: string;
     data_key?: string;
 }) {
-    bkLog("DFViewerInfiniteInner render", {
-        view_name,
-        data_key,
-        data_type: data_wrapper.data_type,
-        length: data_wrapper.length,
-        outside_df_params,
-    });
-
-
     /*
     const lastProps = useRef<any>(null);
 
@@ -390,14 +384,8 @@ export function DFViewerInfiniteInner({
         onFirstDataRendered: (_params) => {
             bkLog("AgGrid onFirstDataRendered");
         },
-        onModelUpdated: (_params) => {
-            bkLog("AgGrid onModelUpdated");
-        },
         onRowDataUpdated: (_params) => {
-            bkLog("AgGrid onRowDataUpdated");
-        },
-        onSortChanged: (_event) => {
-            bkLog("AgGrid onSortChanged", { sortModel: _event.api.getColumnState().filter((c: any) => c.sort) });
+            bkLog("AgGrid onRowDataUpdated (cells repainted)");
         },
         columnDefs:styledColumns,
         getRowId,
@@ -413,10 +401,6 @@ export function DFViewerInfiniteInner({
 
         // Extract datasource separately to ensure it updates when data_wrapper changes
         const datasource = useMemo(() => {
-            bkLog("datasource useMemo recomputing", {
-                data_type: data_wrapper.data_type,
-                length: data_wrapper.length,
-            });
             return data_wrapper.data_type === "DataSource" ? data_wrapper.datasource : {
                 rowCount: data_wrapper.length,
                 getRows: (_params: any) => {
@@ -525,12 +509,11 @@ export function DFViewerInfiniteInner({
         const viewStateRef = useRef<Record<string, { columnState: any[] }>>({});
         const prevViewNameRef = useRef<string | undefined>(view_name);
         useEffect(() => {
+            if (prevViewNameRef.current === view_name) return;
             bkLog("view_name effect fired", {
                 from: prevViewNameRef.current,
                 to: view_name,
-                same: prevViewNameRef.current === view_name,
             });
-            if (prevViewNameRef.current === view_name) return;
             const api = gridRef.current?.api;
             const prev = prevViewNameRef.current;
             prevViewNameRef.current = view_name;
@@ -580,7 +563,6 @@ export function DFViewerInfiniteInner({
                     datasource={datasource}
                     columnDefs={styledColumns}
                     onGridReady={(params) => {
-                        bkLog("AgGrid onGridReady", { view_name, data_key });
                         try {
                             // Ensure pinned rows are applied once API is ready
                             params.api.setGridOption('pinnedTopRowData', topRowsRef.current || []);

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
@@ -458,7 +458,6 @@ export type FailCB = () => void;
 
 
 function verifyResp(resp: PayloadResponse):boolean {
-    debugger;
     if (resp.data.length === 0) {
         return false
     }


### PR DESCRIPTION
## Summary

Extracted from #749. The JS side already had an opt-in `[bk-flash …]` tracer; this adds the Python counterpart and harmonizes the timestamp format so the two streams can be grep'd and interleaved when debugging the search → request → response round-trip.

## What's in

- **Python `_bk_flash`** (`buckaroo/buckaroo_widget.py`): wall-clock `[bk-flash-py HH:MM:SS.mmm]` to stderr, gated by `BUCKAROO_BK_FLASH=1`. Call sites in `_buckaroo_state`, `_handle_widget_change`, `_handle_payload_args` (pandas + polars).
- **JS bkLog harmonization**: swap `performance.now()` for wall-clock `bkTs()` in `BuckarooWidgetInfinite.tsx` and `DFViewerInfinite.tsx` so JS lines align with Python timestamps. Gate is now runtime-checkable (`bkFlashOn()` per call), so `globalThis.__BK_FLASH__ = true` works in DevTools without a bundle reload.
- **New boundary logs** at `model.send infinite_request → Python` and `model.on infinite_resp ← Python`.
- **Trim**: removed unconditional render-time `bkLog` calls (BuckarooInfiniteWidget render, makeStaticInfiniteDs, fakeDs.getRows, getDataWrapper, DFViewer{,Inner} render, datasource useMemo, AgGrid onModelUpdated/onSortChanged/onGridReady, view_name effect when from===to). Keeps signal-to-noise usable when the flag is on.
- **Drop `debugger;`** in `SmartRowCache.ts:461`.

## Enabling the trace

In the kernel:
```bash
BUCKAROO_BK_FLASH=1 jupyter lab
```

In DevTools:
```js
globalThis.__BK_FLASH__ = true
```

Then re-run the widget cell and grep `[bk-flash` in both the browser console and kernel output.

## Test plan

- [x] `pnpm run build:tsc` clean
- [x] `pnpm test` — 233 pass
- [x] `pytest tests/unit/` — 987 pass (1 unrelated build-artifact failure on `test_mcp_uvx_install.py::test_view_data_call` reproduces on plain main and is deselected)
- [x] `BUCKAROO_BK_FLASH=1 pytest tests/unit/test_xorq_buckaroo_widget.py tests/unit/polars_basic_widget_test.py` — 49 pass (verifies guards around `len(processed_df)` don't blow up on xorq Ibis exprs)
- [ ] Manual: enable both flags, type into the search box, see the round-trip timeline (qca → buckaroo_state ← JS → handle_widget_change → infinite_request → infinite_resp → onRowDataUpdated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)