### PR TITLE
chore(lint): pre-push hook for full-tree paddy-format + ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,3 +20,22 @@ repos:
         language: system
         files: ^packages/buckaroo-js-core/.*\.(ts|tsx)$
         pass_filenames: false
+      # Pre-push gate: re-run CI's Python / Lint job locally before push.
+      # The pre-commit `paddy-format` hook above only sees staged files,
+      # so drift in a file you didn't touch (e.g. introduced by a recent
+      # merge to main) slips through and only surfaces on CI. Mirrors
+      # the `LintPython` job in .github/workflows/checks.yml.
+      - id: ruff-check-full
+        name: ruff check (full tree)
+        entry: uv run ruff check
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true
+      - id: paddy-format-check-full
+        name: paddy-format --check (full tree)
+        entry: bash -c 'find buckaroo tests scripts -type f -name "*.py" -not -path "buckaroo/jlisp/lispy.py" -print0 | xargs -0 uv run python scripts/paddy_format.py --check'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+        always_run: true

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -3,9 +3,7 @@ from buckaroo.customizations.polars_analysis import (
     VCAnalysis, PLCleaningStats, BasicAnalysis)
 from buckaroo.pluggable_analysis_framework.polars_analysis_management import PlDfStats
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
-from buckaroo.dataflow.autocleaning import (
-    merge_ops, format_ops, AutocleaningConfig, _rekey_op_sd_to_internal,
-)
+from buckaroo.dataflow.autocleaning import (merge_ops, format_ops, AutocleaningConfig, _rekey_op_sd_to_internal)
 from buckaroo.polars_buckaroo import PolarsAutocleaning
 from buckaroo.customizations.polars_commands import (
     Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search, SDResult
@@ -261,8 +259,7 @@ def test_rekey_preserves_analysis_entries_when_orig_names_collide_with_letters()
         'a': {'rewritten_col_name': 'a', 'orig_col_name': 'b', '_type': 'integer'},
         'b': {'rewritten_col_name': 'b', 'orig_col_name': 'foo', '_type': 'integer'},
         # op-contributed entry keyed by orig name 'foo'
-        'foo': {'highlight_regex': 'x'},
-    }
+        'foo': {'highlight_regex': 'x'}}
     out = _rekey_op_sd_to_internal(cleaning_sd, cleaned_df)
     # analysis entries untouched, in place
     assert out['a']['orig_col_name'] == 'b'


### PR DESCRIPTION
## Summary

PR #761 failed `Python / Lint` on a file I never touched — drift introduced by a recent merge to main (#758) wasn't caught locally because the existing `paddy-format` pre-commit hook only sees staged files, while CI's `LintPython` job runs `--check` over the entire `buckaroo/ tests/ scripts/` tree.

This adds a pre-push stage that mirrors CI's lint job: re-run `ruff check` and `paddy_format.py --check` over the full tree before push. Drift in a file you didn't touch now blocks `git push` instead of showing up red in CI an hour later.

Also reformats the file CI flagged (`tests/unit/dataflow/autocleaning_pl_test.py`) so #761 unblocks once this merges + #761 rebases onto main.

## Activating locally

```bash
pre-commit install --hook-type pre-push
```

(Or `pre-commit install --install-hooks --hook-type pre-commit --hook-type pre-push` to install both.)

## Test plan

- [x] `pre-commit run --all-files --hook-stage pre-push` — both new hooks pass
- [x] `git push` triggers the hooks (verified by this branch's push)
- [x] CI's `Python / Lint` passes