### PR TITLE
feat(styling): init_sd as augmentation channel (nested merge + delete_keys + demo)

### DIFF
--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -106,6 +106,13 @@ class DefaultMainStyling(StylingAnalysis):
             for k in ('highlight_phrase', 'highlight_regex', 'highlight_color'):
                 if k in column_metadata:
                     disp[k] = column_metadata[k]
+        # init_sd users may pass the same nested shape they'd use in
+        # column_config_overrides — e.g. {'comments': {'displayer_args':
+        # {'max_length': 2000}}}. Shallow-merge that into disp so init_sd
+        # augments (rather than replaces) styling's computed displayer_args
+        # AND coexists with op-supplied highlights. Caller wins per-key.
+        if isinstance(column_metadata.get('displayer_args'), dict):
+            disp.update(column_metadata['displayer_args'])
         base_config['displayer_args'] = disp
 
         # Compute content-aware minWidth
@@ -115,6 +122,11 @@ class DefaultMainStyling(StylingAnalysis):
             for pr in kls.pinned_rows)
         min_w = estimate_min_width_px(disp, header_name, column_metadata, has_histogram)
         base_config['ag_grid_specs'] = {'minWidth': min_w}
+        # ag_grid_specs from column_metadata (e.g. init_sd carrying
+        # {'wrapText': True, 'width': 400}) overlay on top of styling's
+        # computed minWidth. Shallow merge — caller wins per-key.
+        if 'ag_grid_specs' in column_metadata:
+            base_config['ag_grid_specs'].update(column_metadata['ag_grid_specs'])
 
         return base_config
 

--- a/buckaroo/customizations/styling.py
+++ b/buckaroo/customizations/styling.py
@@ -128,6 +128,12 @@ class DefaultMainStyling(StylingAnalysis):
         if 'ag_grid_specs' in column_metadata:
             base_config['ag_grid_specs'].update(column_metadata['ag_grid_specs'])
 
+        # init_sd's delete_keys drops top-level keys that style_column added
+        # by default — e.g. the tooltip_config that string / time / binary /
+        # categorical / fallback branches unconditionally attach.
+        for k in column_metadata.get('delete_keys', ()):
+            base_config.pop(k, None)
+
         return base_config
 
 

--- a/docs/example-notebooks/Restaurant-Complaints.ipynb
+++ b/docs/example-notebooks/Restaurant-Complaints.ipynb
@@ -18,11 +18,11 @@
    "id": "load",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-16T00:38:02.078349Z",
-     "iopub.status.busy": "2026-05-16T00:38:02.077859Z",
-     "iopub.status.idle": "2026-05-16T00:38:02.941895Z",
-     "shell.execute_reply": "2026-05-16T00:38:02.941597Z",
-     "shell.execute_reply.started": "2026-05-16T00:38:02.078309Z"
+     "iopub.execute_input": "2026-05-16T02:42:45.667300Z",
+     "iopub.status.busy": "2026-05-16T02:42:45.666822Z",
+     "iopub.status.idle": "2026-05-16T02:42:58.498437Z",
+     "shell.execute_reply": "2026-05-16T02:42:58.498074Z",
+     "shell.execute_reply.started": "2026-05-16T02:42:45.667265Z"
     }
    },
    "outputs": [
@@ -30,8 +30,30 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "It looks like you installed Buckaroo after you started this notebook server.\n",
+      "If you see a messages like\n",
+      "\"Failed to load model class 'DCEFWidgetModel' from module 'buckaroo'\" \n",
+      "restart the jupyter server and try again.\n",
+      "If you have furter errors, please file a bug report at https://github.com/paddymul/buckaroo\n",
+      "--------------------------------------------------------------------------------\n",
+      "buckaroo_mtime 2026-05-15 22:40:35.161550 server_start_time 2026-05-15 15:53:17.185019\n",
       "Buckaroo has been enabled as the default DataFrame viewer.  To return to default dataframe visualization use `from buckaroo import disable; disable()`\n"
      ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "e117d283ee544ec9b3efbe18d9eae588",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "<buckaroo.polars_buckaroo.PolarsBuckarooInfiniteWidget object at 0x118a1dfd0>"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -43,7 +65,7 @@
     "front = ['businessname', 'comments', 'violation', 'violdesc']\n",
     "df = df.select(front + [c for c in df.columns if c not in front])\n",
     "\n",
-    "extra_grid_config = {'rowHeight': 105, 'pinnedRowHeight': 21}  # ~5 lines at the default ~21px line height\n",
+    "extra_grid_config = {'rowHeight': 70, 'pinnedRowHeight': 21}  # ~5 lines at the default ~21px line height\n",
     "column_config_overrides = {\n",
     "    'comments': {\n",
     "        'displayer_args': {'displayer': 'string', 'max_length': 5000,\n",
@@ -53,43 +75,27 @@
     "        'ag_grid_specs': {'wrapText': True, 'width':400, 'maxWidth':800},\n",
     "        'delete_keys': ['tooltip_config'],\n",
     "    },\n",
-    "}"
+    "}\n",
+    "df = df.filter(pl.col('viol_status') == 'Fail')\n",
+    "PolarsBuckarooInfiniteWidget( df, init_sd=column_config_overrides, extra_grid_config=extra_grid_config,\n",
+    "                              component_config = {'dfvHeight': 700})"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
+   "id": "9271f421-eee6-43b9-990f-e49e44c99a80",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "0e9f75d2-4969-42b2-be87-1817a7ddcb05",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2026-05-16T00:38:03.008161Z",
-     "iopub.status.busy": "2026-05-16T00:38:03.007913Z",
-     "iopub.status.idle": "2026-05-16T00:38:03.139186Z",
-     "shell.execute_reply": "2026-05-16T00:38:03.138925Z",
-     "shell.execute_reply.started": "2026-05-16T00:38:03.008149Z"
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "de8aab6505d04227ae813a187d2bc779",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/plain": [
-       "PolarsBuckarooInfiniteWidget(buckaroo_options={'sampled': ['random'], 'auto_clean': ['aggressive', 'conservati…"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "PolarsBuckarooInfiniteWidget(df, init_sd=column_config_overrides, extra_grid_config=extra_grid_config,\n",
-    "                              component_config = {'dfvHeight': 900})"
-   ]
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/docs/example-notebooks/Restaurant-Complaints.ipynb
+++ b/docs/example-notebooks/Restaurant-Complaints.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro",
+   "metadata": {},
+   "source": [
+    "# Restaurant Complaints\n",
+    "\n",
+    "Open `/Users/paddy/buckaroo/restaurant-complaints.parquet`, reorder columns as `[businessname, comments, violation, violdesc, ...rest]`, give `comments` a long `max_length`, and use a 5-line-tall row height with `wrapText` so long comments wrap inside the cell.\n",
+    "\n",
+    "Note: the column in the parquet is `violdesc`, not `violationdesc`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "load",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T00:38:02.078349Z",
+     "iopub.status.busy": "2026-05-16T00:38:02.077859Z",
+     "iopub.status.idle": "2026-05-16T00:38:02.941895Z",
+     "shell.execute_reply": "2026-05-16T00:38:02.941597Z",
+     "shell.execute_reply.started": "2026-05-16T00:38:02.078309Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Buckaroo has been enabled as the default DataFrame viewer.  To return to default dataframe visualization use `from buckaroo import disable; disable()`\n"
+     ]
+    }
+   ],
+   "source": [
+    "import polars as pl\n",
+    "from buckaroo.polars_buckaroo import PolarsBuckarooInfiniteWidget\n",
+    "\n",
+    "df = pl.read_parquet('/Users/paddy/buckaroo/restaurant-complaints.parquet')\n",
+    "\n",
+    "front = ['businessname', 'comments', 'violation', 'violdesc']\n",
+    "df = df.select(front + [c for c in df.columns if c not in front])\n",
+    "\n",
+    "extra_grid_config = {'rowHeight': 105, 'pinnedRowHeight': 21}  # ~5 lines at the default ~21px line height\n",
+    "column_config_overrides = {\n",
+    "    'comments': {\n",
+    "        'displayer_args': {'displayer': 'string', 'max_length': 5000,\n",
+    "                           # 'highlight_color':'red',\n",
+    "                           # 'highlight_phrase':['area'],\n",
+    "                          },\n",
+    "        'ag_grid_specs': {'wrapText': True, 'width':400, 'maxWidth':800},\n",
+    "        'delete_keys': ['tooltip_config'],\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0e9f75d2-4969-42b2-be87-1817a7ddcb05",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-16T00:38:03.008161Z",
+     "iopub.status.busy": "2026-05-16T00:38:03.007913Z",
+     "iopub.status.idle": "2026-05-16T00:38:03.139186Z",
+     "shell.execute_reply": "2026-05-16T00:38:03.138925Z",
+     "shell.execute_reply.started": "2026-05-16T00:38:03.008149Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "de8aab6505d04227ae813a187d2bc779",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/plain": [
+       "PolarsBuckarooInfiniteWidget(buckaroo_options={'sampled': ['random'], 'auto_clean': ['aggressive', 'conservati…"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "PolarsBuckarooInfiniteWidget(df, init_sd=column_config_overrides, extra_grid_config=extra_grid_config,\n",
+    "                              component_config = {'dfvHeight': 900})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a6811d0-13b7-48ef-bc25-f16924e361ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from buckaroo.buckaroo_widget import BuckarooWidget\n",
+    "\n",
+    "BuckarooWidget(\n",
+    "    df,\n",
+    "    column_config_overrides={\n",
+    "        'comments': {\n",
+    "            'displayer_args': {'displayer': 'string', 'max_length': 2000},\n",
+    "            'ag_grid_specs': {'wrapText': True},\n",
+    "        },\n",
+    "    },\n",
+    "    extra_grid_config={'rowHeight': 105},  # ~5 lines at the default ~21px line height\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "view",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from buckaroo.buckaroo_widget import BuckarooWidget\n",
+    "\n",
+    "BuckarooWidget(\n",
+    "    df,\n",
+    "    column_config_overrides={\n",
+    "        'comments': {\n",
+    "            'displayer_args': {'displayer': 'string', 'max_length': 2000},\n",
+    "            'ag_grid_specs': {'wrapText': True},\n",
+    "        },\n",
+    "    },\n",
+    "    extra_grid_config={'rowHeight': 105},  # ~5 lines at the default ~21px line height\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d5b2bbf-5765-41e1-b583-08f576101b6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = pq.read_table('/Users/paddy/buckaroo/restaurant-complaints.parquet')\n",
+    "\n",
+    "# pandas can't yet convert uint8-indexed dictionary columns, so decode them to plain strings first.\n",
+    "for i, field in enumerate(table.schema):\n",
+    "    if pa.types.is_dictionary(field.type):\n",
+    "        table = table.set_column(i, field.name, pc.cast(table.column(i), pa.large_string()))\n",
+    "\n",
+    "df = table.to_pandas()\n",
+    "\n",
+    "front = ['businessname', 'comments', 'violation', 'violdesc']\n",
+    "df = df[front + [c for c in df.columns if c not in front]]\n",
+    "df.shape"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -315,3 +315,16 @@ def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
     assert cc['displayer_args']['max_length'] == 2000
     assert cc['displayer_args']['highlight_regex'] == 'pizza'
     assert cc['ag_grid_specs']['wrapText'] is True
+
+
+def test_style_column_delete_keys_drops_tooltip():
+    """init_sd's delete_keys lets a user drop top-level keys that style_column
+    adds by default. The motivating case: a string column where the user
+    doesn't want a tooltip permanently attached to the cell."""
+    col_meta = {'_type': 'string', 'orig_col_name': 'comments',
+                'delete_keys': ['tooltip_config']}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert 'tooltip_config' not in cc
+    # Other styled keys unaffected
+    assert cc['displayer_args']['displayer'] == 'string'
+    assert 'minWidth' in cc['ag_grid_specs']

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -278,3 +278,40 @@ def test_style_column_handles_col_meta_missing_type():
     column) should fall back to obj rather than KeyError."""
     cc = DefaultMainStyling.style_column('whatever', {'highlight_regex': 'x'})
     assert cc['displayer_args']['displayer'] == 'obj'
+
+
+def test_style_column_merges_nested_displayer_args_and_ag_grid_specs():
+    """init_sd entries use the same nested shape as column_config_overrides
+    — {'displayer_args': {...}, 'ag_grid_specs': {...}} — but unlike
+    overrides, the merge here is shallow-per-bag (caller wins per-key)
+    rather than replace-the-bag. That's the whole point: max_length=2000
+    overrides styling's 35, wrapText/width overlay on minWidth, and any
+    other styled keys (e.g. highlight_regex) survive."""
+    col_meta = {'_type': 'string', 'orig_col_name': 'comments',
+                'displayer_args': {'displayer': 'string', 'max_length': 2000},
+                'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 400}}
+    cc = DefaultMainStyling.style_column('a', col_meta)
+    assert cc['displayer_args']['max_length'] == 2000
+    assert cc['ag_grid_specs']['wrapText'] is True
+    assert cc['ag_grid_specs']['width'] == 400
+    assert cc['ag_grid_specs']['maxWidth'] == 400
+    # styling's computed minWidth is still present unless caller overrode it
+    assert 'minWidth' in cc['ag_grid_specs']
+
+
+def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
+    """The whole point of routing per-column augmentations through init_sd
+    instead of column_config_overrides: init_sd's nested displayer_args and
+    a Search op's flat highlight_regex both land in merged_sd, and both
+    make it into the final displayer_args. column_config_overrides would
+    have clobbered the highlight by replacing displayer_args wholesale."""
+    from buckaroo.dataflow.styling_core import merge_sds
+    init_sd = {'a': {'_type': 'string', 'orig_col_name': 'comments',
+                     'displayer_args': {'displayer': 'string', 'max_length': 2000},
+                     'ag_grid_specs': {'wrapText': True}}}
+    search_contribution = {'a': {'highlight_regex': 'pizza'}}
+    merged = merge_sds(init_sd, search_contribution)
+    cc = DefaultMainStyling.style_column('a', merged['a'])
+    assert cc['displayer_args']['max_length'] == 2000
+    assert cc['displayer_args']['highlight_regex'] == 'pizza'
+    assert cc['ag_grid_specs']['wrapText'] is True

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -288,8 +288,8 @@ def test_style_column_merges_nested_displayer_args_and_ag_grid_specs():
     overrides styling's 35, wrapText/width overlay on minWidth, and any
     other styled keys (e.g. highlight_regex) survive."""
     col_meta = {'_type': 'string', 'orig_col_name': 'comments',
-                'displayer_args': {'displayer': 'string', 'max_length': 2000},
-                'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 400}}
+        'displayer_args': {'displayer': 'string', 'max_length': 2000},
+        'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 400}}
     cc = DefaultMainStyling.style_column('a', col_meta)
     assert cc['displayer_args']['max_length'] == 2000
     assert cc['ag_grid_specs']['wrapText'] is True
@@ -307,8 +307,8 @@ def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
     have clobbered the highlight by replacing displayer_args wholesale."""
     from buckaroo.dataflow.styling_core import merge_sds
     init_sd = {'a': {'_type': 'string', 'orig_col_name': 'comments',
-                     'displayer_args': {'displayer': 'string', 'max_length': 2000},
-                     'ag_grid_specs': {'wrapText': True}}}
+        'displayer_args': {'displayer': 'string', 'max_length': 2000},
+        'ag_grid_specs': {'wrapText': True}}}
     search_contribution = {'a': {'highlight_regex': 'pizza'}}
     merged = merge_sds(init_sd, search_contribution)
     cc = DefaultMainStyling.style_column('a', merged['a'])
@@ -322,7 +322,7 @@ def test_style_column_delete_keys_drops_tooltip():
     adds by default. The motivating case: a string column where the user
     doesn't want a tooltip permanently attached to the cell."""
     col_meta = {'_type': 'string', 'orig_col_name': 'comments',
-                'delete_keys': ['tooltip_config']}
+        'delete_keys': ['tooltip_config']}
     cc = DefaultMainStyling.style_column('a', col_meta)
     assert 'tooltip_config' not in cc
     # Other styled keys unaffected


### PR DESCRIPTION
## Summary

Turns `init_sd` into a real augmentation channel for per-column display config — one that plays nice with lowcode ops (Search → highlight) instead of clobbering them like `column_config_overrides` does. Two `style_column` changes + a `delete_keys` escape hatch + a working demo notebook.

The plumbing this depends on already landed:
- **#755** — jlisp sd channel (SDResult return)
- **#758** — polars Search → `highlight_regex` via SDResult
- **#742** — JS-side `highlight_phrase` / `highlight_regex` on the string displayer

This PR is the styling-layer half: the pieces that let an op's contribution and a user's `init_sd` coexist on the same column.

## Pieces

1. **`feat(styling): merge column_metadata displayer_args + ag_grid_specs`** — two shallow merges in `DefaultMainStyling.style_column`. When `column_metadata` carries `displayer_args` (e.g. `{'max_length': 5000}`) or `ag_grid_specs` (e.g. `{'wrapText': True, 'width': 400}`), they merge into the styled bag instead of replacing. Caller wins per-key. Critically, this lets a Search op's `highlight_regex` and a user's `max_length` coexist on the same column — `column_config_overrides`'s replace semantics would have clobbered the highlight.

2. **`feat(styling): init_sd delete_keys`** — `column_metadata.delete_keys: list[str]` pops the named top-level keys from the final `base_config`. Motivating case: drop the auto-attached `tooltip_config` on a string column the user doesn't want a permanent tooltip on, without subclassing the styling analysis. Operates on top-level only (tooltip_config, ag_grid_specs, displayer_args, col_name) — nested removal isn't needed for the motivating case.

3. **Restaurant-Complaints demo notebook** — working example combining `init_sd` (nested displayer_args + ag_grid_specs + delete_keys) with `extra_grid_config` (rowHeight, pinnedRowHeight) and a `viol_status == 'Fail'` filter on the polars Enum.

## Usage

```python
init_sd = {
    'comments': {
        'displayer_args': {'displayer': 'string', 'max_length': 5000},
        'ag_grid_specs': {'wrapText': True, 'width': 400, 'maxWidth': 800},
        'delete_keys': ['tooltip_config'],
    },
}
PolarsBuckarooInfiniteWidget(df, init_sd=init_sd, ...)
```

This shape is intentionally the same as `column_config_overrides` would take — but `init_sd` augments via `merge_sds` (each key wins per-call), while `column_config_overrides` replaces via shallow `row.update()`.

## Provenance

Salvaged from #748 after #755 / #758 landed the underlying SDResult plumbing. Branched fresh off main; the obsolete 2-tuple-contract commits and the now-merged Search/jlisp pieces were dropped.

## Test plan

- [x] `pytest tests/unit/dataflow/` — 120 pass (3 new tests: nested-merge, search+max_length coexistence, delete_keys)
- [ ] CI green
- [ ] Manual: Restaurant-Complaints.ipynb renders without tooltip on `comments` column, wraps long text, `max_length: 5000` honored

🤖 Generated with [Claude Code](https://claude.com/claude-code)