### PR TITLE
feat(polars): lazy-thread interpreter pipeline (one collect per run)

### DIFF
--- a/buckaroo/customizations/pl_autocleaning_conf.py
+++ b/buckaroo/customizations/pl_autocleaning_conf.py
@@ -1,8 +1,19 @@
+import polars as pl
+
 from buckaroo.dataflow.autocleaning import AutocleaningConfig
 from buckaroo.customizations.polars_commands import (
     Search)
 
 
+def _pl_lazy_enter(df):
+    return df.lazy()
+
+
+def _pl_lazy_exit(df):
+    # GroupBy.transform calls .collect() mid-pipeline, so anything
+    # downstream of a groupby is already an eager DataFrame by the time
+    # we see it here. Only collect if we're still lazy.
+    return df.collect() if isinstance(df, pl.LazyFrame) else df
 
 
 class NoCleaningConfPl(AutocleaningConfig):
@@ -11,5 +22,7 @@ class NoCleaningConfPl(AutocleaningConfig):
     command_klasses = [Search]
     quick_command_klasses = [Search]
     name=""
-    
+    lazy_enter = staticmethod(_pl_lazy_enter)
+    lazy_exit = staticmethod(_pl_lazy_exit)
+
 

--- a/buckaroo/customizations/polars_commands.py
+++ b/buckaroo/customizations/polars_commands.py
@@ -142,7 +142,11 @@ class Search(Command):
         filtered = df.filter(pl.any_horizontal(pl.col(pl.String).str.contains(val)))
         # `.str.contains(val)` treats val as a regex, so expose it as
         # highlight_regex (not _phrase) for consistent semantics on the JS side.
-        string_cols = [c for c, dt in zip(df.columns, df.dtypes) if dt == pl.String]
+        # collect_schema avoids polars's PerformanceWarning when df is a
+        # LazyFrame (the interpreter threads LazyFrame between ops on the
+        # polars path); also works on eager DataFrames.
+        schema = df.collect_schema()
+        string_cols = [name for name, dt in schema.items() if dt == pl.String]
         sd_updates = {c: {'highlight_regex': val} for c in string_cols}
         return SDResult(filtered, sd_updates)
 

--- a/buckaroo/dataflow/autocleaning.py
+++ b/buckaroo/dataflow/autocleaning.py
@@ -70,11 +70,21 @@ class SentinelAutocleaning:
             cleaned_df = df
         return [cleaned_df, {}, generated_code, merged_operations]
 
+def _identity(x):
+    return x
+
+
 class AutocleaningConfig:
     command_klasses = [DefaultCommandKlsList]
     autocleaning_analysis_klasses = []
     quick_command_klasses = []
     name = 'default'
+    # Hooks bookending the lisp-interpreter call in _run_df_interpreter.
+    # Default identity = current behaviour. Polars overrides with df.lazy()
+    # / collect-if-LazyFrame so a multi-op pipeline materialises once
+    # instead of after every command. See NoCleaningConfPl.
+    lazy_enter = staticmethod(_identity)
+    lazy_exit = staticmethod(_identity)
     
     
 class WrongFrontendQuickArgs(Exception):
@@ -136,6 +146,8 @@ class PandasAutocleaning:
         self.df_interpreter, self.gencode_interpreter = df_interpreter, gencode_interpreter
         self.command_config = dict(argspecs=c_patterns, defaultArgs=c_defaults)
         self.quick_command_klasses = conf.quick_command_klasses
+        self.lazy_enter = conf.lazy_enter
+        self.lazy_exit = conf.lazy_exit
 
 
     def _run_df_interpreter(self, df, operations, initial_sd):
@@ -168,7 +180,13 @@ class PandasAutocleaning:
             # contract is precisely "no ops → caller's objects come back as-is".
             return df, initial_sd
 
-        return self.df_interpreter(full_ops, df, initial_sd)
+        # lazy_enter/lazy_exit are conf-provided hooks. Polars flips to
+        # LazyFrame on entry and collects on exit (one materialisation per
+        # pipeline instead of N). Pandas/xorq leave the defaults — identity.
+        # Both hooks run *after* the no-op short-circuit above, so the
+        # by-reference identity contract there is preserved.
+        ret_df, ret_sd = self.df_interpreter(full_ops, self.lazy_enter(df), initial_sd)
+        return self.lazy_exit(ret_df), ret_sd
 
     def _run_code_generator(self, operations):
         if len(operations) == 0:

--- a/tests/unit/dataflow/autocleaning_pl_test.py
+++ b/tests/unit/dataflow/autocleaning_pl_test.py
@@ -5,6 +5,7 @@ from buckaroo.pluggable_analysis_framework.polars_analysis_management import PlD
 from buckaroo.pluggable_analysis_framework.col_analysis import (ColAnalysis)
 from buckaroo.dataflow.autocleaning import (merge_ops, format_ops, AutocleaningConfig, _rekey_op_sd_to_internal)
 from buckaroo.polars_buckaroo import PolarsAutocleaning
+from buckaroo.customizations.pl_autocleaning_conf import NoCleaningConfPl
 from buckaroo.customizations.polars_commands import (
     Command, PlSafeInt, DropCol, FillNA, GroupBy, NoOp, Search, SDResult
 )
@@ -315,6 +316,54 @@ def test_init_sd_displayer_args_and_search_highlight_coexist_on_same_column():
     assert cc['displayer_args']['max_length'] == 2000
     assert cc['displayer_args']['highlight_regex'] == 'pizza'
     assert cc['ag_grid_specs']['wrapText'] is True
+
+
+class _RecordTypeCommand(Command):
+    """Probe command for the lazy-threading tests below: records the
+    runtime type name of `df` it sees mid-pipeline, returns df unchanged.
+
+    Module-level recording — reset at the start of each test that uses it.
+    """
+    seen_types: list = []
+
+    command_default = [s('record_type'), s('df'), 'col']
+    command_pattern = [None]
+
+    @staticmethod
+    def transform(df, col):
+        _RecordTypeCommand.seen_types.append(type(df).__name__)
+        return df
+
+    @staticmethod
+    def transform_to_py(df, col):
+        return "    # record_type"
+
+
+class LazyProbeConf(NoCleaningConfPl):
+    autocleaning_analysis_klasses = []
+    command_klasses = [FillNA, _RecordTypeCommand]
+    quick_command_klasses = []
+    name = ""
+
+
+def test_polars_pipeline_threads_lazyframe_between_ops():
+    """The polars conf flips df to LazyFrame at interpreter entry and
+    collects once at exit. Each command's transform therefore sees a
+    LazyFrame mid-pipeline; the final cleaned df is a DataFrame so
+    make_origs / PlDfStatsV2 keep working unchanged."""
+    _RecordTypeCommand.seen_types = []
+    ac = PolarsAutocleaning([LazyProbeConf])
+    df = pl.DataFrame({'a': [1, None, 3]})
+    ops = [
+        [{'symbol': 'fillna'}, s('df'), 'a', 0],
+        [{'symbol': 'record_type'}, s('df'), 'a'],
+        [{'symbol': 'fillna'}, s('df'), 'a', 0],
+        [{'symbol': 'record_type'}, s('df'), 'a']]
+    cleaned, _sd, _gen, _ops = ac.handle_ops_and_clean(
+        df, cleaning_method='', quick_command_args={}, existing_operations=ops)
+
+    assert _RecordTypeCommand.seen_types == ['LazyFrame', 'LazyFrame']
+    assert isinstance(cleaned, pl.DataFrame)
 
 
 def test_style_column_delete_keys_drops_tooltip():


### PR DESCRIPTION
## Summary

The lisp interpreter today re-assigns `df` after every command — each polars op runs eagerly and materialises a new DataFrame. Switch the polars path to thread a LazyFrame through the pipeline and collect once at exit. Adjacent `with_columns` / `filter` calls fuse in polars's optimiser, filters push down, and a multi-op cleaning run pays one materialisation instead of N.

Implementation lives entirely in the autocleaning layer:

- `AutocleaningConfig` grows two staticmethod hooks, `lazy_enter` and `lazy_exit`, defaulting to identity.
- `NoCleaningConfPl` overrides them with `df.lazy()` on entry and `df.collect() if isinstance(df, pl.LazyFrame) else df` on exit. The isinstance guard handles `GroupBy.transform`, which materialises mid-pipeline (`lazy().group_by().agg().collect()`) — anything downstream of it runs eager, and the exit hook is then a no-op.
- `_run_df_interpreter` reads the hooks off the active conf and wraps the interpreter call. The no-op short-circuit short-circuits *before* `lazy_enter`, preserving the by-reference identity the traitlets/anywidget path depends on (same load-bearing reason as the existing copy/clone branch).

`PolarsAutocleaning.make_origs` and `PlDfStatsV2` both need a concrete DataFrame, which `lazy_exit` guarantees. Pandas and xorq confs inherit the identity defaults — pandas is not lazy, xorq is already lazy expr-wise, so neither needs changes.

Same approach extends to xorq's conf when #767 merges (it inherits the no-op defaults — already correct, since ibis exprs are lazy by construction).

## Test plan

- [ ] `uv run pytest tests/unit/dataflow/autocleaning_pl_test.py -vv` — failing assertion expects `LazyFrame` mid-pipeline; once the fix lands this and the existing 16 tests in the file are green
- [ ] `uv run pytest tests/unit/ --ignore=tests/unit/contrib --ignore=tests/unit/file_cache` — full unit suite stays green (pandas + polars interpreter paths unaffected)
- [ ] `uv run ruff check` on touched files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)