### PR TITLE
chore(hooks): tracked .githooks/ for deterministic pre-commit + pre-push

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Tracked pre-commit hook. Activated per clone via
+#   git config core.hooksPath .githooks
+# Defers to the pre-commit framework so .pre-commit-config.yaml stays
+# the single source of truth for which checks run.
+set -e
+if ! command -v pre-commit >/dev/null 2>&1; then
+    cat >&2 <<'MSG'
+.githooks/pre-commit: pre-commit not found on PATH.
+
+Install one of:
+  uv tool install pre-commit
+  pip install pre-commit
+  brew install pre-commit
+
+Then retry the commit.
+MSG
+    exit 1
+fi
+exec pre-commit run --hook-stage pre-commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tracked pre-push hook. Activated per clone via
+#   git config core.hooksPath .githooks
+# Mirrors CI's Python / Lint job by running the pre-push-stage hooks
+# from .pre-commit-config.yaml (ruff + paddy_format --check) over the
+# full tree. --all-files is a no-op for the always_run/pass_filenames:
+# false hooks defined there, and gives correct behavior for any future
+# pre-push hook that does inspect file lists.
+set -e
+if ! command -v pre-commit >/dev/null 2>&1; then
+    cat >&2 <<'MSG'
+.githooks/pre-push: pre-commit not found on PATH.
+
+Install one of:
+  uv tool install pre-commit
+  pip install pre-commit
+  brew install pre-commit
+
+Then retry the push.
+MSG
+    exit 1
+fi
+exec pre-commit run --hook-stage pre-push --all-files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,19 @@ cd packages/buckaroo-js-core && pnpm storybook
 
 Test suite should complete in under 40 seconds. If it doesn't, something is wrong.
 
+## Git hooks
+
+Hooks live under `.githooks/` and are activated per clone with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Shims defer to `pre-commit` against `.pre-commit-config.yaml`. The pre-push
+hook runs CI's `Python / Lint` job locally (ruff + `paddy_format --check`
+full-tree), so a push that would fail CI fails locally first. See
+CONTRIBUTING.md for installation.
+
 ## CI
 
 Runs on push to main and PRs. Key jobs: LintPython, TestJS, BuildWheel, TestPython (3.11-3.14), Playwright (Storybook, Jupyter, Marimo, WASM). Uses `depot-ubuntu-latest` runners.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,28 @@ pnpm install
 ./scripts/full_build.sh
 ```
 
+### Git hooks
+
+The repo ships pre-commit / pre-push hooks under `.githooks/`. Point git at
+them once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The shims defer to [pre-commit](https://pre-commit.com/) to run the checks
+declared in `.pre-commit-config.yaml` (lint on commit, full-tree ruff +
+`paddy_format --check` on push — same as CI's `Python / Lint` job). Make
+sure pre-commit is on your PATH:
+
+```bash
+uv tool install pre-commit
+```
+
+Tracking the hooks under `.githooks/` instead of relying on `pre-commit
+install`'s generated shims means every clone runs identical hook code,
+and updates propagate via `git pull`.
+
 
 ## Running tests
 


### PR DESCRIPTION
## Summary

- Replaces per-machine \`pre-commit install\` with shim hooks tracked under \`.githooks/\`, activated once per clone with \`git config core.hooksPath .githooks\`.
- Shims exec \`pre-commit run --hook-stage <stage>\`, so \`.pre-commit-config.yaml\` stays the single source of truth.
- Documented in CONTRIBUTING.md ("Git hooks") and CLAUDE.md.

## Why

\`pre-commit install\`'s generated shims live under \`.git/hooks/\` and are written only when a contributor remembers to run it. #762 added a pre-push gate that mirrors CI's \`Python / Lint\` job locally — but a clone that never ran \`pre-commit install --hook-type pre-push\` silently bypasses the gate, exactly the failure mode that just bit #767 (a paddy_format issue slipped to CI).

Tracking \`.githooks/\` means:
- Every clone runs identical hook code, byte-for-byte.
- Changes propagate via \`git pull\`, not a per-machine \`pre-commit install\` re-run.
- New contributors set the path once and forget; can't drift.

## Trade-offs considered

- **Option 1 — bolt onto \`scripts/full_build.sh\`**: convenient but skippable (anyone running \`uv sync\` or \`partial_build.sh\` misses it), and the shim still lives under \`.git/hooks/\` so it can drift if pre-commit upgrades.
- **Option 3 (this PR) — tracked \`.githooks/\` + one-time \`core.hooksPath\`**: small one-time setup per clone, hooks are deterministic afterwards.

## Test plan

- [x] \`git config core.hooksPath .githooks\` activates the hooks on this clone.
- [x] Committing this PR fires \`.githooks/pre-commit\` — staged-files paddy-format / tsc / actionlint stages all reported correctly (Skipped on this commit since no .py/.ts/.yaml files changed).
- [x] Pushing this PR fires \`.githooks/pre-push\` — full-tree ruff + paddy_format --check passed.
- [ ] Reviewer: activate locally with \`git config core.hooksPath .githooks\` and confirm the next commit / push triggers the shim output.

## Notes for reviewers

- Existing \`pre-commit install\`-generated hooks under \`.git/hooks/\` are ignored once \`core.hooksPath\` is set (git uses the configured path exclusively, no fallback). No conflict, but contributors who had previously run \`pre-commit install\` will see their old \`.git/hooks/\` shims go silent.
- Shims print actionable install hints if \`pre-commit\` isn't on PATH (\`uv tool install pre-commit\` / \`pip install pre-commit\` / \`brew install pre-commit\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)