### PR TITLE
chore(hooks): tracked .githooks/ + scope commit-time hooks to pre-commit stage

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Tracked pre-commit hook. Activated per clone via
+#   git config core.hooksPath .githooks
+# Defers to the pre-commit framework so .pre-commit-config.yaml stays
+# the single source of truth for which checks run.
+set -e
+if ! command -v pre-commit >/dev/null 2>&1; then
+    cat >&2 <<'MSG'
+.githooks/pre-commit: pre-commit not found on PATH.
+
+Install one of:
+  uv tool install pre-commit
+  pip install pre-commit
+  brew install pre-commit
+
+Then retry the commit.
+MSG
+    exit 1
+fi
+exec pre-commit run --hook-stage pre-commit

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Tracked pre-push hook. Activated per clone via
+#   git config core.hooksPath .githooks
+# Mirrors CI's Python / Lint job by running the pre-push-stage hooks
+# from .pre-commit-config.yaml (ruff + paddy_format --check) over the
+# full tree. --all-files is a no-op for the always_run/pass_filenames:
+# false hooks defined there, and gives correct behavior for any future
+# pre-push hook that does inspect file lists.
+set -e
+if ! command -v pre-commit >/dev/null 2>&1; then
+    cat >&2 <<'MSG'
+.githooks/pre-push: pre-commit not found on PATH.
+
+Install one of:
+  uv tool install pre-commit
+  pip install pre-commit
+  brew install pre-commit
+
+Then retry the push.
+MSG
+    exit 1
+fi
+exec pre-commit run --hook-stage pre-push --all-files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,11 @@ repos:
     rev: v1.7.11
     hooks:
       - id: actionlint
+        # Without an explicit `stages`, pre-commit's default is "all
+        # stages" — which would (mis)fire this on `git push` as well.
+        # Pin to pre-commit so the pre-push gate stays scoped to the
+        # full-tree lint hooks below.
+        stages: [pre-commit]
   - repo: local
     hooks:
       - id: paddy-format
@@ -12,6 +17,9 @@ repos:
         types: [python]
         files: ^(buckaroo|tests|scripts)/.*\.py$
         exclude: ^buckaroo/jlisp/lispy\.py$
+        # Rewriting variant — must not run on push. The push-time check
+        # is `paddy-format-check-full` below.
+        stages: [pre-commit]
       - id: tsc-buckaroo-js-core
         name: tsc buckaroo-js-core
         # Type-check the whole project, not just staged files — TS needs
@@ -20,6 +28,7 @@ repos:
         language: system
         files: ^packages/buckaroo-js-core/.*\.(ts|tsx)$
         pass_filenames: false
+        stages: [pre-commit]
       # Pre-push gate: re-run CI's Python / Lint job locally before push.
       # The pre-commit `paddy-format` hook above only sees staged files,
       # so drift in a file you didn't touch (e.g. introduced by a recent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,19 @@ cd packages/buckaroo-js-core && pnpm storybook
 
 Test suite should complete in under 40 seconds. If it doesn't, something is wrong.
 
+## Git hooks
+
+Hooks live under `.githooks/` and are activated per clone with:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Shims defer to `pre-commit` against `.pre-commit-config.yaml`. The pre-push
+hook runs CI's `Python / Lint` job locally (ruff + `paddy_format --check`
+full-tree), so a push that would fail CI fails locally first. See
+CONTRIBUTING.md for installation.
+
 ## CI
 
 Runs on push to main and PRs. Key jobs: LintPython, TestJS, BuildWheel, TestPython (3.11-3.14), Playwright (Storybook, Jupyter, Marimo, WASM). Uses `depot-ubuntu-latest` runners.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,28 @@ pnpm install
 ./scripts/full_build.sh
 ```
 
+### Git hooks
+
+The repo ships pre-commit / pre-push hooks under `.githooks/`. Point git at
+them once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The shims defer to [pre-commit](https://pre-commit.com/) to run the checks
+declared in `.pre-commit-config.yaml` (lint on commit, full-tree ruff +
+`paddy_format --check` on push — same as CI's `Python / Lint` job). Make
+sure pre-commit is on your PATH:
+
+```bash
+uv tool install pre-commit
+```
+
+Tracking the hooks under `.githooks/` instead of relying on `pre-commit
+install`'s generated shims means every clone runs identical hook code,
+and updates propagate via `git pull`.
+
 
 ## Running tests
 


### PR DESCRIPTION
Re-applies #770 with the Codex P1 from that PR addressed.

## Summary

- Tracked `.githooks/pre-commit` and `.githooks/pre-push` shims, activated once per clone with `git config core.hooksPath .githooks`.
- Shims exec `pre-commit run --hook-stage <stage>` so `.pre-commit-config.yaml` stays the single source of truth.
- Pins `actionlint`, `paddy-format`, and `tsc-buckaroo-js-core` to `stages: [pre-commit]` — the fix for the Codex P1 below.

## What changed vs #770

#770 was merged and reverted because of [this Codex review](https://github.com/buckaroo-data/buckaroo/pull/770#discussion_r3275341086):

> `pre-commit run --hook-stage pre-push --all-files` runs all hooks enabled for the `pre-push` stage. In this repo `actionlint`, `paddy-format`, and `tsc-buckaroo-js-core` don't declare `stages`, so they inherit pre-commit's default of all stages. That means every push runs those commit-time hooks across the whole tree — and `paddy-format` is the rewriting variant, so it could silently modify files during `git push`.

This is a latent bug in `.pre-commit-config.yaml` itself (the same misbehavior would hit anyone using `pre-commit install --hook-type pre-push`, not just the tracked-shim flow). Fix is in the config, not the shim: explicit `stages: [pre-commit]` on the three commit-time hooks. The pre-push gate is now correctly scoped to the two intended full-tree lint hooks.

Verified locally:

```
$ pre-commit run --hook-stage pre-push --all-files
ruff check (full tree)...................................................Passed
paddy-format --check (full tree).........................................Passed
```

(was 5 hooks before, including the rewriting `paddy-format`.)

## Why tracked `.githooks/` over `pre-commit install`

- `pre-commit install`'s shims live under `.git/hooks/` and are written only when a contributor remembers to run it. The pre-push lint gate added in #762 silently no-ops on clones that never did. PR #767 actually slipped a paddy_format failure to CI for exactly this reason.
- Tracked `.githooks/` → every clone runs identical hook code, updates propagate via `git pull`, can't drift.

## Test plan

- [x] `git config core.hooksPath .githooks` on this clone wires up the shims.
- [x] `git commit` triggers `.githooks/pre-commit` and only the pre-commit-stage hooks fire (skipped on this commit since no .py/.ts/.yaml staged).
- [x] `git push` triggers `.githooks/pre-push` and now runs exactly `ruff-check-full` + `paddy-format-check-full` — verified above.
- [ ] Reviewer: activate with `git config core.hooksPath .githooks` and confirm the next push runs only those two checks.

## Notes for reviewers

- When `core.hooksPath` is set, git ignores `.git/hooks/` entirely — contributors who had previously run `pre-commit install` will see their old shims go silent. No conflict, just a behavior change to flag.
- Shims fail with an actionable hint if `pre-commit` isn't on PATH (`uv tool install pre-commit` / `pip install pre-commit` / `brew install pre-commit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)