### PR TITLE
feat(xorq-search): plumb search term to JS as highlight_phrase via SDResult

### DIFF
--- a/buckaroo/customizations/xorq_commands.py
+++ b/buckaroo/customizations/xorq_commands.py
@@ -17,6 +17,7 @@ that values containing quotes, backslashes, etc. round-trip safely into
 the generated snippet.
 """
 
+from ..jlisp.configure_utils import SDResult  # noqa: F401 (re-export for command authors)
 from ..jlisp.lisp_utils import s
 
 
@@ -102,7 +103,17 @@ class Search:
 
     @staticmethod
     def transform(expr, col, val):
-        return search_expr(expr, val)
+        filtered = search_expr(expr, val)
+        if val is None or val == "":
+            return filtered
+        # ibis ``StringValue.contains`` is a literal substring match (not
+        # regex), so expose the term as highlight_phrase (list) — matching
+        # pandas Search (#764). Polars uses highlight_regex (#758) because
+        # its ``str.contains`` is a regex match.
+        schema = expr.schema()
+        string_cols = [name for name in expr.columns if schema[name].is_string()]
+        sd_updates = {c: {'highlight_phrase': [val]} for c in string_cols}
+        return SDResult(filtered, sd_updates)
 
     @staticmethod
     def transform_to_py(expr, col, val):

--- a/tests/unit/test_xorq_buckaroo_widget.py
+++ b/tests/unit/test_xorq_buckaroo_widget.py
@@ -182,6 +182,56 @@ class TestSearch:
         assert w.df_meta["filtered_rows"] == 5
 
 
+def _find_cc(column_config, col_name):
+    for entry in column_config:
+        if entry.get("col_name") == col_name:
+            return entry
+    raise AssertionError(f"col_name {col_name!r} not in column_config")
+
+
+class TestSearchHighlight:
+    """Equivalent of the polars-search highlight wiring from #758 and the
+    pandas-search version from #764, ported to the xorq backend. ibis
+    ``StringValue.contains`` is a literal substring match, so the search
+    term flows to the JS displayer as ``highlight_phrase`` (list), not
+    ``highlight_regex``."""
+
+    def test_search_op_delivers_highlight_phrase_into_displayer_args(self):
+        """End-to-end through XorqBuckarooWidget — a `search` op should
+        plumb its term into ``displayer_args.highlight_phrase`` for every
+        ibis-String column and skip non-string columns."""
+        w = XorqBuckarooWidget(_searchable_expr())
+        state = w.buckaroo_state.copy()
+        state["quick_command_args"] = {"search": ["admin"]}
+        w.buckaroo_state = state
+
+        cc = w.df_display_args["main"]["df_viewer_config"]["column_config"]
+        a_args = _find_cc(cc, "a")["displayer_args"]
+        assert a_args["displayer"] == "string"
+        assert a_args["highlight_phrase"] == ["admin"]
+        b_args = _find_cc(cc, "b")["displayer_args"]
+        assert b_args["displayer"] == "string"
+        assert b_args["highlight_phrase"] == ["admin"]
+        c_args = _find_cc(cc, "c")["displayer_args"]
+        assert "highlight_phrase" not in c_args
+
+    def test_empty_search_drops_highlight_from_displayer_args(self):
+        """Clearing the search box (``""``) should remove the highlight
+        from displayer_args, matching the filter going back to no-op."""
+        w = XorqBuckarooWidget(_searchable_expr())
+        state = w.buckaroo_state.copy()
+        state["quick_command_args"] = {"search": ["admin"]}
+        w.buckaroo_state = state
+
+        state = w.buckaroo_state.copy()
+        state["quick_command_args"] = {"search": [""]}
+        w.buckaroo_state = state
+
+        cc = w.df_display_args["main"]["df_viewer_config"]["column_config"]
+        a_args = _find_cc(cc, "a")["displayer_args"]
+        assert "highlight_phrase" not in a_args
+
+
 def _paginated_expr():
     return xo.memtable(
         {"a": [3, 1, 4, 1, 5, 9, 2, 6, 5, 3], "b": ["p", "q", "r", "s", "t", "u", "v", "w", "x", "y"]})


### PR DESCRIPTION
## Summary

- Ports the search-highlight wiring from #758 (polars) and #764 (pandas) to the xorq backend.
- `Search.transform` in `xorq_commands.py` now returns `SDResult(filtered_expr, sd_updates)` with `highlight_phrase` keyed per ibis-String column.
- ibis `StringValue.contains` is a literal substring match, so the term flows as `highlight_phrase` (list) — matching pandas semantics. Polars uses `highlight_regex` because its `str.contains` is regex.

No widget-side plumbing was needed: the interpreter (`jlisp/configure_utils.py`) already merges SDResult sd_updates into the live sd, and `PandasAutocleaning._rekey_op_sd_to_internal` rewrites orig-name keys onto buckaroo's internal a/b/c letter keys.

Supersedes #765 (which was built before #767 reorganised the xorq command path through `xorq_commands.py` + SDResult).

## Test plan

- [x] `pytest tests/unit/test_xorq_buckaroo_widget.py` — 39 pass, including the two new `TestSearchHighlight` cases (CI run on the failing-test commit is below).
- [x] `pytest tests/unit/{jlisp,dataflow,commands,test_xorq_commands.py}` — 234 pass; no SDResult plumbing regressions.
- [ ] CI green across Python / Test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)