### PR TITLE
feat(pinned-rows): `?key` prefix marks an optional pinned row

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -186,6 +186,11 @@ export type ColumnConfig = NormalColumnConfig | MultiIndexColumnConfig;
 
 
 export type PinnedRowConfig = {
+    // A leading `?` marks an optional row: the unprefixed key is looked up
+    // in the summary stats, and if absent the row is omitted entirely
+    // (rather than rendered with undefined values). Used for scoped stats
+    // like `?cleaned_histogram_bins` / `?filtered_histogram_bins` that
+    // only exist when their scope is active.
     primary_key_val: string;
     displayer_args: DisplayerArgs;
     //used to render index column values with string not the specified displayer, otherwise the column will be listed as NaN or blank

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -162,6 +162,58 @@ describe("testing utility functions in gridUtils ", () => {
         undefined
       ]);
     });
+
+    it("includes an optional `?`-prefixed pinned row when the unprefixed key exists in data", () => {
+      const data: DFData = [
+        { index: "histogram_bins", value: 1 },
+        { index: "filtered_histogram_bins", value: 2 }
+      ];
+      const pinnedConfig: PinnedRowConfig[] = [
+        { primary_key_val: "histogram_bins", displayer_args: { displayer: "obj" } },
+        { primary_key_val: "?filtered_histogram_bins", displayer_args: { displayer: "obj" } }
+      ];
+      const result = extractPinnedRows(data, pinnedConfig);
+      expect(result).toStrictEqual([
+        { index: "histogram_bins", value: 1 },
+        { index: "filtered_histogram_bins", value: 2 }
+      ]);
+    });
+
+    it("omits an optional `?`-prefixed pinned row when the unprefixed key is absent (not undefined)", () => {
+      const data: DFData = [
+        { index: "histogram_bins", value: 1 }
+      ];
+      const pinnedConfig: PinnedRowConfig[] = [
+        { primary_key_val: "histogram_bins", displayer_args: { displayer: "obj" } },
+        { primary_key_val: "?filtered_histogram_bins", displayer_args: { displayer: "obj" } },
+        { primary_key_val: "?cleaned_histogram_bins", displayer_args: { displayer: "obj" } }
+      ];
+      const result = extractPinnedRows(data, pinnedConfig);
+      expect(result.length).toBe(1);
+      expect(result).toStrictEqual([
+        { index: "histogram_bins", value: 1 }
+      ]);
+    });
+
+    it("still emits undefined for an unprefixed required pinned row when its key is absent", () => {
+      // Backward-compat: required (no `?`) rows preserve the existing
+      // "kept as undefined when absent" behavior so callers that depend on
+      // positional alignment with pinned_rows config keep working.
+      const data: DFData = [
+        { index: "histogram_bins", value: 1 }
+      ];
+      const pinnedConfig: PinnedRowConfig[] = [
+        { primary_key_val: "histogram_bins", displayer_args: { displayer: "obj" } },
+        { primary_key_val: "missing", displayer_args: { displayer: "obj" } },
+        { primary_key_val: "?cleaned_histogram_bins", displayer_args: { displayer: "obj" } }
+      ];
+      const result = extractPinnedRows(data, pinnedConfig);
+      expect(result.length).toBe(2);
+      expect(result).toStrictEqual([
+        { index: "histogram_bins", value: 1 },
+        undefined
+      ]);
+    });
   });
 
   describe("dfToAgrid", () => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -1,7 +1,7 @@
 //import { add, multiply } from "../src/math";
 
-import { 
-    extractSDFT,  
+import {
+    extractSDFT,
     extractPinnedRows,
     dfToAgrid,
     getHeightStyle2,
@@ -9,12 +9,13 @@ import {
     getSubChildren,
     childColDef,
     multiIndexColToColDef,
+    getCellRendererSelector,
 
 } from './gridUtils';
 import * as _ from "lodash-es";
 import { DFData, DFViewerConfig, NormalColumnConfig, MultiIndexColumnConfig, PinnedRowConfig, ColumnConfig } from "./DFWhole";
 import { getFloatFormatter, getCompactNumberFormatter, formatDuration, formatIsoDuration, getDurationFormatter } from './Displayer';
-import { ColDef, ValueFormatterParams } from 'ag-grid-community';
+import { ColDef, ICellRendererParams, ValueFormatterParams } from 'ag-grid-community';
 
 describe("testing utility functions in gridUtils ", () => {
   // mostly sanity checks to help develop gridUtils
@@ -213,6 +214,74 @@ describe("testing utility functions in gridUtils ", () => {
         { index: "histogram_bins", value: 1 },
         undefined
       ]);
+    });
+  });
+
+  describe("getCellRendererSelector with `?`-prefixed pinned keys", () => {
+    // The PR #777 strip must also apply at renderer-resolution time, not
+    // only at extract-row time. A `?filtered_histogram` config entry points
+    // at a data row whose `index` is the bare `"filtered_histogram"`, so
+    // the selector's lookup must compare against the stripped key.
+    //
+    // Using `displayer: "histogram"` because it routes through
+    // getCellRenderer to the stable HistogramCell export — the resulting
+    // `component` is reference-comparable across calls, unlike the
+    // closure-wrapped TextCellRenderer the `inherit` / formatter paths
+    // produce.
+    const columnConfigs: ColumnConfig[] = [
+      {
+        col_name: "temperature",
+        header_name: "temperature",
+        displayer_args: { displayer: "float", min_fraction_digits: 3, max_fraction_digits: 3 },
+      } as NormalColumnConfig,
+    ];
+
+    const makeParams = (indexVal: string, colId: string) =>
+      ({
+        node: { rowPinned: "bottom", data: { index: indexVal } },
+        column: { getColId: () => colId },
+      } as unknown as ICellRendererParams<any, any, any>);
+
+    it("resolves the same renderer for `?key` and `key` configs (strip applied at lookup time)", () => {
+      const prefixedSel = getCellRendererSelector(
+        [{ primary_key_val: "?filtered_histogram", displayer_args: { displayer: "histogram" } }],
+        columnConfigs,
+      );
+      const bareSel = getCellRendererSelector(
+        [{ primary_key_val: "filtered_histogram", displayer_args: { displayer: "histogram" } }],
+        columnConfigs,
+      );
+      const params = makeParams("filtered_histogram", "temperature");
+      const prefixedResult = prefixedSel(params);
+      const bareResult = bareSel(params);
+      // Both configs should hit the histogram cellRenderer branch.
+      // Without the strip in getCellRendererSelector, prefixedResult would
+      // fall through to the default (anyRenderer / objFormatter text
+      // cell) instead, and `.component` would NOT equal HistogramCell.
+      const { HistogramCell } = require("./HistogramCell");
+      expect(prefixedResult?.component).toBe(HistogramCell);
+      expect(bareResult?.component).toBe(HistogramCell);
+    });
+
+    it("does not match a config entry against a data row whose `index` literally contains the `?` prefix", () => {
+      // Codex-flagged corollary: `?` is a reserved control char in this
+      // namespace. A config `?filtered_histogram` strips to
+      // `filtered_histogram`, so a data row whose literal index is
+      // `"?filtered_histogram"` does NOT match — it falls through to the
+      // default renderer. This locks in the reserved-character semantics
+      // so any future change is intentional.
+      const prefixedSel = getCellRendererSelector(
+        [{ primary_key_val: "?filtered_histogram", displayer_args: { displayer: "histogram" } }],
+        columnConfigs,
+      );
+      const { HistogramCell } = require("./HistogramCell");
+
+      // Bare key in data → match → HistogramCell.
+      expect(prefixedSel(makeParams("filtered_histogram", "temperature"))?.component).toBe(HistogramCell);
+      // Literal `?key` in data → strip on config side searches for
+      // `filtered_histogram`, finds nothing matching `?filtered_histogram`
+      // in data → default renderer, NOT HistogramCell.
+      expect(prefixedSel(makeParams("?filtered_histogram", "temperature"))?.component).not.toBe(HistogramCell);
     });
   });
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -84,8 +84,30 @@ export function getCellRendererorFormatter(
 }
 
 
+// A `?` prefix on PinnedRowConfig.primary_key_val marks an optional row:
+// the unprefixed key is looked up in the data, and if absent the entry is
+// skipped entirely (rather than emitting undefined). Used to declare
+// pinned rows for scopes like `cleaned_*` / `filtered_*` that only exist
+// when their scope is active.
+export function isOptionalPinnedKey(key: string): boolean {
+    return key.startsWith("?");
+}
+
+export function stripOptionalPinnedKey(key: string): string {
+    return isOptionalPinnedKey(key) ? key.slice(1) : key;
+}
+
 export function extractPinnedRows(sdf: DFData, prc: PinnedRowConfig[]) {
-    return _.map(_.map(prc, "primary_key_val"), (x) => _.find(sdf, { index: x }));
+    const result: (DFData[number] | undefined)[] = [];
+    for (const cfg of prc) {
+        const raw = cfg.primary_key_val;
+        const found = _.find(sdf, { index: stripOptionalPinnedKey(raw) });
+        if (found === undefined && isOptionalPinnedKey(raw)) {
+            continue;
+        }
+        result.push(found);
+    }
+    return result;
 }
 
 export function extractSingleSeriesSummary(
@@ -318,9 +340,10 @@ export function getCellRendererSelector(pinned_rows: PinnedRowConfig[], column_c
             if (pk === undefined) {
                 return anyRenderer; // default renderer
             }
-            const maybePrc: PinnedRowConfig | undefined = _.find(pinned_rows, {
-                primary_key_val: pk,
-            });
+            const maybePrc: PinnedRowConfig | undefined = _.find(
+                pinned_rows,
+                (cfg) => stripOptionalPinnedKey(cfg.primary_key_val) === pk,
+            );
             if (maybePrc === undefined) {
                 return anyRenderer;
             }

--- a/packages/buckaroo-js-core/src/stories/OptionalPinnedRows.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/OptionalPinnedRows.stories.tsx
@@ -1,0 +1,169 @@
+/**
+ * Story to verify the `?key` optional-pinned-row prefix added in PR #777.
+ *
+ * `PinnedRowConfig.primary_key_val` now supports a leading `?` that marks
+ * the row as optional: if the unprefixed key isn't found in the summary
+ * stats data, the row is omitted entirely (instead of rendering with
+ * undefined values, which is what a required row does).
+ *
+ * Use case: ship one default config containing `?cleaned_*` and
+ * `?filtered_*` entries; only the rows for active scopes actually render.
+ *
+ * Interactive: the toggle flips between three states so you can see
+ * pinned rows appear/disappear in real time without re-mounting the grid:
+ *   - "raw"      → summary stats has only bare keys (mean, median, ...)
+ *                  Expected: `?filtered_*` and `?cleaned_*` rows omitted.
+ *   - "filter"   → summary stats also has `filtered_*` keys
+ *                  Expected: `?filtered_*` rows appear, `?cleaned_*` still omitted.
+ *   - "filter+clean" → summary stats also has both `filtered_*` and `cleaned_*`
+ *                  Expected: all optional rows appear.
+ *
+ * Also includes a "required-missing" row (no `?` prefix, key absent) that
+ * stays as an undefined row — proving backward-compat.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import { useMemo, useState } from "react";
+import { DFViewerInfinite } from "../components/DFViewerParts/DFViewerInfinite";
+import { ShadowDomWrapper, SelectBox } from "./StoryUtils";
+import { DFViewerConfig, NormalColumnConfig } from "../components/DFViewerParts/DFWhole";
+
+type DFRow = Record<string, any>;
+
+const idxCol: NormalColumnConfig = {
+  col_name: "index",
+  header_name: "index",
+  displayer_args: { displayer: "obj" },
+};
+
+const intCol: NormalColumnConfig = {
+  col_name: "station_id",
+  header_name: "station_id",
+  displayer_args: { displayer: "float", min_fraction_digits: 0, max_fraction_digits: 0 },
+};
+
+const floatCol: NormalColumnConfig = {
+  col_name: "temperature",
+  header_name: "temperature",
+  displayer_args: { displayer: "float", min_fraction_digits: 3, max_fraction_digits: 3 },
+};
+
+/**
+ * Pinned config exercising all three flavors:
+ *   - required, present       → renders normally
+ *   - required, absent        → renders as undefined row (backward-compat)
+ *   - optional `?`, present   → renders normally
+ *   - optional `?`, absent    → row omitted entirely
+ */
+const viewerConfig: DFViewerConfig = {
+  column_config: [intCol, floatCol],
+  left_col_configs: [idxCol],
+  pinned_rows: [
+    { primary_key_val: "dtype", displayer_args: { displayer: "obj" } },
+    { primary_key_val: "mean", displayer_args: { displayer: "inherit" } },
+    { primary_key_val: "median", displayer_args: { displayer: "inherit" } },
+    { primary_key_val: "min", displayer_args: { displayer: "inherit" } },
+    { primary_key_val: "max", displayer_args: { displayer: "inherit" } },
+    // required but absent: stays as an `undefined` row (backward-compat)
+    { primary_key_val: "always_missing_required", displayer_args: { displayer: "inherit" } },
+    // optional, scope-conditional:
+    { primary_key_val: "?filtered_mean", displayer_args: { displayer: "inherit" } },
+    { primary_key_val: "?filtered_median", displayer_args: { displayer: "inherit" } },
+    { primary_key_val: "?cleaned_min", displayer_args: { displayer: "inherit" } },
+    { primary_key_val: "?cleaned_max", displayer_args: { displayer: "inherit" } },
+  ],
+};
+
+const mainData: DFRow[] = [
+  { index: 0, station_id: 519, temperature: 22.5 },
+  { index: 1, station_id: 497, temperature: 18.3 },
+  { index: 2, station_id: 402, temperature: 25.1 },
+  { index: 3, station_id: 435, temperature: 19.8 },
+  { index: 4, station_id: 293, temperature: 21.0 },
+];
+
+const rawStats: DFRow[] = [
+  { index: "dtype", station_id: "int64", temperature: "float64" },
+  { index: "mean", station_id: 429.2, temperature: 21.34 },
+  { index: "median", station_id: 435, temperature: 21.0 },
+  { index: "min", station_id: 293, temperature: 18.3 },
+  { index: "max", station_id: 519, temperature: 25.1 },
+];
+
+const filteredOverlay: DFRow[] = [
+  { index: "filtered_mean", station_id: 466.0, temperature: 22.7 },
+  { index: "filtered_median", station_id: 466.0, temperature: 22.7 },
+];
+
+const cleanedOverlay: DFRow[] = [
+  { index: "cleaned_min", station_id: 293, temperature: 18.3 },
+  { index: "cleaned_max", station_id: 519, temperature: 25.1 },
+];
+
+type Scope = "raw" | "filter" | "filter+clean";
+const ALL_SCOPES: Scope[] = ["raw", "filter", "filter+clean"];
+
+const buildStats = (scope: Scope): DFRow[] => {
+  let out = [...rawStats];
+  if (scope === "filter" || scope === "filter+clean") out = out.concat(filteredOverlay);
+  if (scope === "filter+clean") out = out.concat(cleanedOverlay);
+  return out;
+};
+
+const OptionalPinnedRowsInner = () => {
+  const [scope, setScope] = useState<Scope>("raw");
+  const data_wrapper = useMemo(
+    () => ({
+      data_type: "Raw" as const,
+      data: mainData,
+      length: mainData.length,
+    }),
+    [],
+  );
+  const summary_stats_data = useMemo(() => buildStats(scope), [scope]);
+
+  return (
+    <ShadowDomWrapper>
+      <div style={{ width: 720 }}>
+        <div style={{ padding: "8px 12px", background: "#f4f4f4", marginBottom: 8 }}>
+          <SelectBox<Scope>
+            label="Active scope"
+            options={ALL_SCOPES}
+            value={scope}
+            onChange={setScope}
+          />
+          <span style={{ marginLeft: 12, fontFamily: "monospace", fontSize: 12 }}>
+            { scope === "raw"
+                ? "Only bare keys → ?filtered_* and ?cleaned_* rows OMITTED"
+                : scope === "filter"
+                ? "filter active → ?filtered_* rows VISIBLE, ?cleaned_* OMITTED"
+                : "filter + clean active → all optional rows VISIBLE" }
+          </span>
+        </div>
+        <div style={{ height: 500 }}>
+          <DFViewerInfinite
+            data_wrapper={data_wrapper}
+            df_viewer_config={viewerConfig}
+            summary_stats_data={summary_stats_data}
+            activeCol={["station_id", "station_id"]}
+            setActiveCol={() => {}}
+            outside_df_params={{}}
+          />
+        </div>
+      </div>
+    </ShadowDomWrapper>
+  );
+};
+
+const meta = {
+  title: "Buckaroo/DFViewer/OptionalPinnedRows",
+  component: OptionalPinnedRowsInner,
+  parameters: { layout: "centered" },
+  tags: ["autodocs"],
+} satisfies Meta<typeof OptionalPinnedRowsInner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {},
+};


### PR DESCRIPTION
## Summary

- Adds `?` prefix support to `PinnedRowConfig.primary_key_val`. A leading `?` means: render the row iff the unprefixed key exists in the summary stats; otherwise omit the row entirely.
- Unprefixed keys preserve today's behavior (kept as `undefined` when absent) for callers that rely on positional alignment with the config.
- Purely additive: no existing config uses the prefix today, so this PR alone is observable-no-op. Unlocks the upcoming scoped-summary-stats backend work (raw / cleaned / filtered) where default configs ship `?cleaned_*` / `?filtered_*` entries.

Touches `extractPinnedRows` (to skip absent optional rows) and `getCellRendererSelector` (to match stripped keys so the cell renderer binds correctly when a `?key` config entry points at a data row with the bare `index`).

See `docs/plans/async-stats.md` (forthcoming) for the broader plan this slots into.

## Test plan

- [x] Three failing test cases added first (`test(pinned-rows): failing tests …` commit), all assertions strict (`toStrictEqual` + explicit length) to avoid Jest's `toEqual` silently ignoring trailing `undefined` items.
- [x] Implementation lands the helpers + lookup change; all 239 tests in `packages/buckaroo-js-core` pass locally.
- [ ] CI: verify the test-first commit fails and the fix commit passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)