### PR TITLE
fix(dataflow): reentry guard on _operation_result (#780)

### DIFF
--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -151,19 +151,30 @@ class DataFlow(ABCDataflow):
 
         These merged operations are then set back onto the "self.operations" trait.
 
-        Obviously this can lead to cycles so this code must be approached carefully
-
+        Obviously this can lead to cycles so this code must be approached carefully.
+        Concretely: this method sets ``self.operations = result[3]`` while
+        also observing the ``operations`` trait, so the observer re-fires
+        inside its own execution. Without the reentry guard below, every
+        downstream observer (cleaned → processed_result → _summary_sd →
+        populate_df_meta) runs twice per single ``quick_command_args``
+        change — measured as ~2× search latency for a 500k-row xorq frame.
         """
-        result = self.ac_obj.handle_ops_and_clean(
-            self.sampled_df, self.cleaning_method, self.quick_command_args, self.operations)
-
-        if result is None:
+        if getattr(self, '_in_operation_result', False):
             return
-        else:
-            self.cleaned = result
-            self.operations = result[3]
-        self.operation_results = {'transformed_df':None,
-            'generated_py_code': self.generated_code}
+        self._in_operation_result = True
+        try:
+            result = self.ac_obj.handle_ops_and_clean(
+                self.sampled_df, self.cleaning_method, self.quick_command_args, self.operations)
+
+            if result is None:
+                return
+            else:
+                self.cleaned = result
+                self.operations = result[3]
+            self.operation_results = {'transformed_df':None,
+                'generated_py_code': self.generated_code}
+        finally:
+            self._in_operation_result = False
 
     @property
     def cleaned_df(self):

--- a/tests/unit/basic_widget_test.py
+++ b/tests/unit/basic_widget_test.py
@@ -189,6 +189,44 @@ def test_quick_commands_run():
     #assert bw.operations == [[sQ('search'), s('df'), "col", "aa"]]
 
 
+def test_quick_command_args_change_does_not_double_fire_operation_result():
+    """Regression for #780.
+
+    ``DataFlow._operation_result`` is registered as an ``@observe`` callback
+    on ``('sampled_df', 'cleaning_method', 'quick_command_args', 'operations')``
+    and sets ``self.operations = result[3]`` inside its own body. Without a
+    reentry guard, the trait observer re-fires the method inside its own
+    execution, doubling all downstream work (``handle_ops_and_clean``,
+    ``_processed_result``, ``_get_summary_sd``, ``populate_df_meta``). On a
+    500k-row xorq frame this manifested as ~2× search latency.
+
+    Assert that handle_ops_and_clean runs exactly once per
+    ``quick_command_args`` change (it's the per-fire workhorse — counting
+    its invocations is the cleanest proxy for "_operation_result fired").
+    """
+    df = pd.DataFrame({'a': ["foo", "bar", "baz"], 'b': [1, 2, 3]})
+    bw = BuckarooWidget(df)
+
+    # Patch after construction so the init-time invocations don't count.
+    call_count = {'n': 0}
+    original_handle = bw.dataflow.ac_obj.handle_ops_and_clean
+
+    def counting_handle(*args, **kwargs):
+        call_count['n'] += 1
+        return original_handle(*args, **kwargs)
+
+    bw.dataflow.ac_obj.handle_ops_and_clean = counting_handle
+
+    # Single external trait change.
+    bw.dataflow.quick_command_args = {'search': ['ba']}
+
+    assert call_count['n'] == 1, (
+        f"_operation_result fired {call_count['n']} times for one "
+        "quick_command_args change; see #780 — the observer re-enters via "
+        "``self.operations = result[3]`` and doubles all downstream work."
+    )
+
+
 def test_multi_index_cols() -> None:
     df = get_multiindex_cols_df()
     bw = BuckarooWidget(df)


### PR DESCRIPTION
## Summary

Adds a reentry guard to `DataFlow._operation_result` (`buckaroo/dataflow/dataflow.py`). The method is registered as an `@observe` callback on `('sampled_df', 'cleaning_method', 'quick_command_args', 'operations')` and writes `self.operations = result[3]` inside its own body, so the trait observer re-fires the method inside its own execution. Every downstream observer (`cleaned` → `processed_result` → `_summary_sd` → `populate_df_meta`) runs twice per single `quick_command_args` change.

Closes #780.

## Impact

Measured on the 500k-row citibike parquet from the pydata-app demo, sending a single search via `buckaroo_state_change` with `quick_command_args = {"search": ["elect"]}`:

| Backend | state_change | total round-trip |
|---|---|---|
| pandas (`/load mode="buckaroo"`)        | 1369 → 704ms  | 1374 → 708ms  |
| xorq (`/load_expr`, post-#776)          | 3970 → 1919ms | 4118 → 2061ms |

Both passes today produce equivalent state; the second is pure duplicate work.

## Implementation

Single test + fix commit (the count assertion exercises the bug through `BuckarooWidget`, so the regression catches it for every backend — no xorq-specific dependency).

```diff
     def _operation_result(self, _change:Any) -> None:
         """...
+        Concretely: this method sets ``self.operations = result[3]`` while
+        also observing the ``operations`` trait, so the observer re-fires
+        inside its own execution. Without the reentry guard below, every
+        downstream observer (cleaned → processed_result → _summary_sd →
+        populate_df_meta) runs twice per single ``quick_command_args``
+        change — measured as ~2× search latency for a 500k-row xorq frame.
         """
+        if getattr(self, '_in_operation_result', False):
+            return
+        self._in_operation_result = True
+        try:
             result = self.ac_obj.handle_ops_and_clean(...)
             ...
             self.cleaned = result
             self.operations = result[3]
             self.operation_results = {...}
+        finally:
+            self._in_operation_result = False
```

The docstring already flagged the hazard ("*Obviously this can lead to cycles so this code must be approached carefully*") — this just adds the guard the comment was warning about.

## Test plan

- [x] Regression test added: `tests/unit/basic_widget_test.py::test_quick_command_args_change_does_not_double_fire_operation_result` asserts `handle_ops_and_clean` runs exactly once per `quick_command_args` change. Fails on `main` with `n=2`, passes with this fix.
- [x] Full `basic_widget_test.py` suite green (16 passed).
- [x] End-to-end timing measured against a live `python -m buckaroo.server` + pydata-app companion, both pandas and xorq backends — numbers in the impact table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)