### PR TITLE
feat(sd-cache): keyed summary-stats cache (raw / clean / filt scopes)

### DIFF
--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -21,6 +21,7 @@ from .styling_core import (
 
 
 from .abc_dataflow import ABCDataflow
+from .sd_cache import hash_chain, split_chain_by_scope
 
 
 class DfTrait(Any):
@@ -106,6 +107,15 @@ class DataFlow(ABCDataflow):
     df_meta = Any()
 
     merged_sd = Any()
+
+    # Keyed summary-stats cache. The three pointer traitlets carry short
+    # opaque hashes of the op chain that produced each scope's df; the
+    # frontend reads <scope>_sd_key and looks the matching SD blob up in
+    # summary_stats_cache. See sd_cache.py for the encoding.
+    raw_sd_key = Unicode('').tag(sync=True)
+    clean_sd_key = Unicode('').tag(sync=True)
+    filt_sd_key = Unicode('').tag(sync=True)
+    summary_stats_cache = Dict({}).tag(sync=True)
 
     style_method = Unicode('simple')
     column_config = Any()
@@ -398,7 +408,76 @@ class CustomizableDataflow(DataFlow):
         self.merged_sd  = merge_sd_overrides(
             intermediate_sd, self.processed_df, self.processed_sd)
 
+    def _compute_scope_df(self, scope: str):
+        """Return the df that scope's SD should be computed against.
 
+        Subclasses with a real autocleaning interpreter can produce a
+        clean-without-filter df; the base case (no real cleaning) falls
+        back to sampled_df for raw/clean and processed_df for filt.
+        """
+        if scope == 'filt':
+            return self.processed_df
+        if scope == 'raw':
+            return self.sampled_df
+        # scope == 'clean'
+        clean_ops = split_chain_by_scope(self.operations)['clean']
+        run_interp = getattr(self.ac_obj, '_run_df_interpreter', None)
+        if not clean_ops or run_interp is None:
+            return self.sampled_df
+        try:
+            cleaned_df, _sd = run_interp(self.sampled_df, clean_ops, {})
+        except Exception:
+            return self.sampled_df
+        return cleaned_df
+
+    @observe('summary_sd', 'operations', 'analysis_klasses')
+    @exception_protect('sd-cache-protector')
+    def _populate_sd_cache(self, _change):
+        """Write per-scope SD blobs into ``summary_stats_cache``.
+
+        Each scope's chain hashes to a stable opaque key; entries already
+        present are skipped (cache hit), so a ``quick_command_args`` flip
+        recomputes only the filtered scope's contribution while raw/clean
+        ride the existing entries. Pointer traitlets are always
+        overwritten so the frontend can switch which entry it's looking
+        at without waiting for a new SD computation.
+
+        Observes ``summary_sd`` (not ``processed_result``) so we can
+        reuse the value that ``_summary_sd`` just computed for the
+        filtered scope — no second pass through the analysis pipeline.
+        Raw and clean scopes are computed from scratch, but only when
+        their chain hashes are new to the cache, and only when their
+        hash differs from the filt scope's (so a widget with no
+        cleaning and no filter does one SD compute total).
+        """
+        if self.processed_df is None:
+            return
+        chains = split_chain_by_scope(self.operations)
+        keys = {scope: hash_chain(chain) for scope, chain in chains.items()}
+        new_cache = dict(self.summary_stats_cache)
+        cache_grew = False
+
+        # filt scope reuses the SD that _summary_sd just produced.
+        if keys['filt'] not in new_cache:
+            new_cache[keys['filt']] = self._sd_to_jsondf(self.summary_sd or {})
+            cache_grew = True
+
+        # raw + clean: fresh compute, but only on cache miss.
+        for scope in ('raw', 'clean'):
+            if keys[scope] in new_cache:
+                continue
+            scope_df = self._compute_scope_df(scope)
+            if scope_df is None:
+                continue
+            sd, _errs = self._get_summary_sd(scope_df)
+            new_cache[keys[scope]] = self._sd_to_jsondf(sd)
+            cache_grew = True
+
+        if cache_grew:
+            self.summary_stats_cache = new_cache
+        self.raw_sd_key = keys['raw']
+        self.clean_sd_key = keys['clean']
+        self.filt_sd_key = keys['filt']
 
     ### start code interpreter block
     def add_command(self, incomingCommandKls):

--- a/buckaroo/dataflow/sd_cache.py
+++ b/buckaroo/dataflow/sd_cache.py
@@ -1,0 +1,82 @@
+"""Keyed summary-stats cache.
+
+Three scopes — raw / clean / filt — each addressed by the canonical op
+chain that produced them. The chain is the cache key, hashed to a short
+opaque string for use as a dict key on the wire.
+
+Why this exists: the dataflow re-derives SD on every state change today,
+even when most of the relevant state didn't move. Keying SD by its op
+chain means a ``quick_command_args`` flip is a cache miss for the
+filtered scope only — the raw and cleaned scopes are cache hits and
+nothing recomputes. xorq backends double up the win because their own
+expression cache deduplicates the same shape one layer down.
+
+The frontend reads the three pointer traitlets
+(``raw_sd_key`` / ``clean_sd_key`` / ``filt_sd_key``) — each holds an
+opaque hash — and looks the corresponding entry up in
+``summary_stats_cache``. Python is the sole writer of cache keys; the
+frontend never hashes anything itself, so there's no canonical-JSON
+contract to drift across the language boundary.
+"""
+import hashlib
+import json
+from typing import Any, Dict, List
+
+from buckaroo.jlisp.lisp_utils import is_symbol, sym_meta_get
+
+
+def _canonical_chain_repr(chain: List[Any]) -> str:
+    """Stable JSON serialization of an op chain.
+
+    sort_keys keeps dict-of-dicts ordering deterministic across Python
+    versions; default=str catches the odd Symbol-or-similar that slips
+    through from the lispy interpreter without crashing the hash.
+    """
+    return json.dumps(chain, sort_keys=True, default=str)
+
+
+def hash_chain(chain: List[Any]) -> str:
+    """Short opaque hash of an op chain — used as a cache key.
+
+    blake2b with an 8-byte digest gives 16 hex chars: enough headroom for
+    collision-free identification within a session, short enough not to
+    bloat the wire when many cache entries accumulate.
+    """
+    return hashlib.blake2b(
+        _canonical_chain_repr(chain).encode(), digest_size=8).hexdigest()
+
+
+def _is_real_op(op: Any) -> bool:
+    """True for genuine operations — list with a symbol head.
+
+    The dataflow seeds ``operations`` with a sentinel like
+    ``{'meta':'no-op'}`` until the autocleaning pipeline has run; that
+    bare dict is not a runnable op, and feeding it to the interpreter
+    yields garbage. Filtering on shape keeps the cache observer safe
+    against any intermediate seed state without hardcoding the sentinel
+    value.
+    """
+    return isinstance(op, list) and len(op) > 0 and is_symbol(op[0])
+
+
+def _is_quick_command_op(op: Any) -> bool:
+    if not _is_real_op(op):
+        return False
+    return sym_meta_get(op[0], 'quick_command') is True
+
+
+def split_chain_by_scope(operations: List[Any]) -> Dict[str, List[Any]]:
+    """Partition the full operations list into the three scope chains.
+
+    * raw: always empty — raw scope is "no ops applied"
+    * clean: real ops that aren't quick-commands (autocleaning and
+      user-authored ops both live here — they survive a filter flip)
+    * filt: every real op — autocleaning + quick-command + user
+
+    Both buckets are filtered to real ops only, so seed sentinels like
+    ``{'meta':'no-op'}`` are ignored. Quick-command ops are tagged
+    ``meta.quick_command = True`` by ``sQ()``.
+    """
+    real_ops = [op for op in (operations or []) if _is_real_op(op)]
+    clean_ops = [op for op in real_ops if not _is_quick_command_op(op)]
+    return {'raw': [], 'clean': clean_ops, 'filt': real_ops}

--- a/tests/unit/dataflow/sd_cache_test.py
+++ b/tests/unit/dataflow/sd_cache_test.py
@@ -1,0 +1,119 @@
+"""Tests for the keyed summary-stats cache.
+
+The cache maps an op-chain hash to a parquet-b64 SD blob. Three pointer
+traits — raw/clean/filt — tell the frontend which entry to read for
+each scope. The invariant that matters: a state change that doesn't
+move a scope's chain must not produce a new cache entry for that scope.
+"""
+import pandas as pd
+import pytest
+
+from buckaroo import BuckarooWidget
+from buckaroo.customizations.analysis import DefaultSummaryStats, PdCleaningStats
+from buckaroo.customizations.pandas_commands import (
+    DropCol, FillNA, GroupBy, NoOp, SafeInt, Search)
+from buckaroo.customizations.pd_autoclean_conf import NoCleaningConf
+from buckaroo.dataflow.autocleaning import AutocleaningConfig, PandasAutocleaning
+from buckaroo.dataflow.sd_cache import hash_chain, split_chain_by_scope
+from buckaroo.jlisp.lisp_utils import s, sA, sQ
+from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis
+
+
+class CleaningGenOps(ColAnalysis):
+    requires_summary = ['int_parse_fail', 'int_parse']
+    provides_defaults = {'cleaning_ops': []}
+
+    @classmethod
+    def computed_summary(kls, column_metadata):
+        if column_metadata['int_parse'] > 0.3:
+            return {
+                'cleaning_ops': [
+                    {'symbol': 'safe_int', 'meta': {'auto_clean': True}},
+                    {'symbol': 'df'},
+                ],
+                'add_orig': True,
+            }
+        return {'cleaning_ops': []}
+
+
+class _Conf(AutocleaningConfig):
+    autocleaning_analysis_klasses = [DefaultSummaryStats, CleaningGenOps, PdCleaningStats]
+    command_klasses = [DropCol, FillNA, GroupBy, NoOp, SafeInt, Search]
+    quick_command_klasses = [Search]
+    name = 'default'
+
+
+class _CacheWidget(BuckarooWidget):
+    autocleaning_klass = PandasAutocleaning
+    autoclean_conf = (_Conf, NoCleaningConf)
+
+
+@pytest.fixture
+def dirty_df():
+    return pd.DataFrame({'a': [10, 20, 30, 40, 10, 20.3, 5, None, None, None],
+        'b': ['3', '4', 'a', '5', '5', 'b', 'b', None, None, None]})
+
+
+def test_chain_hash_is_deterministic():
+    chain = [[sQ('search'), s('df'), 'col', 'needle']]
+    assert hash_chain(chain) == hash_chain(chain)
+    assert hash_chain([]) != hash_chain(chain)
+
+
+def test_split_chain_separates_quick_commands_from_cleaning():
+    """Quick-command ops move with the filter; cleaning ops survive a filter flip."""
+    auto_op = [sA('safe_int'), s('df'), 'a']
+    quick_op = [sQ('search'), s('df'), 'col', 'needle']
+    chains = split_chain_by_scope([auto_op, quick_op])
+    assert chains['raw'] == []
+    assert chains['clean'] == [auto_op]
+    assert chains['filt'] == [auto_op, quick_op]
+
+
+def test_cache_populates_on_widget_init(dirty_df):
+    """After construction the cache has one entry per scope, and each
+    pointer trait points to a real entry."""
+    bw = _CacheWidget(dirty_df, debug=False)
+    df = bw.dataflow
+
+    assert df.raw_sd_key, "raw_sd_key should be populated"
+    assert df.clean_sd_key, "clean_sd_key should be populated"
+    assert df.filt_sd_key, "filt_sd_key should be populated"
+
+    cache = df.summary_stats_cache
+    # raw and filt always exist; clean equals filt when no filter is
+    # active (no quick-command ops applied yet), so the cache can have
+    # 2 or 3 distinct entries depending on whether any quick command
+    # is in operations at init.
+    assert df.raw_sd_key in cache
+    assert df.clean_sd_key in cache
+    assert df.filt_sd_key in cache
+
+
+def test_filter_flip_only_grows_filt_entry(dirty_df):
+    """When ``quick_command_args`` changes, raw and clean pointers must
+    not move and their cache entries must already be present (cache
+    hit). Only the filt entry gets recomputed."""
+    bw = _CacheWidget(dirty_df, debug=False)
+    df = bw.dataflow
+
+    # Cleaning method first, so we have a non-empty clean chain.
+    bw.buckaroo_state = {'cleaning_method': 'default', 'post_processing': '', 'sampled': False, 'show_commands': 'on',
+        'df_display': 'main', 'search_string': '', 'quick_command_args': {}}
+    raw_before = df.raw_sd_key
+    clean_before = df.clean_sd_key
+    filt_before = df.filt_sd_key
+    cache_size_before = len(df.summary_stats_cache)
+
+    # Apply a filter — only the filt scope's chain should change.
+    bw.buckaroo_state = {**bw.buckaroo_state, 'quick_command_args': {'search': ['needle']}}
+
+    assert df.raw_sd_key == raw_before, "raw pointer must not move on filter flip"
+    assert df.clean_sd_key == clean_before, "clean pointer must not move on filter flip"
+    assert df.filt_sd_key != filt_before, "filt pointer must change on filter flip"
+
+    # Cache grew by at most one entry (the new filt scope). Raw and
+    # clean were cache hits.
+    assert len(df.summary_stats_cache) == cache_size_before + 1
+    assert raw_before in df.summary_stats_cache
+    assert clean_before in df.summary_stats_cache


### PR DESCRIPTION
## Summary

A keyed summary-stats cache: three pointer traits (``raw_sd_key`` /
``clean_sd_key`` / ``filt_sd_key``) carry an opaque hash of the op
chain that produced each scope's SD, and a new ``summary_stats_cache:
Dict`` traitlet maps those hashes to parquet-b64 SD blobs. The frontend
reads ``<scope>_sd_key`` and looks the entry up in the cache; Python is
the sole writer of cache keys, so there's no canonical-JSON contract
to drift across the boundary.

The substrate that makes the whole "stop recomputing SDs you already
have" line of work tractable. Sits on top of whatever encoding
``sd_to_parquet_b64`` produces (today's row format, or #782's wide-typed
format when that lands — they compose).

## The invariant that matters

A state change that doesn't move a scope's chain must not produce a
new SD computation for that scope. Concretely, flipping
``quick_command_args`` keeps the raw and clean keys constant — those
entries are cache hits — and only the filt scope sees a new key.

That's the test (``tests/unit/dataflow/sd_cache_test.py``):

```
raw_before  == raw_after     # raw pointer unchanged
clean_before == clean_after  # clean pointer unchanged
filt_before != filt_after    # filt pointer moved
len(cache_after) == len(cache_before) + 1   # one new entry, not three
```

## Why this lands cleanly with no perf regression

The naive shape — "compute SD for all three scopes from scratch every
state change" — would have tripled the analysis-pipeline work on
xorq backends (the ``test_widget_construction_query_count`` regression
test catches that).

The observer instead **reuses ``self.summary_sd``** for the filt
scope (it's already computed by ``_summary_sd``), so this lands
without adding a second pass through the analysis pipeline for the
scope the old flow was already covering. Raw and clean do fresh SD
compute, but only on cache miss and only when their hash differs from
filt's. A widget with no cleaning method and no filter does exactly
one SD compute total — same as before this PR. Query count test
stays green.

## Why this isn't built on top of any other open PR

There are related in-flight PRs around scoped summary stats (#778 and
the smorgasbord stack) and SD encoding (#782). This branches cleanly
from main:

- It does not modify any file that #782 touches.
- It does not depend on, or duplicate, the ``filtered_*`` keys /
  ``merged_sd`` machinery in #778. The keyed cache is the lower-level
  primitive that addresses the same need at a different layer; the two
  can ship in either order and reconcile at merge time.

## Test plan

- [x] 4/4 new tests in ``tests/unit/dataflow/sd_cache_test.py``
- [x] Full Python suite (1015 passed, 1 unrelated MCP test deselected
      for empty static artifact in worktree)
- [x] ``test_widget_construction_query_count`` stays ≤6 queries
- [x] ``ruff check`` + ``paddy-format`` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)