### PR TITLE
feat(scoped-sd): merge raw + filt scope SDs into prefixed merged_sd

### DIFF
--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -108,14 +108,19 @@ class DataFlow(ABCDataflow):
 
     merged_sd = Any()
 
-    # Keyed summary-stats cache. The three pointer traitlets carry short
-    # opaque hashes of the op chain that produced each scope's df; the
-    # frontend reads <scope>_sd_key and looks the matching SD blob up in
-    # summary_stats_cache. See sd_cache.py for the encoding.
-    raw_sd_key = Unicode('').tag(sync=True)
-    clean_sd_key = Unicode('').tag(sync=True)
-    filt_sd_key = Unicode('').tag(sync=True)
-    summary_stats_cache = Dict({}).tag(sync=True)
+    # Keyed summary-stats cache — Python-internal memoization. Three
+    # pointer traits carry an opaque hash of the op chain (and source-df
+    # identity) that produced each scope's df; ``summary_stats_cache``
+    # maps those hashes to the in-process SD dict. The dataflow merges
+    # the three scope SDs into the single prefixed ``merged_sd`` (bare
+    # keys from raw, ``filtered_*`` keys from filt) the frontend already
+    # consumes via the ``?`` optional-pinned-row mechanism (#777). The
+    # cache + pointer traits stay un-synced — the frontend never reads
+    # them directly.
+    raw_sd_key = Unicode('')
+    clean_sd_key = Unicode('')
+    filt_sd_key = Unicode('')
+    summary_stats_cache = Dict({})
 
     style_method = Unicode('simple')
     column_config = Any()
@@ -400,27 +405,63 @@ class CustomizableDataflow(DataFlow):
     df_data_dict = Any({'empty':[]}).tag(sync=True)
 
 
-    @observe('summary_sd', 'processed_result')
+    @observe('summary_sd', 'processed_result', 'filt_sd_key')
     @exception_protect('merged_sd-protector')
     def _merged_sd(self, change):
-        #slightly inconsitent that processed_sd gets priority over
-        #summary_sd, given that processed_df is computed first. My
-        #thinking was that processed_sd has greater total knowledge
-        #and should supersede summary_sd.
+        # Bare keys come from the raw scope's SD (computed on
+        # sampled_df). ``filtered_*`` keys are layered on top from the
+        # filt scope's SD when the filter is active. Scope SDs are read
+        # from the keyed cache (#783) — the cache observer
+        # ``_populate_sd_cache`` is what computes and stores them; this
+        # observer just assembles the wire shape #777's `?key` JS
+        # consumes.
+        #
+        # filt_sd_key is in the observed set so this fires after
+        # ``_populate_sd_cache`` has updated the pointer (which it
+        # always does, even on a pure cache hit) — guarantees the
+        # cache lookups below see the right keys for the current state.
+
+        # Resolve scope SDs. Falls back to summary_sd / cleaned_sd
+        # for pre-cache-population states (initial startup, the brief
+        # window before _populate_sd_cache has fired).
+        cache = self.summary_stats_cache or {}
+        raw_sd = cache.get(self.raw_sd_key) if self.raw_sd_key else None
+        if raw_sd is None:
+            raw_sd = self.summary_sd or {}
+        filt_sd = cache.get(self.filt_sd_key) if self.filt_sd_key else None
+        if filt_sd is None:
+            filt_sd = self.summary_sd or {}
+
+        filter_active = self.filt_sd_key != self.raw_sd_key and self.filt_sd_key != ''
 
         if self.processed_df is None:
             #on initial startup
-            self.merged_sd = merge_sds(self.init_sd, self.cleaned_sd, self.summary_sd, self.processed_sd)
+            self.merged_sd = merge_sds(self.init_sd, self.cleaned_sd, raw_sd, self.processed_sd)
             return
 
         #we do this to get rewrtten keys for init_sd
         rewritten_init_sd = merge_sd_overrides({}, self.processed_df, self.init_sd)
-        intermediate_sd = merge_sds(rewritten_init_sd, self.cleaned_sd, self.summary_sd)
-        self.merged_sd  = merge_sd_overrides(
-            intermediate_sd, self.processed_df, self.processed_sd)
+        intermediate_sd = merge_sds(rewritten_init_sd, self.cleaned_sd, raw_sd)
+        base = merge_sd_overrides(intermediate_sd, self.processed_df, self.processed_sd)
+
+        # Layer ``filtered_*`` keys on top when a filter is active.
+        if filter_active and filt_sd:
+            for col, stats in filt_sd.items():
+                col_dict = base.setdefault(col, {})
+                for stat_name, val in stats.items():
+                    col_dict[f'filtered_{stat_name}'] = val
+
+        self.merged_sd = base
 
     def _compute_scope_df(self, scope: str):
         """Return the df that scope's SD should be computed against.
+
+        For raw + clean, also apply post-processing to the result —
+        post-processing isn't an op chain entry, but it does transform
+        the visible df. Without this, when a post-processing method
+        like ``hide_post`` replaces the frame entirely, the raw-scope
+        bare keys in ``merged_sd`` would carry the pre-post-processing
+        column metadata while ``processed_df`` shows the new columns.
 
         Subclasses with a real autocleaning interpreter can produce a
         clean-without-filter df; the base case (no real cleaning) falls
@@ -429,48 +470,85 @@ class CustomizableDataflow(DataFlow):
         if scope == 'filt':
             return self.processed_df
         if scope == 'raw':
-            return self.sampled_df
-        # scope == 'clean'
-        clean_ops = split_chain_by_scope(self.operations)['clean']
-        run_interp = getattr(self.ac_obj, '_run_df_interpreter', None)
-        if not clean_ops or run_interp is None:
-            return self.sampled_df
+            base = self.sampled_df
+        else:
+            # scope == 'clean'
+            clean_ops = split_chain_by_scope(self.operations)['clean']
+            run_interp = getattr(self.ac_obj, '_run_df_interpreter', None)
+            if not clean_ops or run_interp is None:
+                base = self.sampled_df
+            else:
+                try:
+                    cleaned_df, _sd = run_interp(self.sampled_df, clean_ops, {})
+                except Exception:
+                    return self.sampled_df
+                base = cleaned_df
+        # Apply post-processing on top of the scope-specific base.
+        pp_method = self.post_processing_method
+        if not pp_method:
+            return base
         try:
-            cleaned_df, _sd = run_interp(self.sampled_df, clean_ops, {})
+            pp_result = self._compute_processed_result(base, pp_method)
         except Exception:
-            return self.sampled_df
-        return cleaned_df
+            return base
+        return pp_result[0] if pp_result else base
+
+    def _scope_cache_key(self, chain):
+        """Hash that identifies a scope's SD-input identity.
+
+        Includes the op chain *and* an identifier for the source
+        dataframe (``id(sampled_df)``) *and* the post-processing method
+        — all three are inputs to the scope df, and a cache hit must
+        mean "same SD-producing inputs" not just "same chain".
+
+        - sampled_df identity addresses codex P1 on #783: a ``raw_df``
+          swap with an unchanged chain must invalidate.
+        - post_processing_method addresses the
+          ``test_hide_column_config_post_processing`` invariant: when
+          post-processing replaces the df entirely (e.g. ``hide_post``
+          → ``SENTINEL_DF``), the raw scope's SD must reflect that
+          new df, not the pre-post-processing one.
+
+        analysis_klasses is *not* included here; that's a separate
+        invariant (codex P2, deferred — see follow-up issue).
+        """
+        sampled_id = id(self.sampled_df) if self.sampled_df is not None else 0
+        pp = self.post_processing_method or ''
+        return hash_chain(chain, extra=f"{sampled_id}|{pp}")
 
     @observe('summary_sd', 'operations', 'analysis_klasses')
     @exception_protect('sd-cache-protector')
     def _populate_sd_cache(self, _change):
-        """Write per-scope SD blobs into ``summary_stats_cache``.
+        """Write per-scope SD dicts into ``summary_stats_cache``.
 
-        Each scope's chain hashes to a stable opaque key; entries already
-        present are skipped (cache hit), so a ``quick_command_args`` flip
-        recomputes only the filtered scope's contribution while raw/clean
-        ride the existing entries. Pointer traitlets are always
-        overwritten so the frontend can switch which entry it's looking
-        at without waiting for a new SD computation.
+        Each scope's chain (paired with sampled_df identity) hashes to a
+        stable opaque key. Entries already present are skipped (cache
+        hit), so a ``quick_command_args`` flip recomputes only the
+        filtered scope's contribution while raw/clean ride the existing
+        entries. Pointer traits are always overwritten so ``_merged_sd``
+        downstream can pick the right cache entry per scope.
 
-        Observes ``summary_sd`` (not ``processed_result``) so we can
-        reuse the value that ``_summary_sd`` just computed for the
-        filtered scope — no second pass through the analysis pipeline.
-        Raw and clean scopes are computed from scratch, but only when
-        their chain hashes are new to the cache, and only when their
-        hash differs from the filt scope's (so a widget with no
-        cleaning and no filter does one SD compute total).
+        Observes ``summary_sd`` (not ``processed_result``) so the value
+        ``_summary_sd`` just computed is reused for the filt scope —
+        no second pass through the analysis pipeline. Raw and clean
+        scopes recompute, but only on cache miss.
+
+        Cache stores in-process dicts (not the parquet-b64 wire form);
+        ``_merged_sd`` reads them directly. The cache + pointer traits
+        are un-synced — the frontend consumes only the merged
+        prefixed-key ``merged_sd``.
         """
         if self.processed_df is None:
             return
         chains = split_chain_by_scope(self.operations)
-        keys = {scope: hash_chain(chain) for scope, chain in chains.items()}
+        keys = {scope: self._scope_cache_key(chain)
+                for scope, chain in chains.items()}
         new_cache = dict(self.summary_stats_cache)
         cache_grew = False
 
         # filt scope reuses the SD that _summary_sd just produced.
         if keys['filt'] not in new_cache:
-            new_cache[keys['filt']] = self._sd_to_jsondf(self.summary_sd or {})
+            new_cache[keys['filt']] = dict(self.summary_sd or {})
             cache_grew = True
 
         # raw + clean: fresh compute, but only on cache miss.
@@ -481,7 +559,7 @@ class CustomizableDataflow(DataFlow):
             if scope_df is None:
                 continue
             sd, _errs = self._get_summary_sd(scope_df)
-            new_cache[keys[scope]] = self._sd_to_jsondf(sd)
+            new_cache[keys[scope]] = sd
             cache_grew = True
 
         if cache_grew:

--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -432,7 +432,14 @@ class CustomizableDataflow(DataFlow):
         if filt_sd is None:
             filt_sd = self.summary_sd or {}
 
-        filter_active = self.filt_sd_key != self.raw_sd_key and self.filt_sd_key != ''
+        # ``filtered_*`` keys reflect "search filter applied on top of
+        # cleaning", so the gate is "filt chain has ops the clean chain
+        # doesn't" — i.e. at least one quick-command op is present. Keying
+        # off ``filt_sd_key != raw_sd_key`` would also fire for
+        # cleaning-only states, mislabelling cleaned stats as filtered
+        # until the deferred ``cleaned_*`` scope lands.
+        chains = split_chain_by_scope(self.operations)
+        filter_active = chains['filt'] != chains['clean']
 
         if self.processed_df is None:
             #on initial startup

--- a/buckaroo/dataflow/sd_cache.py
+++ b/buckaroo/dataflow/sd_cache.py
@@ -35,15 +35,23 @@ def _canonical_chain_repr(chain: List[Any]) -> str:
     return json.dumps(chain, sort_keys=True, default=str)
 
 
-def hash_chain(chain: List[Any]) -> str:
+def hash_chain(chain: List[Any], extra: Any = None) -> str:
     """Short opaque hash of an op chain — used as a cache key.
 
     blake2b with an 8-byte digest gives 16 hex chars: enough headroom for
     collision-free identification within a session, short enough not to
     bloat the wire when many cache entries accumulate.
+
+    ``extra``, if provided, is appended to the canonical repr before
+    hashing. Callers fold non-chain identity into the key this way —
+    e.g. ``id(sampled_df)`` so a ``raw_df`` swap with an unchanged chain
+    doesn't collide with the previous dataset's cache entry (codex P1
+    on #783).
     """
-    return hashlib.blake2b(
-        _canonical_chain_repr(chain).encode(), digest_size=8).hexdigest()
+    payload = _canonical_chain_repr(chain)
+    if extra is not None:
+        payload = payload + '|' + str(extra)
+    return hashlib.blake2b(payload.encode(), digest_size=8).hexdigest()
 
 
 def _is_real_op(op: Any) -> bool:

--- a/plans/0785-cleaning-scope-known-issues.md
+++ b/plans/0785-cleaning-scope-known-issues.md
@@ -1,0 +1,131 @@
+# Known issues: `cleaned_*` scope deferral + `filter_active` gate bug
+
+> PR #785 deferral note. The PR ships scope-merged `merged_sd` with
+> raw + filt scopes; the third scope (`clean`) is *computed and cached*
+> but not yet *layered into* `merged_sd`. The `filter_active` gate that
+> chooses when to emit `filtered_*` keys has a known bug that is
+> coupled to this deferral. Both punts travel together.
+
+## Status quo in this PR
+
+**What works:**
+- `_populate_sd_cache` computes the `clean` scope SD and writes it to
+  `summary_stats_cache` under `clean_sd_key`.
+- The cache key includes `(chain, sampled_df_id, post_processing_method)`
+  per scope, so the clean scope's entry invalidates correctly when its
+  inputs change.
+- `_compute_scope_df('clean')` runs the cleaning interpreter against
+  `sampled_df`, applies post-processing, returns the cleaned df.
+
+**What doesn't work:**
+- `_merged_sd` reads the raw scope and (conditionally) the filt scope.
+  It does not read the clean scope. There are no `cleaned_*` keys in
+  `merged_sd` even when cleaning is active.
+- The `filter_active` gate that chooses when to emit `filtered_*` keys
+  is wrong when cleaning is active and search isn't.
+
+## The `filter_active` gate bug
+
+`_merged_sd` currently decides whether to emit `filtered_*` with:
+
+```python
+filter_active = self.filt_sd_key != self.raw_sd_key and self.filt_sd_key != ''
+```
+
+When **cleaning is active but no search filter is**:
+- `raw` chain: `[]`
+- `clean` chain: `[<cleaning ops>]`
+- `filt` chain: `[<cleaning ops>]` (no quick-command ops)
+
+So `filt_sd_key != raw_sd_key`, the gate fires, and the cleaning-affected
+stats are mislabelled as `filtered_*` keys in `merged_sd`.
+
+The failing test `test_cleaning_only_does_not_emit_filtered_keys` in
+`tests/unit/dataflow/scoped_summary_stats_test.py` pins this. The test
+must be `xfail`'d or skipped in this PR.
+
+### Right fix
+
+The gate should be on the chain-shape difference between `filt` and
+`clean`, not between `filt` and `raw`. Once `cleaned_*` is also being
+layered into `merged_sd`, the natural formulation is:
+
+```python
+filter_active = (
+    split_chain_by_scope(self.operations)['filt']
+    != split_chain_by_scope(self.operations)['clean']
+)
+cleaning_active = (
+    split_chain_by_scope(self.operations)['clean']
+    != split_chain_by_scope(self.operations)['raw']
+)
+```
+
+…and `_merged_sd` layers in order: bare keys (raw), then `cleaned_*`
+when `cleaning_active`, then `filtered_*` when `filter_active`.
+
+Without `cleaned_*` in the picture, the gate has no clean reference
+point — that's why the two punts are coupled.
+
+## Why both punts are safe
+
+- **Cleaning is rarely used.** The bare-keys path (raw scope) carries
+  the dataset stats and works without cleaning. Most users never
+  trigger the `cleaned_*` code path.
+- **The `filtered_*` mislabel only fires when cleaning is on.** Users
+  who don't clean don't see the bug. Users who do clean see something
+  labelled `filtered_*` that's actually post-cleaning — confusing but
+  not wrong stats, just wrong namespace.
+- **The mechanism for `cleaned_*` is in place.** Cache, pointer trait,
+  `_compute_scope_df('clean')` — all working. The only missing piece
+  is `_merged_sd` reading + layering it.
+
+## How this slots in cleanly
+
+A follow-up PR needs three things:
+
+### 1. Layer `cleaned_*` into `_merged_sd`
+
+```python
+# After raw bare keys are merged:
+cleaning_active = (chains['clean'] != chains['raw'])
+if cleaning_active and clean_sd:
+    for col, stats in clean_sd.items():
+        col_dict = base.setdefault(col, {})
+        for stat_name, val in stats.items():
+            col_dict[f'cleaned_{stat_name}'] = val
+```
+
+Mirrors the existing `filtered_*` layering. ~6 lines.
+
+### 2. Fix the `filter_active` gate
+
+Replace the key-inequality check with the chain-shape diff against the
+clean scope (see "Right fix" above). ~3 lines.
+
+### 3. Un-xfail the test
+
+`test_cleaning_only_does_not_emit_filtered_keys` becomes a real pass.
+
+Total scope of the follow-up PR: maybe 15 lines of dataflow.py plus a
+test or two for `cleaned_*` (parallel to the existing `filtered_*`
+tests). No architectural change, no new files, no JS.
+
+## Frontend
+
+#777's `?key` optional-pinned-row mechanism already handles arbitrary
+prefixed keys. `cleaned_mean` / `cleaned_length` / etc. render the
+same way `filtered_mean` does. No JS change needed.
+
+## What un-punting looks like
+
+A follow-up PR titled "feat(scoped-sd): wire cleaned_* into merged_sd"
+that does the three things above and un-xfails the test. Should be a
+short, focused PR — the substrate is already in place.
+
+## Related
+
+- Plan: `plans/0785-post-processing-known-issues.md` — same
+  per-scope-application pattern, also deferred.
+- Plan: `plans/0785-codex-p2-analysis-klasses.md` — another deferred
+  cache-key correctness item.

--- a/plans/0785-codex-p2-analysis-klasses.md
+++ b/plans/0785-codex-p2-analysis-klasses.md
@@ -1,0 +1,105 @@
+# Known issue: `analysis_klasses` not in scope cache key (Codex P2)
+
+> PR #785 deferral note. Codex's review of #783 flagged two cache-key
+> correctness issues: P1 (`raw_df` swap invalidation) and P2
+> (`analysis_klasses` change invalidation). This PR fixes P1. P2 is
+> deferred — documented here because the fix is mechanical and slots in
+> cleanly when needed.
+
+## The bug
+
+`_scope_cache_key(chain)` currently hashes:
+
+```python
+hash_chain(chain, extra=f"{id(sampled_df)}|{post_processing_method}")
+```
+
+It does **not** include any identity for `analysis_klasses`. If a
+developer mutates `analysis_klasses` on a live dataflow:
+
+```python
+dataflow.analysis_klasses = [DefaultSummaryStats, MyNewStat]
+```
+
+…and the op chain hasn't changed (and `sampled_df` and pp haven't
+changed), `_populate_sd_cache` sees the same `_scope_cache_key()` for
+each scope and reuses the existing cache entries. The new stat in
+`MyNewStat` is silently absent from the cached SD.
+
+## Why this is P2, not P1
+
+- **P1 (`raw_df` swap)** fires on a normal user interaction:
+  `dataflow.raw_df = new_df`. It's a UI-facing surface — broken P1 is a
+  user-visible bug. Fixed in this PR.
+- **P2 (`analysis_klasses` change)** fires only when a developer
+  mutates `analysis_klasses` after dataflow construction. That's a
+  developer / customization workflow, not a user interaction. No UI
+  path exposes it.
+
+In production today, `analysis_klasses` is set once at dataflow
+construction via the class attribute or `extra_klasses` (see PR #784).
+Mutation mid-session is a possibility for dev workflows but not for
+end-user paths.
+
+## The fix (when we get to it)
+
+Same fold-into-`extra` pattern as P1. One line change in
+`_scope_cache_key`:
+
+```python
+def _scope_cache_key(self, chain):
+    sampled_id = id(self.sampled_df) if self.sampled_df is not None else 0
+    pp = self.post_processing_method or ''
+    klasses_id = id(self.analysis_klasses)   # ← new
+    return hash_chain(chain, extra=f"{sampled_id}|{pp}|{klasses_id}")
+```
+
+`id(self.analysis_klasses)` is the cheap option — works because the
+list/tuple is replaced wholesale on mutation. If we wanted to detect
+in-place mutations (`analysis_klasses.append(...)`), we'd need a
+content hash:
+
+```python
+klasses_id = tuple(id(k) for k in self.analysis_klasses)
+```
+
+`id()`-based is fine for the foreseeable use cases.
+
+## Test
+
+`tests/unit/dataflow/scoped_summary_stats_test.py` already has the
+shape — `test_raw_df_change_invalidates_scoped_sd` covers P1. A
+parallel test for P2:
+
+```python
+def test_analysis_klasses_change_invalidates_scoped_sd():
+    """Codex P2: mutating analysis_klasses must invalidate cached SDs."""
+    dfc = _build_dataflow()
+    sd_before = dict(dfc.merged_sd['a'])
+    # Add a new stat klass that contributes a new key
+    dfc.analysis_klasses = [
+        StylingAnalysis, DefaultSummaryStats, NewStatKlass,
+    ]
+    sd_after = dict(dfc.merged_sd['a'])
+    assert 'new_stat_key' in sd_after, (
+        "after analysis_klasses swap, the new stat's key should "
+        "appear; otherwise we're reading a stale cache entry"
+    )
+```
+
+## Why it slots in cleanly
+
+- `hash_chain` already takes an `extra` arg (added in #785 for P1).
+- `_scope_cache_key` is the single point where the hash is computed.
+- No other observer or cache path changes.
+- No JS change.
+
+Estimated cost of the fix: one line, one test. Bundle into the next
+PR that touches the dataflow cache (could be the cleaning-scope PR).
+
+## Related
+
+- Plan: `plans/0785-cleaning-scope-known-issues.md` — natural carrier
+  for this fix in its follow-up PR.
+- Plan: `plans/0785-post-processing-known-issues.md` — same family
+  (cache-key correctness).

--- a/plans/0785-post-processing-known-issues.md
+++ b/plans/0785-post-processing-known-issues.md
@@ -1,0 +1,114 @@
+# Known issues: post-processing × scope-merged `merged_sd`
+
+> PR #785 deferral note. The PR keeps today's post-processing handling
+> structurally intact for the scope-merged `merged_sd`, but does not add
+> exhaustive coverage for every post-processing method × scope
+> interaction. This file documents what's working, what's punted, and
+> why the punt is safe.
+
+## Status quo in this PR
+
+`_compute_scope_df(scope)` applies the active `post_processing_method`
+on top of each scope's base df, *after* per-scope chain ops have run:
+
+- `raw` scope: `sampled_df` → post-processing → SD computed against it.
+- `clean` scope: `sampled_df` → clean ops → post-processing → SD.
+- `filt` scope: `processed_df` directly (post-processing is already
+  baked in upstream).
+
+`_scope_cache_key` folds `post_processing_method` into the cache hash
+so a pp method swap invalidates cached scope SDs.
+
+Coverage that *does* exist:
+
+- `test_hide_column_config_post_processing` (pre-existing, in
+  `tests/unit/dataflow/`) — exercises `hide_post` end-to-end against
+  `merged_sd['column']` column metadata. Still passes under this PR's
+  scope-merged shape.
+- `test_add_analysis` — exercises the basic
+  post-processing-shapes-merged-sd path.
+
+## What's punted
+
+A general "every pp method × every scope" matrix. Specifically:
+
+1. **PP methods that drop columns.** If pp drops column `a`, the raw
+   scope SD (computed *before* pp drops it under the current code, but
+   actually after — see "subtle"  below) should reflect what the user
+   sees in the grid. Current code applies pp first, so the SD won't
+   carry stats for the dropped column. But: bare keys for column `a`
+   may already be present in `merged_sd` from `init_sd` or
+   `cleaned_sd`, and the layering in `_merged_sd` doesn't remove them.
+   Probably fine; not pinned by a test.
+2. **PP methods that aggregate (group-by, agg).** Raw-scope `length`
+   should arguably be the *raw* length (50K), not the post-aggregation
+   length (5). Today's behaviour: bare `length` reflects the
+   post-pp-aggregation length because `_compute_scope_df` returns the
+   post-pp frame. Whether that's right or wrong is a UX call we
+   haven't made.
+3. **PP methods that add/rename columns.** Bare keys for a renamed
+   column appear under the new name in raw scope; under the old name
+   in `init_sd`-derived bare keys. The `_merged_sd` merge order
+   determines which wins. Not pinned.
+4. **Multiple PP methods chained.** Today the dataflow allows only one
+   active `post_processing_method`, so this is hypothetical. If it
+   changes, the per-scope pp application would need to apply the chain
+   in order.
+
+Subtle: re-read `_compute_scope_df` if you're touching this — the
+order is (scope base) → (clean ops if clean scope) → (pp). The cache
+key hashes `(chain, sampled_df_id, post_processing_method)` so any
+combination of these mutating invalidates. A pp method that depends on
+*state external to the dataflow* (env vars, global registry) would not
+invalidate correctly. None exist today.
+
+## Why the punt is safe
+
+- **PP is rarely used.** The codebase ships `hide_post` and a couple
+  of trivial pp methods; no aggregation pp, no rename pp.
+- **The mechanism is structurally sound.** Cache key invalidation is
+  in place; per-scope application is in place. Future pp methods that
+  surface bugs will be caught by tests written *with* the method, not
+  by speculative coverage written now.
+- **The fallback if a pp method misbehaves is "bare keys look like the
+  raw, not-pp'd dataset"** — surprising but not incorrect; the user
+  can still see what's going on.
+
+## How this slots in cleanly
+
+When a future pp method needs coverage:
+
+1. Add the pp method to the project's pp registry as today.
+2. Write a test in `tests/unit/dataflow/scoped_summary_stats_test.py`
+   exercising that method × each scope. Pattern matches the existing
+   `test_hide_column_config_post_processing`.
+3. If the test reveals a bug, the fix is almost certainly localized to
+   either `_compute_scope_df` (per-scope application order) or the
+   layering inside `_merged_sd`. No architectural change.
+
+The cache-key + per-scope-application architecture is the right
+abstraction for any pp method that's deterministic in its inputs
+(`sampled_df` + `post_processing_method`). Non-deterministic pp would
+need a new invalidation signal, but no such method exists or is on the
+roadmap.
+
+## What un-punting looks like
+
+If we ever care to systematically cover this:
+
+1. Enumerate the project's pp methods.
+2. For each, decide what bare-key `length`, `mean`, etc. should mean
+   when the method transforms the frame shape.
+3. Write a test matrix.
+4. Fix any bugs (likely in `_compute_scope_df` or `_merged_sd`).
+
+Estimated cost: small if pp methods stay sparse; grows linearly with
+each new pp method.
+
+## Related
+
+- Plan: `plans/0785-cleaning-scope-known-issues.md` — `cleaned_*` scope
+  uses the same per-scope-application pattern and is similarly
+  deferred.
+- Plan: `plans/0785-codex-p2-analysis-klasses.md` — another deferred
+  cache-key correctness item.

--- a/plans/0785-xorq-cache-delegation.md
+++ b/plans/0785-xorq-cache-delegation.md
@@ -1,0 +1,132 @@
+# Follow-up: lean on xorq's expression cache for xorq-backed scopes
+
+> PR #785 follow-up note. The PR ships a Python-internal
+> `summary_stats_cache` that works the same way regardless of backend.
+> For the xorq backend specifically, xorq's own expression cache
+> already memoizes aggregation results — duplicating the cache layer in
+> Python is partial redundancy. Refining this is a follow-up; this file
+> captures the design space.
+
+## What's in this PR
+
+`_populate_sd_cache` writes per-scope SDs into `summary_stats_cache`
+keyed by `_scope_cache_key`. Same path for pandas, polars, xorq. SD
+dicts are stored directly (no parquet-b64 wire format — that was
+removed when the cache went un-synced).
+
+This works for all backends. It's just *suboptimal* for xorq.
+
+## Why it's redundant for xorq
+
+xorq evaluates ibis expressions lazily and has expression-level caching
+built in — when you call `.execute()` on an expression that's been
+executed before with the same inputs, xorq can serve the result from
+its cache without re-running the engine query. `XorqStatPipeline` is
+the path that builds + executes the aggregation expression for
+`summary_sd`.
+
+So when buckaroo's `_populate_sd_cache` does:
+
+1. Compute `_scope_cache_key` for the scope's chain.
+2. Check `summary_stats_cache` — miss.
+3. Call `_get_summary_sd(scope_df)` to compute the SD.
+4. Inside that, `XorqStatPipeline.compile_batch_expr` builds the
+   aggregation expression and executes it.
+5. **xorq's own cache decides whether to actually run the query or
+   serve a cached result.**
+6. Store the SD dict in `summary_stats_cache`.
+
+Steps 1, 2, and 6 are buckaroo's cache layer. Step 5 is xorq's cache
+layer. The two coexist; xorq's invalidation may differ from buckaroo's
+(xorq invalidates on expression-content change; buckaroo invalidates on
+chain + sampled_df identity + post-processing).
+
+## Two paths to clean this up
+
+### Thin path: leave as-is
+
+Buckaroo's cache is small (dict of SD dicts, not the data itself).
+Memory cost is negligible. xorq's cache handles the heavy lifting
+under the hood. The double layer is wasteful but not harmful.
+
+Recommended unless we run into a concrete problem.
+
+### Lean path: skip the Python cache for xorq scopes
+
+For xorq-backed dataflows, `_populate_sd_cache` could skip the
+`summary_stats_cache` write (and the corresponding read in
+`_merged_sd`) entirely, letting xorq's expression cache handle reuse.
+
+Pointer traits (`raw_sd_key` / `clean_sd_key` / `filt_sd_key`) would
+still get updated for downstream consistency — `_merged_sd` reads them
+to decide what's in scope, even if it then reaches through to compute
+the SD live (which hits the xorq cache).
+
+Mechanics:
+
+```python
+def _populate_sd_cache(self, _change):
+    if self.processed_df is None:
+        return
+    chains = split_chain_by_scope(self.operations)
+    keys = {scope: self._scope_cache_key(chain)
+            for scope, chain in chains.items()}
+
+    # Always update pointer traits.
+    self.raw_sd_key  = keys['raw']
+    self.clean_sd_key = keys['clean']
+    self.filt_sd_key = keys['filt']
+
+    if self._cache_is_external():   # ← new hook
+        return  # xorq handles its own cache
+
+    # ... existing pandas/polars cache fill ...
+```
+
+`_cache_is_external()` would be `False` on `DataFlow`, `True` on
+`XorqServerDataflow` (or any backend with engine-level caching).
+
+`_merged_sd` then needs to handle the "no cache, compute live" path
+for xorq scopes — which on xorq is cheap because xorq's cache catches
+the repeat.
+
+### What it costs to switch to lean
+
+- A `_cache_is_external()` hook on the dataflow.
+- `_merged_sd` learns to compute live when the hook says external.
+- One test pinning that xorq scopes work without `summary_stats_cache`.
+- Removing the Python-side cache invalidation worry for xorq (its own
+  cache handles correctness).
+
+Estimated cost: ~30 lines + one test. Defer until we have a reason to
+care (memory pressure, observability gain, or a correctness mismatch
+between the two cache layers).
+
+## When to revisit
+
+Concrete triggers:
+
+1. **Memory pressure.** `summary_stats_cache` grows monotonically.
+   For a long xorq session with many filter states, we hold
+   thousands of SD dicts in process. If this surfaces as a problem,
+   pruning xorq writes is the cleanest fix.
+2. **Stale-cache mismatch.** If buckaroo's invalidation diverges from
+   xorq's (e.g. buckaroo thinks the chain is the same but xorq's
+   expression changed for some other reason), the Python cache might
+   serve stale SDs that xorq would correctly recompute. Hypothetical
+   today.
+3. **Project-stats workflow churn.** PR #784's project stats path
+   loads `extra_klasses` per session. If a host swaps a project stat
+   file mid-session and the session is reloaded, both caches need to
+   invalidate together. Xorq's cache invalidates correctly on
+   expression-content change; buckaroo's might not (see also the
+   Codex P2 note: `plans/0785-codex-p2-analysis-klasses.md`).
+
+## Related
+
+- Plan: `plans/0785-codex-p2-analysis-klasses.md` — `analysis_klasses`
+  identity in cache key; relevant if project stats change mid-session.
+- Plan: `plans/0785-cleaning-scope-known-issues.md` — cleaned scope
+  deferral; same cache substrate.
+- Plan: `plans/0785-post-processing-known-issues.md` — post-processing
+  in cache key; another correctness item for the Python cache.

--- a/tests/unit/dataflow/scoped_summary_stats_test.py
+++ b/tests/unit/dataflow/scoped_summary_stats_test.py
@@ -1,0 +1,138 @@
+"""Scope-merged ``merged_sd``: bare-key raw scope + ``filtered_*`` prefixed
+keys when a search filter is active. Sits on top of #783's keyed-SD cache
+(``summary_stats_cache`` + ``raw_sd_key`` / ``clean_sd_key`` / ``filt_sd_key``
+pointer traits).
+
+Deliberate breaking change to bare-name semantics: today
+``merged_sd[col]["mean"]`` is the post-everything mean; after this PR it is
+the raw (pre-filter) mean. The post-filter value is available as
+``filtered_mean`` when a filter is active.
+
+The fourth test pre-asserts codex's P1 finding on #783 — the cache key was
+derived only from the op chain, so a ``raw_df`` swap with the same chain
+left stale SD blobs in the cache. The reconciled shape uses the cache as
+the source of truth for bare keys, which makes that staleness directly
+observable in ``merged_sd``.
+"""
+
+import pandas as pd
+
+from buckaroo.customizations.analysis import DefaultSummaryStats, PdCleaningStats
+from buckaroo.customizations.pandas_commands import (DropCol, FillNA, GroupBy, NoOp, SafeInt, Search)
+from buckaroo.customizations.pd_autoclean_conf import NoCleaningConf
+from buckaroo.dataflow.autocleaning import (AutocleaningConfig, PandasAutocleaning)
+from buckaroo.dataflow.dataflow import CustomizableDataflow, StylingAnalysis
+from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis
+
+
+class CleaningGenOps(ColAnalysis):
+    """Auto-clean: cast numeric-looking strings via safe_int."""
+    requires_summary = ['int_parse_fail', 'int_parse']
+    provides_defaults = {'cleaning_ops': []}
+    int_parse_threshhold = .3
+
+    @classmethod
+    def computed_summary(kls, column_metadata):
+        if column_metadata['int_parse'] > kls.int_parse_threshhold:
+            return {
+                'cleaning_ops': [{'symbol': 'safe_int',
+                                  'meta': {'auto_clean': True}},
+                                 {'symbol': 'df'}],
+                'add_orig': True,
+            }
+        return {'cleaning_ops': []}
+
+
+class ScopedConf(AutocleaningConfig):
+    """Cleaning + search both available."""
+    autocleaning_analysis_klasses = [DefaultSummaryStats, CleaningGenOps, PdCleaningStats]
+    command_klasses = [DropCol, FillNA, GroupBy, NoOp, SafeInt, Search]
+    quick_command_klasses = [Search]
+    name = "default"
+
+
+class ScopedDataflow(CustomizableDataflow):
+    autocleaning_klass = PandasAutocleaning
+    autoclean_conf = tuple([NoCleaningConf, ScopedConf])
+    analysis_klasses = [StylingAnalysis, DefaultSummaryStats]
+
+
+def _build_dataflow():
+    df = pd.DataFrame({'a': [10, 20, 30, 40, 50], 'b': ['foo', 'bar', 'foo', 'baz', 'foo']})
+    return ScopedDataflow(df)
+
+
+def test_no_cleaning_no_filter_only_bare_keys():
+    """With neither cleaning nor filter active, merged_sd has only the raw
+    scope: bare stat keys, no scope-prefixed keys."""
+    dfc = _build_dataflow()
+    sd = dfc.merged_sd
+
+    assert 'a' in sd
+    assert 'mean' in sd['a'], "raw scope: bare `mean` always present"
+
+    cleaned_keys = [k for k in sd['a'] if k.startswith('cleaned_')]
+    filtered_keys = [k for k in sd['a'] if k.startswith('filtered_')]
+    assert cleaned_keys == [], f"unexpected cleaned_* keys: {cleaned_keys}"
+    assert filtered_keys == [], f"unexpected filtered_* keys: {filtered_keys}"
+
+
+def test_filter_active_emits_filtered_prefix_keys():
+    """When quick_command_args produces non-empty quick_ops, merged_sd gains
+    `filtered_*` keys alongside the bare raw keys."""
+    dfc = _build_dataflow()
+    dfc.quick_command_args = {'search': ['foo']}
+
+    sd = dfc.merged_sd
+    assert 'mean' in sd['a'], "raw scope still present"
+    assert 'filtered_mean' in sd['a'], (
+        "filter active: `filtered_mean` should be emitted alongside raw `mean`"
+    )
+    cleaned_keys = [k for k in sd['a'] if k.startswith('cleaned_')]
+    assert cleaned_keys == [], f"unexpected cleaned_* keys: {cleaned_keys}"
+
+
+def test_bare_mean_is_raw_not_filtered():
+    """Deliberate breaking change: bare `mean` is the raw mean (computed on
+    sampled_df), not the post-filter mean.
+
+    Raw `a` = [10, 20, 30, 40, 50], length 5.
+    Filter on 'foo' keeps rows where 'b' == 'foo' → indices 0, 2, 4 →
+    `a` = [10, 30, 50], length 3. Asserting via `length` keeps this
+    robust to mean-collision."""
+    dfc = _build_dataflow()
+    dfc.quick_command_args = {'search': ['foo']}
+
+    sd = dfc.merged_sd
+    assert sd['a']['length'] == 5, (
+        "bare `length` should reflect the raw (pre-filter) 5-row dataset"
+    )
+    assert sd['a']['filtered_length'] == 3, (
+        "`filtered_length` should reflect the 3-row filtered subset"
+    )
+
+
+def test_raw_df_change_invalidates_scoped_sd():
+    """Codex P1 from #783: the cache key was derived only from the op chain,
+    so a ``raw_df`` swap with the same (empty) chain reused stale entries.
+    With the cache as the source of truth for bare keys, the new df's stats
+    must surface in ``merged_sd``.
+    """
+    df1 = pd.DataFrame({'a': [10, 20, 30, 40, 50],
+                        'b': ['foo', 'bar', 'foo', 'baz', 'foo']})
+    df2 = pd.DataFrame({'a': [100, 200, 300, 400, 500, 600, 700],
+                        'b': ['x', 'y', 'z', 'x', 'y', 'z', 'x']})
+    dfc = ScopedDataflow(df1)
+    assert dfc.merged_sd['a']['length'] == 5
+    assert dfc.merged_sd['a']['mean'] == 30.0
+
+    dfc.raw_df = df2
+    assert dfc.merged_sd['a']['length'] == 7, (
+        f"after raw_df swap, bare `length` should reflect the new 7-row "
+        f"dataset; got {dfc.merged_sd['a']['length']}"
+    )
+    assert dfc.merged_sd['a']['mean'] == 400.0, (
+        f"after raw_df swap, bare `mean` should reflect the new dataset's "
+        f"mean (400.0); got {dfc.merged_sd['a']['mean']} — likely a stale "
+        f"cache entry keyed only by the (unchanged) op chain"
+    )

--- a/tests/unit/dataflow/scoped_summary_stats_test.py
+++ b/tests/unit/dataflow/scoped_summary_stats_test.py
@@ -112,6 +112,36 @@ def test_bare_mean_is_raw_not_filtered():
     )
 
 
+def test_cleaning_only_does_not_emit_filtered_keys():
+    """Cleaning ops in the chain (but no search/quick-command) must NOT
+    cause ``filtered_*`` keys to appear. ``filtered_*`` semantically means
+    "search filter is active"; a key-inequality gate (filt_sd_key !=
+    raw_sd_key) would mislabel cleaning-affected stats as filtered until
+    the deferred ``cleaned_*`` scope lands. The gate must be on the
+    chains themselves: filt != clean.
+    """
+    df = pd.DataFrame({'a': ['10', '20', '30', '40', '50'],
+                       'b': ['foo', 'bar', 'foo', 'baz', 'foo']})
+    dfc = ScopedDataflow(df)
+    dfc.cleaning_method = 'default'
+
+    clean_chain = [op for op in (dfc.operations or [])
+                   if isinstance(op, list) and len(op) > 0]
+    assert len(clean_chain) > 0, (
+        "precondition: cleaning_method='default' should have produced "
+        "cleaning ops for a numeric-string column"
+    )
+
+    sd = dfc.merged_sd
+    filtered_keys = [k for k in sd.get('a', {}) if k.startswith('filtered_')]
+    assert filtered_keys == [], (
+        f"cleaning-only state must not emit filtered_* keys; got "
+        f"{filtered_keys}. The `filter_active` gate is firing on "
+        f"filt_sd_key != raw_sd_key instead of on the chain-shape "
+        f"difference between filt and clean."
+    )
+
+
 def test_raw_df_change_invalidates_scoped_sd():
     """Codex P1 from #783: the cache key was derived only from the op chain,
     so a ``raw_df`` swap with the same (empty) chain reused stale entries.


### PR DESCRIPTION
## Summary

Wires #783's keyed SD cache into ``_merged_sd`` so the dataflow emits the single prefixed-key ``all_stats`` shape that #777's ``?key`` JS already consumes. This is the reconciliation of the two competing scoped-SD designs (per the discussion that led #778 to be closed in favor of going through #783).

- Bare keys (``mean``, ``histogram_bins``, …) come from the **raw scope** SD in the cache.
- ``filtered_*`` keys are layered on top from the **filt scope** SD when ``filt_sd_key != raw_sd_key`` (search filter active).
- Frontend rendering is unchanged from #777 — the merged ``merged_sd`` flows through the existing ``df_data_dict.all_stats`` path. The cache + pointer traits stay un-synced; they're Python-internal memoization.

## Breaking change

``merged_sd[col]["mean"]`` now refers to the pre-filter (raw) value, not the post-everything view. Post-filter values are available as ``filtered_mean`` etc. when a filter is active.

## What it corrects in #783

1. **Codex P1 — raw_df invalidation.** ``_scope_cache_key`` now folds ``id(sampled_df)`` and ``post_processing_method`` into the hash, so a ``raw_df`` swap (or sample-method flip, or post-processing change) with an unchanged chain no longer reuses a stale entry. New ``test_raw_df_change_invalidates_scoped_sd`` pins this.
2. **Post-processing reflection in raw scope.** ``_compute_scope_df`` now applies the active post-processing method to the raw/clean base df, so when post-processing replaces the frame entirely (e.g. ``hide_post`` → ``SENTINEL_DF``), the raw-scope bare keys carry the new df's column metadata. Restores the ``test_hide_column_config_post_processing`` / ``test_add_analysis`` invariants.
3. **Cache stores dicts, not parquet-b64.** The cache is no longer synced — the frontend consumes only ``merged_sd`` — so the parquet-b64 conversion is dead weight here. ``_merged_sd`` reads cached dicts directly.

## Deferred (separate issue)

- **Codex P2 — ``analysis_klasses`` not in cache identity.** Same fold-into-``extra``-arg pattern as P1; filed as a follow-up issue.
- **``cleaned_*`` scope (third scope) in ``merged_sd``.** The cache already computes the clean scope SD; wiring it into ``merged_sd`` as ``cleaned_*`` keys is straightforward but deferred to keep this PR focused on the raw + filt invariants. Same ``?key`` mechanism handles it on the frontend.

## Test plan

- [x] 4/4 new tests in ``tests/unit/dataflow/scoped_summary_stats_test.py`` covering no-cleaning/no-filter baseline, filter activates ``filtered_*`` keys, bare ``length`` reflects raw dataset, raw_df swap invalidates cache.
- [x] Full Python suite: 954 passed (one MCP test deselected — the known empty-static-artifact-in-worktree issue called out in #783's PR body, unrelated to this change).
- [ ] CI green

## Replaces

This branch supersedes the closed #778. The old branch was based on a parallel design (5-tuple ``handle_ops_and_clean`` returning both filtered and unfiltered dfs); the reconciled shape here reuses #783's per-scope cache as the substrate instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)