### PR TITLE
feat(paf): @stat(pushdown=...) declares engine push-down support

### DIFF
--- a/buckaroo/pluggable_analysis_framework/stat_func.py
+++ b/buckaroo/pluggable_analysis_framework/stat_func.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import inspect
 from dataclasses import dataclass, field
-from typing import Any, Callable, List, Optional, TypedDict, get_type_hints
+from typing import Any, Callable, List, Optional, Tuple, TypedDict, get_type_hints
 
 
 class MultipleProvides(TypedDict):
@@ -145,6 +145,10 @@ class StatFunc:
         column_filter: optional predicate on column dtype
         quiet: suppress error reporting
         default: fallback value on failure (MISSING = no fallback)
+        pushdown: backend identifiers (e.g. ``("xorq", "polars")``) whose
+            engines can compute this stat via aggregation push-down without
+            in-process materialization. Empty default means pandas-only /
+            requires materialization.
     """
     name: str
     func: Callable
@@ -154,6 +158,7 @@ class StatFunc:
     column_filter: Optional[Callable] = None
     quiet: bool = False
     default: Any = field(default_factory=lambda: MISSING)
+    pushdown: Tuple[str, ...] = ()
     spread_dict_result: bool = False  # v1 compat: spread all dict keys into accumulator
     v1_computed: bool = False  # v1 compat: pass full accumulator as single dict arg
 
@@ -250,7 +255,7 @@ def _get_requires_from_params(sig: inspect.Signature, hints: dict) -> tuple:
 # @stat decorator
 # ---------------------------------------------------------------------------
 
-def stat(column_filter=None, quiet=False, default=MISSING):
+def stat(column_filter=None, quiet=False, default=MISSING, pushdown=()):
     """Decorator that converts a function into a StatFunc.
 
     The function signature IS the contract:
@@ -262,6 +267,12 @@ def stat(column_filter=None, quiet=False, default=MISSING):
     Single-provider stats: name the function the same as the accumulator
     key the rest of the DAG expects. Use ``MultipleProvides`` (a TypedDict
     alias) when one function should write several keys.
+
+    ``pushdown=`` declares which backends can compute this stat via
+    engine-side aggregation push-down (no in-process materialization).
+    Empty default means pandas-only / requires materialization. Recognised
+    identifiers: ``"xorq"``, ``"polars"``. Normalised to a tuple so callers
+    may pass a list.
 
     Usage::
 
@@ -276,6 +287,10 @@ def stat(column_filter=None, quiet=False, default=MISSING):
         @stat(default=0)
         def safe_ratio(a: int, b: int) -> float:
             return a / b
+
+        @stat(pushdown=("xorq", "polars"))
+        def mean(col):
+            return col.mean()
 
         class TypingResult(MultipleProvides):
             is_numeric: bool
@@ -298,7 +313,8 @@ def stat(column_filter=None, quiet=False, default=MISSING):
         provides_keys = _get_provides_from_return_type(func.__name__, return_type)
 
         stat_func = StatFunc(name=func.__name__, func=func, requires=requires, provides=provides_keys,
-            needs_raw=needs_raw, column_filter=column_filter, quiet=quiet, default=default)
+            needs_raw=needs_raw, column_filter=column_filter, quiet=quiet, default=default,
+            pushdown=tuple(pushdown))
 
         # Attach metadata to the function so pipeline can find it
         func._stat_func = stat_func

--- a/buckaroo/pluggable_analysis_framework/stat_func.py
+++ b/buckaroo/pluggable_analysis_framework/stat_func.py
@@ -312,9 +312,12 @@ def stat(column_filter=None, quiet=False, default=MISSING, pushdown=()):
         requires, needs_raw = _get_requires_from_params(sig, hints)
         provides_keys = _get_provides_from_return_type(func.__name__, return_type)
 
+        # A bare string is the natural single-backend form; ``tuple(str)``
+        # would silently expand it to a tuple of characters.
+        pushdown_norm = (pushdown,) if isinstance(pushdown, str) else tuple(pushdown)
         stat_func = StatFunc(name=func.__name__, func=func, requires=requires, provides=provides_keys,
             needs_raw=needs_raw, column_filter=column_filter, quiet=quiet, default=default,
-            pushdown=tuple(pushdown))
+            pushdown=pushdown_norm)
 
         # Attach metadata to the function so pipeline can find it
         func._stat_func = stat_func

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -195,6 +195,15 @@ class TestStatDecorator:
         assert pushdown_sum._stat_func.pushdown == ("xorq",)
         assert isinstance(pushdown_sum._stat_func.pushdown, tuple)
 
+    def test_stat_pushdown_accepts_bare_string(self):
+        # A bare string is the natural form for one backend.
+        # ``tuple("xorq")`` would silently store ``('x','o','r','q')``.
+        @stat(pushdown="xorq")
+        def pushdown_count(ser: RawSeries) -> int:
+            return int(ser.count())
+
+        assert pushdown_count._stat_func.pushdown == ("xorq",)
+
 
 class _MultiSizeStats(MultipleProvides):
     row_count: int

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -176,6 +176,25 @@ class TestStatDecorator:
         sf = distinct_per._stat_func
         assert sf.default is MISSING
 
+    def test_stat_default_pushdown_is_empty(self):
+        sf = length._stat_func
+        assert sf.pushdown == ()
+
+    def test_stat_pushdown_stored_on_stat_func(self):
+        @stat(pushdown=("xorq", "polars"))
+        def pushdown_mean(ser: RawSeries) -> float:
+            return float(ser.mean())
+
+        assert pushdown_mean._stat_func.pushdown == ("xorq", "polars")
+
+    def test_stat_pushdown_normalises_list_to_tuple(self):
+        @stat(pushdown=["xorq"])
+        def pushdown_sum(ser: RawSeries) -> float:
+            return float(ser.sum())
+
+        assert pushdown_sum._stat_func.pushdown == ("xorq",)
+        assert isinstance(pushdown_sum._stat_func.pushdown, tuple)
+
 
 class _MultiSizeStats(MultipleProvides):
     row_count: int


### PR DESCRIPTION
## Summary

Extends `@stat()` with a `pushdown=` parameter so individual stat functions
can declare which backends they support engine-side push-down on (e.g.
`("xorq", "polars")`). Stored as `StatFunc.pushdown: Tuple[str, ...]`,
default `()` (pandas-only / requires materialization).

Foundation for an upcoming protocol extension that will let lazy /
deferred backends compute summary stats by pushing the aggregation down
to the engine rather than materializing the frame. This PR is *just* the
metadata plumbing — no scheduler / consumer code yet.

## Changes

- New `pushdown: Tuple[str, ...]` field on `StatFunc` dataclass.
- New `pushdown=` kwarg on the `stat()` decorator. Tuple-normalised so a
  caller can pass a list without breaking hashability downstream.
- Docstring example for the new kwarg.

## Tests

- Failing-tests commit (one CI run with red): three tests pinning default
  empty pushdown, explicit pushdown round-trip, and list-to-tuple
  normalisation.
- Fix commit: the `stat_func.py` changes. All three tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)