### PR TITLE
fix(server): clamp infinite_request window — DoS guard (#797)

### DIFF
--- a/buckaroo/server/data_loading.py
+++ b/buckaroo/server/data_loading.py
@@ -84,11 +84,13 @@ def handle_infinite_request_buckaroo(
     dataflow: ServerDataflow, payload_args: dict
 ) -> tuple[dict, bytes]:
     """Infinite scroll handler using the dataflow's processed_df and merged_sd."""
-    start = payload_args["start"]
-    end = payload_args["end"]
+    from buckaroo.server.window import clamp_window
     _unused, processed_df, merged_sd = dataflow.widget_args_tuple
     if processed_df is None:
         return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0}, b"")
+    # Clamp window against the (post-filter) processed_df size — see #797.
+    start, end = clamp_window(
+        payload_args.get("start"), payload_args.get("end"), len(processed_df))
 
     try:
         sort = payload_args.get("sort")
@@ -164,8 +166,11 @@ def get_display_state_lazy(ldf: pl.LazyFrame) -> tuple[dict, dict, dict]:
 def handle_infinite_request_lazy(ldf: pl.LazyFrame, orig_to_rw: dict, rw_to_orig: dict, total_rows: int,
         payload_args: dict) -> tuple[dict, bytes]:
     """Serve an infinite-scroll slice from a Polars LazyFrame."""
-    start = int(payload_args.get("start", 0))
-    end = int(payload_args.get("end", 0))
+    from buckaroo.server.window import clamp_window
+    # Clamp window against total_rows so end >> total doesn't ship
+    # the entire LazyFrame in one parquet frame. See #797.
+    start, end = clamp_window(
+        payload_args.get("start", 0), payload_args.get("end", 0), total_rows)
 
     base = ldf.select(pl.all())
     sort_col = payload_args.get("sort")
@@ -273,8 +278,10 @@ def handle_infinite_request(df: pd.DataFrame, payload_args: dict) -> tuple[dict,
     (a, b, c, ...) since that's what the Parquet data uses. We need to
     map it back to the original column name for sorting.
     """
-    start = payload_args["start"]
-    end = payload_args["end"]
+    from buckaroo.server.window import clamp_window
+    # Clamp window against df length — see #797.
+    start, end = clamp_window(
+        payload_args.get("start"), payload_args.get("end"), len(df))
 
     sort = payload_args.get("sort")
     if sort:

--- a/buckaroo/server/window.py
+++ b/buckaroo/server/window.py
@@ -1,0 +1,56 @@
+"""Window clamping for ``infinite_request`` payloads.
+
+The WS protocol carries ``{start, end}`` row indices from AG-Grid's
+infinite-loading model. Without clamping, a malicious or buggy client
+can request ``{start: 0, end: 99_999_999}`` and the server happily
+materialises the entire underlying table into one parquet binary
+frame — on a million-row table that's tens of megabytes per call.
+See #797.
+
+``clamp_window`` keeps the request bounded to a single page-sized
+window (default 10 000 rows, matching AG-Grid's max practical page
+size) regardless of caller intent.
+
+The constant is module-level so tests can monkeypatch a lower bound
+without having to fabricate a million-row fixture.
+"""
+
+# Hard ceiling on rows returned in a single infinite_request. Tuned to
+# AG-Grid's default infinite-scroll buffer (a few thousand rows) with
+# generous headroom; well below the practical WS write-buffer limit.
+MAX_INFINITE_WINDOW: int = 10_000
+
+
+def clamp_window(start, end, total_rows: int) -> tuple[int, int]:
+    """Clamp an ``{start, end}`` window to a valid, bounded slice.
+
+    Returns a ``(start, end)`` pair such that:
+      - ``0 <= start <= end``
+      - ``end <= total_rows`` (never asks for past-end rows)
+      - ``end - start <= MAX_INFINITE_WINDOW`` (caps page size)
+      - non-integer / None inputs are coerced where possible, else
+        treated as 0 (the safest fallback)
+
+    Designed for the WS infinite_request payload, but is a pure
+    function with no buckaroo-side dependencies — drop in anywhere a
+    row-window needs sanitising.
+    """
+    try:
+        start = max(0, int(start))
+    except (TypeError, ValueError):
+        start = 0
+    try:
+        end = int(end)
+    except (TypeError, ValueError):
+        end = start
+    try:
+        total = int(total_rows)
+    except (TypeError, ValueError):
+        total = 0
+
+    end = min(end, total)
+    if end < start:
+        end = start
+    if end - start > MAX_INFINITE_WINDOW:
+        end = start + MAX_INFINITE_WINDOW
+    return start, end

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import traceback
 
+from buckaroo.server.window import clamp_window
 from buckaroo.xorq_buckaroo import (
     NoCleaningConfXorq, XorqAutocleaning, XorqDataflow, XorqDfStatsV2,
     XorqInfiniteSampling, _XORQ_ANALYSIS_KLASSES, _expr_count,
@@ -68,8 +69,6 @@ def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,
     ``window_to_parquet`` helper, and returns the
     ``(json_msg, parquet_bytes)`` pair the WebSocket handler ships as
     a text + binary frame pair (matching the pandas/polars paths)."""
-    start = int(payload_args["start"])
-    end = int(payload_args["end"])
     _unused, processed_df, merged_sd = xorq_dataflow.widget_args_tuple
     if processed_df is None:
         return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0}, b"")
@@ -83,6 +82,11 @@ def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,
             ascending = payload_args.get("sort_direction") == "asc"
 
         total_length = _expr_count(processed_df)
+        # Clamp the request window to a bounded slice — protects
+        # against ``end >> total_rows`` requests that would otherwise
+        # ship the entire table in a single WS frame. See #797.
+        start, end = clamp_window(
+            payload_args.get("start"), payload_args.get("end"), total_length)
         parquet_bytes = window_to_parquet(processed_df, start, end, sort_col, ascending)
         return ({"type": "infinite_resp", "key": payload_args, "data": [],
             "length": total_length}, parquet_bytes)

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -142,6 +142,57 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             shutil.rmtree(builds_root, ignore_errors=True)
 
     @tornado.testing.gen_test
+    async def test_ws_infinite_request_clamps_oversized_window(self):
+        """Regression for #797: a request with ``end >> total_rows``
+        must clamp to ``MAX_INFINITE_WINDOW``. Pre-fix the xorq path
+        returned the entire underlying table in one parquet frame —
+        92 MB on the boston dataset.
+
+        For test ergonomics ``MAX_INFINITE_WINDOW`` is lowered to 3
+        and the existing 10-row fixture exposes the clamp without
+        needing an 11k-row fixture.
+        """
+        from buckaroo.server import window as W
+        original_max = W.MAX_INFINITE_WINDOW
+        W.MAX_INFINITE_WINDOW = 3
+        builds_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": "lx-clamp", "build_dir": build_path})
+
+            ws = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/lx-clamp")
+            await ws.read_message()  # discard initial_state
+
+            ws.write_message(json.dumps({
+                "type": "infinite_request",
+                "payload_args": {"start": 0, "end": 99_999_999,
+                    "sourceName": "default", "origEnd": 99_999_999}}))
+
+            r = json.loads(await ws.read_message())
+            self.assertEqual(r["type"], "infinite_resp")
+            # `length` reports total table rows (unclamped) — that's
+            # the contract clients depend on for the virtual-scroll
+            # heuristic. Only the *window* must be clamped.
+            self.assertEqual(r["length"], 10)
+
+            binary_frame = await ws.read_message()
+            self.assertIsInstance(binary_frame, bytes)
+            table = pq.read_table(io.BytesIO(binary_frame))
+            # 10-row table, end=99_999_999, MAX_INFINITE_WINDOW=3
+            # → clamp(0, 99_999_999, 10) = (0, 10), then cap window
+            # to 3 → window of 3 rows.
+            self.assertEqual(table.num_rows, 3,
+                f"window must clamp to MAX_INFINITE_WINDOW=3; "
+                f"got {table.num_rows} (pre-fix: 10)")
+
+            ws.close()
+        finally:
+            W.MAX_INFINITE_WINDOW = original_max
+            shutil.rmtree(builds_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
     async def test_session_reuse_xorq_then_pandas(self):
         """A client that POSTs /load_expr and then POSTs /load with the
         same session id should see the pandas data on subsequent

--- a/tests/unit/server/test_window.py
+++ b/tests/unit/server/test_window.py
@@ -1,0 +1,73 @@
+"""Unit tests for ``buckaroo.server.window.clamp_window``.
+
+Pure function — fast, deterministic, doesn't need a server.
+"""
+import pytest
+
+from buckaroo.server import window as W
+
+
+@pytest.fixture(autouse=True)
+def reset_max_window():
+    """Restore MAX_INFINITE_WINDOW across tests that mutate it."""
+    saved = W.MAX_INFINITE_WINDOW
+    yield
+    W.MAX_INFINITE_WINDOW = saved
+
+
+class TestClampWindow:
+    def test_normal_window_unchanged(self):
+        assert W.clamp_window(0, 100, 1_000) == (0, 100)
+
+    def test_end_clamped_to_total(self):
+        """The DoS case from #797: end >> total returns the whole table.
+        Must clamp to total."""
+        assert W.clamp_window(0, 99_999_999, 500) == (0, 500)
+
+    def test_window_cap_kicks_in_when_total_is_large(self):
+        """For a million-row table the response must still be bounded."""
+        s, e = W.clamp_window(0, 99_999_999, 1_000_000)
+        assert e - s <= W.MAX_INFINITE_WINDOW
+
+    def test_window_cap_with_offset(self):
+        """Cap applies to (end - start), not just absolute end."""
+        s, e = W.clamp_window(50_000, 99_999_999, 1_000_000)
+        assert s == 50_000
+        assert e - s <= W.MAX_INFINITE_WINDOW
+
+    def test_negative_start_floored_to_zero(self):
+        assert W.clamp_window(-100, 50, 1_000) == (0, 50)
+
+    def test_end_less_than_start_returns_empty(self):
+        """Caller asked for a backwards window; return an empty slice
+        instead of crashing."""
+        s, e = W.clamp_window(100, 50, 1_000)
+        assert s == e  # empty
+
+    def test_zero_window(self):
+        assert W.clamp_window(0, 0, 1_000) == (0, 0)
+
+    def test_total_zero_returns_empty(self):
+        s, e = W.clamp_window(0, 100, 0)
+        assert s == 0
+        assert e == 0
+
+    def test_string_inputs_coerced(self):
+        """AG-Grid sometimes ships ``start`` / ``end`` as JSON strings."""
+        assert W.clamp_window("0", "10", 100) == (0, 10)
+
+    def test_none_inputs_safe_fallback(self):
+        s, e = W.clamp_window(None, None, 1_000)
+        assert s == 0
+        assert e == 0
+
+    def test_garbage_inputs_safe_fallback(self):
+        s, e = W.clamp_window("not_a_number", "abc", 100)
+        assert s == 0
+        assert e == 0
+
+    def test_monkeypatched_max_window(self):
+        """MAX_INFINITE_WINDOW is module-level so tests can lower it."""
+        W.MAX_INFINITE_WINDOW = 3
+        s, e = W.clamp_window(0, 100, 1_000)
+        assert e - s == 3


### PR DESCRIPTION
## Summary

Closes #797. The WS ``infinite_request`` handler didn't clamp ``end`` against ``total_rows``; a request with ``end >> total_rows`` happily returned the entire underlying table in one parquet binary frame. On the boston restaurant data (883K rows × 26 cols) this was a ~92 MB WS write per request — a trivial DoS vector and an easy off-by-one trap for clients.

This PR adds a tiny ``clamp_window`` helper, applies it to all four ``infinite_request`` entry points, and pins the contract with both a unit-test sweep and a WS-level integration test.

## Changes

- **New: ``buckaroo/server/window.py``** — pure ``clamp_window(start, end, total_rows)`` helper. Module-level ``MAX_INFINITE_WINDOW = 10_000`` (overridable for tests).
- **Wired into all four handlers**: ``handle_infinite_request`` (vanilla), ``handle_infinite_request_buckaroo`` (pandas dataflow), ``handle_infinite_request_lazy`` (polars), ``handle_infinite_request_xorq`` (ibis).
- **Tests**:
  - 12 unit tests on ``clamp_window`` covering normal/oversize/zero/negative/garbage inputs.
  - 1 WS integration test (``test_ws_infinite_request_clamps_oversized_window``) that lowers ``MAX_INFINITE_WINDOW`` to 3 and fires ``end=99_999_999`` against the 10-row xorq fixture — pre-fix returned 10 rows, post-fix returns 3.

## Commit split

- ``444c9d1e`` — failing test + helper (the integration tests fail on this commit; pure ``clamp_window`` unit tests pass since they only exercise the new helper).
- ``f2235a72`` — apply ``clamp_window`` in handlers. Failing test now passes.

## Why ``length`` is still unclamped

The ``infinite_resp.length`` field reports the *total* row count for the underlying expression / dataframe — AG-Grid's virtual-scroll uses this to size the scrollbar. Only the actual row *slice* shipped on the binary frame is clamped. Clients with sane ``end`` values see no behavior change.

## Test plan

- [x] ``tests/unit/server/test_window.py`` — 12 pure-function tests
- [x] ``tests/unit/server/test_load_expr.py::test_ws_infinite_request_clamps_oversized_window`` — end-to-end WS
- [x] Full Python suite: 977 passed, 1 skipped (the pre-existing flaky MCP test in editable-install worktrees)
- [x] Build: ``./scripts/full_build.sh`` clean
- [ ] CI green (pending push)

## Risk

Low. The clamp only constrains pathological inputs; clients with sensible ``end`` values are unaffected. The default ``MAX_INFINITE_WINDOW = 10_000`` is generous relative to AG-Grid's default infinite-scroll buffer (~100–1000 rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)