### PR TITLE
fix(server): gate xorq infinite_request error_info on BUCKAROO_DEBUG (#798)

### DIFF
--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -8,12 +8,20 @@ installed still imports cleanly.
 """
 from __future__ import annotations
 
+import logging
+import os
 import traceback
 
 from buckaroo.xorq_buckaroo import (
     NoCleaningConfXorq, XorqAutocleaning, XorqDataflow, XorqDfStatsV2,
     XorqInfiniteSampling, _XORQ_ANALYSIS_KLASSES, _expr_count,
     window_to_parquet)
+
+# Mirrors ``websocket_handler._BUCKAROO_DEBUG`` — when set, error_info
+# carries the full traceback for local debugging. Without it, clients see
+# a generic message so source paths and stack frames don't leak.
+_BUCKAROO_DEBUG = os.environ.get("BUCKAROO_DEBUG", "").lower() in ("1", "true")
+log = logging.getLogger("buckaroo.server.xorq_loading")
 
 
 class XorqServerDataflow(XorqDataflow):
@@ -87,5 +95,11 @@ def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,
         return ({"type": "infinite_resp", "key": payload_args, "data": [],
             "length": total_length}, parquet_bytes)
     except Exception:
+        tb = traceback.format_exc()
+        log.error("xorq infinite_request error: %s", tb)
+        # Mirrors the pandas-path gate in websocket_handler.py — clients
+        # in production runs see a generic message; only ``BUCKAROO_DEBUG``
+        # opens the source-leak channel.
         return ({"type": "infinite_resp", "key": payload_args, "data": [],
-            "length": 0, "error_info": traceback.format_exc()}, b"")
+            "length": 0,
+            "error_info": tb if _BUCKAROO_DEBUG else "Request failed"}, b"")

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -142,6 +142,46 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             shutil.rmtree(builds_root, ignore_errors=True)
 
     @tornado.testing.gen_test
+    async def test_xorq_infinite_request_error_info_no_traceback(self):
+        """Regression for #798: the xorq path put ``traceback.format_exc()``
+        into ``error_info`` unconditionally — leaking server-side source
+        paths to WS clients. Pandas path gates this behind
+        ``BUCKAROO_DEBUG``; xorq must too.
+
+        Trigger the exception with a sort column that doesn't exist in
+        ``merged_sd`` — raises ``KeyError`` inside
+        ``handle_infinite_request_xorq``.
+        """
+        builds_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": "lx-leak", "build_dir": build_path})
+
+            ws = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/lx-leak")
+            await ws.read_message()  # discard initial_state
+
+            ws.write_message(json.dumps({
+                "type": "infinite_request",
+                "payload_args": {"start": 0, "end": 5,
+                    "sort": "nonexistent_col", "sort_direction": "asc",
+                    "sourceName": "default", "origEnd": 5}}))
+
+            r = json.loads(await ws.read_message())
+            self.assertEqual(r["type"], "infinite_resp")
+            self.assertIn("error_info", r)
+            # The bug: pre-fix this carries a full traceback starting
+            # with "Traceback (most recent call last):\n  File ...".
+            # Production runs shouldn't leak source paths to clients.
+            self.assertFalse(r["error_info"].startswith("Traceback"),
+                f"error_info leaked traceback to client (first 200 chars): "
+                f"{r['error_info'][:200]!r}")
+            ws.close()
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
     async def test_session_reuse_xorq_then_pandas(self):
         """A client that POSTs /load_expr and then POSTs /load with the
         same session id should see the pandas data on subsequent


### PR DESCRIPTION
## Summary

Closes #798. ``handle_infinite_request_xorq`` was unconditionally returning ``traceback.format_exc()`` in the response's ``error_info`` field — leaking server-side source paths and stack frames to any WS client that hit an exception path. The pandas-path handler in ``websocket_handler.py:241-245`` already does the right thing (gate on ``BUCKAROO_DEBUG`` env, log server-side). This patch mirrors that pattern for xorq.

## Changes

- ``buckaroo/server/xorq_loading.py``: import ``_BUCKAROO_DEBUG`` from env, log the traceback at ERROR level, ship ``"Request failed"`` to clients unless debug is enabled.
- ``tests/unit/server/test_load_expr.py`` (failing-test commit): new ``test_xorq_infinite_request_error_info_no_traceback`` that triggers the exception path with an invalid sort column and asserts ``error_info`` does not start with ``"Traceback"``.

## Commit split

- ``1da4ee36`` — failing test (today the test fails because xorq leaks the traceback)
- ``e141d7a7`` — fix (gates on ``BUCKAROO_DEBUG``, logs server-side)

## Test plan

- [x] ``tests/unit/server/test_load_expr.py`` — all 5 tests pass (including the new one)
- [ ] CI green (pending push)

## Side benefit

Pre-fix the xorq handler didn't ``log.error`` the traceback at all — operators running non-debug deployments had no record of errors at all. This patch closes that gap (matches the pandas handler's logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)