### PR TITLE
fix(server): guard WS on_message against non-dict JSON + unknown types (#805)

### DIFF
--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -42,11 +42,27 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             self.write_message(json.dumps({"type": "error", "error_code": "invalid_json", "message": "Invalid JSON"}))
             return
 
+        # Reject non-object JSON (null, arrays, scalars) explicitly.
+        # Without this guard, ``msg.get(...)`` below raises ``AttributeError``
+        # on ``None`` etc., Tornado swallows it, and the WS closes
+        # permanently. See #805.
+        if not isinstance(msg, dict):
+            self.write_message(json.dumps({"type": "error",
+                "error_code": "invalid_message_shape",
+                "message": f"WS messages must be JSON objects; got {type(msg).__name__}"}))
+            return
+
         msg_type = msg.get("type")
         if msg_type == "infinite_request":
             self._handle_infinite_request(msg.get("payload_args", {}))
         elif msg_type == "buckaroo_state_change":
             self._handle_buckaroo_state_change(msg.get("new_state") or {})
+        else:
+            # Pre-#805 unknown / missing ``type`` was silently dropped —
+            # clients had no way to debug. Tell them what they sent.
+            self.write_message(json.dumps({"type": "error",
+                "error_code": "unknown_message_type",
+                "message": f"Unknown WS message type: {msg_type!r}"}))
 
     def _handle_buckaroo_state_change(self, new_state):
         sessions = self.application.settings["sessions"]

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -142,6 +142,54 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             shutil.rmtree(builds_root, ignore_errors=True)
 
     @tornado.testing.gen_test
+    async def test_ws_message_robustness(self):
+        """Regression for #805: ``on_message`` did ``msg.get(...)`` on
+        whatever ``json.loads`` returned, which is unsafe when the JSON
+        is not an object (``null``, bare arrays, scalars). ``null`` in
+        particular killed the WS — ``None.get`` raises ``AttributeError``,
+        Tornado swallows it, the stream closes.
+
+        Adjacent: unknown message types (``{"type": 42}``, missing
+        ``type``, empty ``{}``) were silently dropped. Clients couldn't
+        debug because no response came.
+
+        This test sends each malformed shape and asserts the server
+        returns a structured error frame, NOT a silent drop or a
+        crashed WS.
+        """
+        import asyncio
+        await _post(self.get_http_port(), "/load",
+            {"session": "ws-guard",
+             "path": "/tmp/restaurant-complaints-pandas.parquet",
+             "mode": "buckaroo", "no_browser": True})
+        ws = await tornado.websocket.websocket_connect(
+            f"ws://localhost:{self.get_http_port()}/ws/ws-guard")
+        await ws.read_message()  # discard initial_state
+
+        # Each entry: (label, raw_ws_message). Server must respond
+        # to each with a structured error frame within 2s.
+        cases = [
+            ("bare_null", "null"),
+            ("bare_array", "[1,2,3]"),
+            ("bare_scalar", "42"),
+            ("empty_object", "{}"),
+            ("missing_type", json.dumps({"payload": "x"})),
+            ("type_as_int", json.dumps({"type": 42, "payload": "x"})),
+            ("unknown_type",
+                json.dumps({"type": "buckaroo_invented_command"})),
+        ]
+        for label, raw in cases:
+            ws.write_message(raw)
+            frame = await asyncio.wait_for(ws.read_message(), timeout=3.0)
+            self.assertIsNotNone(frame, f"{label}: no response (silent drop)")
+            d = json.loads(frame)
+            self.assertEqual(d.get("type"), "error",
+                f"{label}: expected error frame, got {d.get('type')!r}")
+            self.assertIn("error_code", d,
+                f"{label}: error frame missing error_code")
+        ws.close()
+
+    @tornado.testing.gen_test
     async def test_session_reuse_xorq_then_pandas(self):
         """A client that POSTs /load_expr and then POSTs /load with the
         same session id should see the pandas data on subsequent

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -1,5 +1,6 @@
 """End-to-end tests for POST /load_expr — server load path for
 XorqBuckarooInfiniteWidget over a xorq/ibis expression."""
+import asyncio
 import io
 import json
 import os
@@ -155,19 +156,19 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
 
         This test sends each malformed shape and asserts the server
         returns a structured error frame, NOT a silent drop or a
-        crashed WS.
+        crashed WS. After the barrage, a well-formed infinite_request
+        confirms the WS is still alive — the headline pre-fix bug was
+        that ``null`` permanently killed the stream.
+
+        No ``/load`` setup: the guards run before any session lookup,
+        so the test works against an empty session and is portable
+        across machines.
         """
-        import asyncio
-        await _post(self.get_http_port(), "/load",
-            {"session": "ws-guard",
-             "path": "/tmp/restaurant-complaints-pandas.parquet",
-             "mode": "buckaroo", "no_browser": True})
         ws = await tornado.websocket.websocket_connect(
             f"ws://localhost:{self.get_http_port()}/ws/ws-guard")
-        await ws.read_message()  # discard initial_state
 
         # Each entry: (label, raw_ws_message). Server must respond
-        # to each with a structured error frame within 2s.
+        # to each with a structured error frame within 3s.
         cases = [
             ("bare_null", "null"),
             ("bare_array", "[1,2,3]"),
@@ -187,6 +188,19 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
                 f"{label}: expected error frame, got {d.get('type')!r}")
             self.assertIn("error_code", d,
                 f"{label}: error frame missing error_code")
+
+        # Liveness: WS survived the malformed barrage. Send a well-formed
+        # request and confirm we still get a response. With no session
+        # data loaded, _handle_infinite_request returns an infinite_resp
+        # with empty data — what matters is that *any* frame arrives.
+        ws.write_message(json.dumps({
+            "type": "infinite_request",
+            "payload_args": {"start": 0, "end": 10,
+                "sourceName": "default", "origEnd": 10}}))
+        frame = await asyncio.wait_for(ws.read_message(), timeout=3.0)
+        self.assertIsNotNone(frame, "WS died after malformed barrage")
+        d = json.loads(frame)
+        self.assertEqual(d.get("type"), "infinite_resp")
         ws.close()
 
     @tornado.testing.gen_test


### PR DESCRIPTION
## Summary

Closes #805. The WS ``on_message`` handler called ``msg.get(...)`` on the parsed JSON without checking ``msg`` was actually a dict. Three issues:

1. ``null``, bare arrays, scalars crashed: ``None.get`` / ``list.get`` raise ``AttributeError``. Tornado swallows the exception and closes the stream — the WS is permanently dead. **Hostile DoS**: any client can kill its own WS session by sending one literal ``null``.
2. Unknown ``type`` values (e.g. ``{"type": 42}``, ``{"type": "unknown_command"}``) were silently dropped — no error frame, no log, clients had no way to know their messages were ignored.
3. Empty objects (``{}``) and dicts missing ``type`` were also silently dropped — same diagnosability problem.

This PR adds two guards at the top of ``on_message``: one for non-dict JSON, one for unknown ``type``. Each returns a structured ``{"type": "error", "error_code": ...}`` frame.

## Stress-test findings (smorg/post-785-playground WS fuzz)

| input | pre-fix | post-fix |
|---|---|---|
| ``"not json"`` | ✓ ``{"error_code": "invalid_json"}`` | unchanged |
| ``null`` | **💥 WS killed permanently** | ✓ ``{"error_code": "invalid_message_shape"}`` |
| ``[1,2,3]`` | ⚠ AttributeError, sometimes survives | ✓ ``{"error_code": "invalid_message_shape"}`` |
| ``42`` | crash | ✓ ``{"error_code": "invalid_message_shape"}`` |
| ``{}`` | ⏱ silently dropped | ✓ ``{"error_code": "unknown_message_type"}`` |
| ``{"type": 42}`` | ⏱ silently dropped | ✓ ``{"error_code": "unknown_message_type"}`` |
| ``{"payload": "x"}`` | ⏱ silently dropped | ✓ ``{"error_code": "unknown_message_type"}`` |
| ``{"type": "future_command"}`` | ⏱ silently dropped | ✓ ``{"error_code": "unknown_message_type"}`` |

## Commits

- ``18140b39`` — failing test in ``test_load_expr.py::test_ws_message_robustness``. Sends 7 malformed shapes, asserts each gets a structured error frame.
- ``228fdbf9`` — fix. Test passes.

## Risk

Low. The added guards only affect inputs that today are crashes or silent drops — no well-formed client behavior changes.

## Test plan

- [x] ``test_ws_message_robustness`` — new
- [x] All other ``test_load_expr.py`` tests pass (5/5)
- [ ] CI green (pending push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)