### PR TITLE
feat(paf): @stat(cost=...) decorator + tag known-expensive stats

### DIFF
--- a/buckaroo/customizations/pd_stats_v2.py
+++ b/buckaroo/customizations/pd_stats_v2.py
@@ -176,7 +176,7 @@ def computed_default_summary_stats(length: int, value_counts: pd.Series, null_co
 HistogramSeriesResult = TypedDict('HistogramSeriesResult', {'histogram_args': dict, 'histogram_bins': list})
 
 
-@stat()
+@stat(cost="aggregate")
 def histogram_series(ser: RawSeries) -> HistogramSeriesResult:
     """Compute histogram args from raw series (numeric path)."""
     if not pd.api.types.is_numeric_dtype(ser):
@@ -210,7 +210,7 @@ def histogram_series(ser: RawSeries) -> HistogramSeriesResult:
     }
 
 
-@stat()
+@stat(cost="aggregate")
 def histogram(value_counts: pd.Series, nan_per: float, is_numeric: bool, length: int, min: Any, max: Any,
         histogram_args: dict) -> list:
     """Compute histogram from summary stats and histogram args."""

--- a/buckaroo/customizations/pl_stats_v2.py
+++ b/buckaroo/customizations/pl_stats_v2.py
@@ -113,7 +113,7 @@ def pl_numeric_stats(ser: RawSeries) -> NumericStatsResult:
 # Histogram Series (polars series API)
 # ============================================================
 
-@stat()
+@stat(cost="aggregate")
 def pl_histogram_series(ser: RawSeries) -> HistogramSeriesResult:
     """Compute histogram args from raw polars series (numeric path)."""
     if not ser.dtype.is_numeric():

--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -255,7 +255,7 @@ def _categorical_histogram(execute: Callable[[Any], pd.DataFrame], expr: Any, co
     return out
 
 
-@stat(default=[])
+@stat(default=[], cost="aggregate")
 def histogram(expr: XorqExpr, execute: XorqExecute, orig_col_name: str, is_numeric: bool, is_bool: bool, length: int,
         distinct_count: int, min: float, max: float) -> list:
     """10-bucket numeric histogram or top-10 categorical histogram.

--- a/buckaroo/pluggable_analysis_framework/stat_func.py
+++ b/buckaroo/pluggable_analysis_framework/stat_func.py
@@ -132,6 +132,9 @@ class StatKey:
 # StatFunc — a registered stat computation
 # ---------------------------------------------------------------------------
 
+VALID_COSTS = ("scalar", "aggregate")
+
+
 @dataclass
 class StatFunc:
     """A registered stat computation.
@@ -145,6 +148,11 @@ class StatFunc:
         column_filter: optional predicate on column dtype
         quiet: suppress error reporting
         default: fallback value on failure (MISSING = no fallback)
+        cost: cost class — ``"scalar"`` (cheap, ships in the initial
+            state_change response) or ``"aggregate"`` (slow path that the
+            JS orchestrator fetches via a separate round-trip after a
+            debounce). Histograms, value_counts and other per-column
+            queries belong in ``"aggregate"``.
     """
     name: str
     func: Callable
@@ -154,6 +162,7 @@ class StatFunc:
     column_filter: Optional[Callable] = None
     quiet: bool = False
     default: Any = field(default_factory=lambda: MISSING)
+    cost: str = "scalar"
     spread_dict_result: bool = False  # v1 compat: spread all dict keys into accumulator
     v1_computed: bool = False  # v1 compat: pass full accumulator as single dict arg
 
@@ -250,7 +259,7 @@ def _get_requires_from_params(sig: inspect.Signature, hints: dict) -> tuple:
 # @stat decorator
 # ---------------------------------------------------------------------------
 
-def stat(column_filter=None, quiet=False, default=MISSING):
+def stat(column_filter=None, quiet=False, default=MISSING, cost="scalar"):
     """Decorator that converts a function into a StatFunc.
 
     The function signature IS the contract:
@@ -262,6 +271,12 @@ def stat(column_filter=None, quiet=False, default=MISSING):
     Single-provider stats: name the function the same as the accumulator
     key the rest of the DAG expects. Use ``MultipleProvides`` (a TypedDict
     alias) when one function should write several keys.
+
+    ``cost=`` declares the compute-cost class. ``"scalar"`` (default)
+    means cheap — ships in the initial state_change response. ``"aggregate"``
+    means slow (histograms, value_counts, per-column queries) — the JS
+    orchestrator fetches these via a separate round-trip after a debounce.
+    See plans/js-driven-stat-debounce.md.
 
     Usage::
 
@@ -277,6 +292,10 @@ def stat(column_filter=None, quiet=False, default=MISSING):
         def safe_ratio(a: int, b: int) -> float:
             return a / b
 
+        @stat(cost="aggregate")
+        def histogram(...) -> list:
+            ...
+
         class TypingResult(MultipleProvides):
             is_numeric: bool
             is_integer: bool
@@ -285,6 +304,10 @@ def stat(column_filter=None, quiet=False, default=MISSING):
         def typing_stats(dtype: str) -> TypingResult:
             ...
     """
+    if cost not in VALID_COSTS:
+        raise ValueError(
+            f"@stat(cost={cost!r}): invalid cost class. "
+            f"Must be one of {VALID_COSTS}.")
     def decorator(func):
         sig = inspect.signature(func)
         try:
@@ -298,7 +321,8 @@ def stat(column_filter=None, quiet=False, default=MISSING):
         provides_keys = _get_provides_from_return_type(func.__name__, return_type)
 
         stat_func = StatFunc(name=func.__name__, func=func, requires=requires, provides=provides_keys,
-            needs_raw=needs_raw, column_filter=column_filter, quiet=quiet, default=default)
+            needs_raw=needs_raw, column_filter=column_filter, quiet=quiet, default=default,
+            cost=cost)
 
         # Attach metadata to the function so pipeline can find it
         func._stat_func = stat_func

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -200,6 +200,25 @@ class TestStatDecorator:
             def bad(ser: RawSeries) -> float:
                 return float(ser.mean())
 
+    def test_known_expensive_stats_marked_aggregate(self):
+        """The expensive built-in stat funcs (histogram producers across
+        all three engines) are tagged ``cost="aggregate"`` so a
+        downstream router can schedule them on the slow path."""
+        from buckaroo.customizations.pd_stats_v2 import histogram as pd_histogram
+        from buckaroo.customizations.pd_stats_v2 import histogram_series as pd_hs
+        from buckaroo.customizations.pl_stats_v2 import pl_histogram_series
+
+        assert pd_histogram._stat_func.cost == "aggregate"
+        assert pd_hs._stat_func.cost == "aggregate"
+        assert pl_histogram_series._stat_func.cost == "aggregate"
+
+        # xorq histogram (optional dep — skip if not installed)
+        try:
+            from buckaroo.customizations.xorq_stats_v2 import histogram as xq_histogram
+        except ImportError:
+            return
+        assert xq_histogram._stat_func.cost == "aggregate"
+
 
 class _MultiSizeStats(MultipleProvides):
     row_count: int

--- a/tests/unit/test_paf_v2.py
+++ b/tests/unit/test_paf_v2.py
@@ -176,6 +176,30 @@ class TestStatDecorator:
         sf = distinct_per._stat_func
         assert sf.default is MISSING
 
+    def test_stat_default_cost_is_scalar(self):
+        # Default cost class is "scalar" — the bulk of stats are cheap.
+        # Only known-expensive ones opt in to "aggregate".
+        sf = length._stat_func
+        assert sf.cost == "scalar"
+
+    def test_stat_explicit_cost_aggregate(self):
+        @stat(cost="aggregate")
+        def big_compute(ser: RawSeries) -> float:
+            return float(ser.mean())
+
+        assert big_compute._stat_func.cost == "aggregate"
+
+    def test_stat_invalid_cost_rejected(self):
+        # Only "scalar" and "aggregate" are recognised. A typo should
+        # fail loud at decoration time — silently dropping an invalid
+        # cost would leak into the cost-class router as an unscheduled
+        # stat group.
+        import pytest as _pt
+        with _pt.raises(ValueError, match="cost"):
+            @stat(cost="bigly")
+            def bad(ser: RawSeries) -> float:
+                return float(ser.mean())
+
 
 class _MultiSizeStats(MultipleProvides):
     row_count: int


### PR DESCRIPTION
## Summary

Phase 1 of [the JS-driven progressive stats design](https://github.com/buckaroo-data/buckaroo/blob/plans/js-driven-stat-debounce/plans/js-driven-stat-debounce.md) — the metadata field only. Adds a ``cost: str`` field to ``StatFunc`` declaring the compute-cost class of a stat. ``"scalar"`` (default) means cheap — ships in the initial state response. ``"aggregate"`` is the opt-in for slow stats that a future JS-driven router will fetch via a separate WS round-trip after a debounce.

This PR ships the metadata only — no consumer yet. That's a separate PR (Phase 2). Shipping the field independently means the tags don't have to be batched with downstream changes; consumers can adopt incrementally.

## Changes

- ``StatFunc.cost: str`` — default ``"scalar"``. Validated against ``VALID_COSTS = ("scalar", "aggregate")`` at decoration time.
- ``@stat(cost=...)`` decorator kwarg. Bad values (e.g. ``cost="bigly"``) raise ``ValueError`` loudly rather than silently bypassing a router downstream.
- Tag the four built-in histogram stats as ``cost="aggregate"``:
  - ``buckaroo.customizations.pd_stats_v2.histogram``
  - ``buckaroo.customizations.pd_stats_v2.histogram_series``
  - ``buckaroo.customizations.pl_stats_v2.pl_histogram_series``
  - ``buckaroo.customizations.xorq_stats_v2.histogram``

These are the known per-column-querying expensive funcs — ~250 ms × 26 cols on the boston restaurant dataset via xorq datafusion, ~6.5 s total. Tagging them now is harmless until a router consumes the field.

## Why these specific stats

Profile of one state_change on boston (xorq backend, 883K rows × 26 cols, instrumented):

```
xorq.process_table phase 2 (per-column queries) — 6.5 s
└─ histogram queries (one per column) dominate
batch_execute (scalars + value_counts)         — 360 ms
```

The histogram producers are the only stats that re-query the backend per column. Everything else (length, min, max, mean, std, distinct_count, top-K) is computed in the scalar batch. So the cost-class line is clear: histograms are aggregate, the rest are scalar.

``value_counts`` itself is a borderline case — on polars/pandas it's relatively fast (~10-20 ms on 883K-row strings); on xorq it's part of the scalar batch already. Leaving it as scalar for now; a future PR can split it if needed.

## Commit split

- ``84d802d3`` — failing tests (3 new in ``TestStatDecorator``: default cost, explicit aggregate, invalid cost rejection).
- ``898414f7`` — implementation + tags + one more test (``test_known_expensive_stats_marked_aggregate``) pinning the four tagged stats.

## Test plan

- [x] ``TestStatDecorator`` — 10/10 pass (3 new for cost + 1 new for tags + 6 existing)
- [x] Full Python suite: 968 passed, 1 skipped (the pre-existing flaky MCP test in editable-install worktrees)
- [x] No downstream consumer yet → no behavior change. Existing pipelines run unchanged.
- [ ] CI green (pending push)

## Risk

Zero behavior change. The ``cost`` field is read by nobody yet. The decorator's validation only affects new ``@stat(cost=...)`` callers, of which there are 4 (all under buckaroo/customizations/).

## Next

- Phase 2: split ``process_table`` into ``process_table_scalars`` / ``_aggregates`` keyed off the new field. New WS message types.
- Phase 3: ``BuckarooStateOrchestrator`` JS class with the 2× adaptive debounce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)