### PR TITLE
feat(server): configurable demo datasets via --dataset CLI (#811)

### DIFF
--- a/buckaroo/server/__main__.py
+++ b/buckaroo/server/__main__.py
@@ -13,8 +13,55 @@ from buckaroo.server.app import make_app
 LOG_DIR = os.path.join(os.path.expanduser("~"), ".buckaroo", "logs")
 os.makedirs(LOG_DIR, exist_ok=True)
 
+_VALID_DATASET_KINDS = ("pandas", "lazy", "xorq")
 
-def bind_and_make_app(port: int, open_browser: bool):
+
+def parse_dataset_spec(spec: str) -> dict:
+    """Parse a single ``--dataset NAME=KIND:PATH`` spec into a
+    ``{"label", "kind", "target"}`` dict.
+
+    ``KIND`` is one of ``pandas`` / ``lazy`` / ``xorq``. For pandas and
+    lazy, ``PATH`` is a data file (.csv/.parquet/...); for xorq it's a
+    build dir produced by ``xorq build``. Raises ``ValueError`` for
+    malformed specs and unknown kinds — argparse surfaces these as
+    user-facing CLI errors via ``argparse.ArgumentTypeError`` (see
+    ``_argparse_dataset`` below).
+
+    See issue #811 — replaces the hard-coded demo paths previously baked
+    into ``SESSION_HTML``."""
+    if "=" not in spec:
+        raise ValueError(
+            f"--dataset spec missing '=': expected NAME=KIND:PATH, got {spec!r}")
+    label, kind_and_target = spec.split("=", 1)
+    label = label.strip()
+    if not label:
+        raise ValueError(f"--dataset spec has empty NAME: {spec!r}")
+    if ":" not in kind_and_target:
+        raise ValueError(
+            f"--dataset spec missing ':' after KIND: expected NAME=KIND:PATH, got {spec!r}")
+    kind, target = kind_and_target.split(":", 1)
+    kind = kind.strip()
+    target = target.strip()
+    if kind not in _VALID_DATASET_KINDS:
+        raise ValueError(
+            f"--dataset spec has unknown kind {kind!r}: expected one of "
+            f"{_VALID_DATASET_KINDS}, got {spec!r}")
+    if not target:
+        raise ValueError(f"--dataset spec has empty PATH: {spec!r}")
+    return {"label": label, "kind": kind, "target": target}
+
+
+def _argparse_dataset(spec: str) -> dict:
+    """argparse adapter: convert ``ValueError`` from ``parse_dataset_spec``
+    into ``argparse.ArgumentTypeError`` so argparse can format a nice
+    ``usage:`` error and exit nonzero."""
+    try:
+        return parse_dataset_spec(spec)
+    except ValueError as e:
+        raise argparse.ArgumentTypeError(str(e)) from e
+
+
+def bind_and_make_app(port: int, open_browser: bool, datasets: list | None = None):
     """Bind the listening socket, then build the Application with the *bound*
     port stamped into ``settings``.
 
@@ -28,7 +75,7 @@ def bind_and_make_app(port: int, open_browser: bool):
     """
     sockets = tornado.netutil.bind_sockets(port, address="127.0.0.1")
     bound_port = sockets[0].getsockname()[1]
-    app = make_app(port=bound_port, open_browser=open_browser)
+    app = make_app(port=bound_port, open_browser=open_browser, datasets=datasets)
     return sockets, bound_port, app
 
 
@@ -40,6 +87,13 @@ def main():
         help="Exit when stdin closes. Used by parent supervisors (Tauri) to "
         "guarantee the sidecar dies when the parent does — closing stdin is "
         "more reliable than process-tree teardown across platforms.")
+    parser.add_argument("--dataset", type=_argparse_dataset, action="append", default=[],
+        metavar="NAME=KIND:PATH", dest="datasets",
+        help="Register a dataset for the /s/<id> demo dropdown. Repeatable. "
+        "KIND is one of pandas / lazy / xorq. PATH is a data file (pandas/lazy) "
+        "or a build dir (xorq). Examples: "
+        "--dataset boston-pandas=pandas:/data/boston.parquet "
+        "--dataset boston-xorq=xorq:/builds/boston-xorq")
     args = parser.parse_args()
 
     # Line-buffer stdout so the BUCKAROO_PORT handshake reaches a parent supervisor
@@ -70,7 +124,8 @@ def main():
     log = logging.getLogger("buckaroo.server")
     log.info("Server starting — port=%d open_browser=%s pid=%d", args.port, not args.no_browser, os.getpid())
 
-    sockets, bound_port, app = bind_and_make_app(port=args.port, open_browser=not args.no_browser)
+    sockets, bound_port, app = bind_and_make_app(port=args.port,
+        open_browser=not args.no_browser, datasets=args.datasets)
     server = tornado.httpserver.HTTPServer(app)
     server.add_sockets(sockets)
 

--- a/buckaroo/server/app.py
+++ b/buckaroo/server/app.py
@@ -10,7 +10,16 @@ from buckaroo.server.session import SessionManager
 SERVER_START_TIME = time.time()
 
 
-def make_app(sessions: SessionManager | None = None, port: int = 8888, open_browser: bool = True) -> tornado.web.Application:
+def make_app(sessions: SessionManager | None = None, port: int = 8888, open_browser: bool = True,
+        datasets: list | None = None) -> tornado.web.Application:
+    """Build the tornado app.
+
+    ``datasets`` is the operator-supplied list of dropdown entries the
+    demo page (/s/<id>) exposes — each a ``{"label", "kind", "target"}``
+    dict, with ``kind`` in ``("pandas", "lazy", "xorq")``. ``None`` /
+    ``[]`` means no datasets configured: the page omits the dropdown
+    entirely rather than shipping the author's filesystem layout. See
+    issue #811."""
     if sessions is None:
         sessions = SessionManager()
 
@@ -24,4 +33,6 @@ def make_app(sessions: SessionManager | None = None, port: int = 8888, open_brow
             (r"/load_compare", LoadCompareHandler),
             (r"/s/([^/]+)", SessionPageHandler),
             (r"/ws/([^/]+)", DataStreamHandler),
-        ], sessions=sessions, port=port, open_browser=open_browser, static_path=os.path.abspath(static_path), server_start_time=SERVER_START_TIME)
+        ], sessions=sessions, port=port, open_browser=open_browser,
+        static_path=os.path.abspath(static_path),
+        server_start_time=SERVER_START_TIME, datasets=datasets or [])

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -583,8 +583,13 @@ def _render_engine_bar(datasets: list) -> tuple:
 
     See issue #811: the previous design hard-coded
     ``/tmp/restaurant-complaints-pandas.parquet`` etc. inline; now the
-    operator supplies them via ``--dataset NAME=KIND:PATH``."""
-    datasets_json = json.dumps(datasets or [])
+    operator supplies them via ``--dataset NAME=KIND:PATH``.
+
+    Uses ``tornado.escape.json_encode`` (not ``json.dumps``) because the
+    output is embedded inline in a ``<script>`` block: a target string
+    containing ``</script>`` would otherwise break out of the tag.
+    ``json_encode`` replaces ``</`` with ``<\\/``."""
+    datasets_json = tornado.escape.json_encode(datasets or [])
     if not datasets:
         return "", datasets_json
     options = ["<option value=\"\">— switch dataset —</option>"]
@@ -677,8 +682,6 @@ SESSION_HTML = """\
     // survive. The dropdown element is only emitted when at least one
     // operator dataset is registered — see issue #811.
     (function () {
-        const sel = document.getElementById("engine-select");
-        const statusEl = document.getElementById("engine-status");
         const SESSION_ID = "__SESSION_ID__";
         const DATASETS = JSON.parse(
             document.getElementById("buckaroo-datasets").textContent || "[]");
@@ -688,44 +691,37 @@ SESSION_HTML = """\
         if (qs.get("pl")) qsOverrides.push({label: "(from URL) lazy", kind: "lazy", target: qs.get("pl")});
         if (qs.get("xq")) qsOverrides.push({label: "(from URL) xorq", kind: "xorq", target: qs.get("xq")});
         const ENTRIES = DATASETS.concat(qsOverrides);
+        if (ENTRIES.length === 0) return;
+
+        // Find or inject the bar. The server emits it whenever it has
+        // operator-supplied datasets; we inject it when only QS overrides
+        // exist. Either way the rest of this function works against the
+        // same select element.
+        let sel = document.getElementById("engine-select");
         if (!sel) {
-            // No dropdown rendered (no datasets configured and no QS overrides).
-            // If only QS overrides are present, we still want them reachable —
-            // but the server didn't emit the bar. Inject a minimal bar now.
-            if (qsOverrides.length > 0) {
-                const bar = document.createElement("div");
-                bar.id = "engine-bar";
-                bar.style.cssText = "padding: 4px 10px; font-family: sans-serif; font-size: 12px; color: #ccc; background: #1f1f24; border-bottom: 1px solid #333; flex-shrink: 0;";
-                bar.innerHTML = 'Dataset: <select id="engine-select" style="background: #2a2a30; color: #ddd; border: 1px solid #444; padding: 2px 6px; margin-left: 6px;"><option value="">— switch dataset —</option></select><span id="engine-status" style="margin-left: 12px; color: #888;"></span>';
-                document.body.insertBefore(bar, document.getElementById("root"));
-            } else {
-                return;
-            }
+            const bar = document.createElement("div");
+            bar.id = "engine-bar";
+            bar.style.cssText = "padding: 4px 10px; font-family: sans-serif; font-size: 12px; color: #ccc; background: #1f1f24; border-bottom: 1px solid #333; flex-shrink: 0;";
+            bar.innerHTML = 'Dataset: <select id="engine-select" style="background: #2a2a30; color: #ddd; border: 1px solid #444; padding: 2px 6px; margin-left: 6px;"></select><span id="engine-status" style="margin-left: 12px; color: #888;"></span>';
+            document.body.insertBefore(bar, document.getElementById("root"));
+            sel = document.getElementById("engine-select");
         }
-        const selNow = document.getElementById("engine-select");
-        const statusNow = document.getElementById("engine-status");
-        // Re-render options if we inserted the bar above, or append QS extras
-        // to a server-rendered list.
-        if (sel === null) {
-            ENTRIES.forEach((ds, i) => {
-                const opt = document.createElement("option");
-                opt.value = String(i);
-                opt.dataset.kind = ds.kind;
-                opt.dataset.target = ds.target;
-                opt.textContent = `${ds.label} (${ds.kind})`;
-                selNow.appendChild(opt);
-            });
-        } else {
-            qsOverrides.forEach((ds, i) => {
-                const opt = document.createElement("option");
-                opt.value = String(DATASETS.length + i);
-                opt.dataset.kind = ds.kind;
-                opt.dataset.target = ds.target;
-                opt.textContent = `${ds.label} (${ds.kind})`;
-                selNow.appendChild(opt);
-            });
-        }
-        selNow.addEventListener("change", async (e) => {
+        const statusEl = document.getElementById("engine-status");
+
+        // Rebuild options from ENTRIES so the DOM and our index space stay
+        // in lockstep — regardless of whether the server pre-rendered the
+        // operator datasets or we just injected an empty select.
+        sel.innerHTML = '<option value="">— switch dataset —</option>';
+        ENTRIES.forEach((ds, i) => {
+            const opt = document.createElement("option");
+            opt.value = String(i);
+            opt.dataset.kind = ds.kind;
+            opt.dataset.target = ds.target;
+            opt.textContent = `${ds.label} (${ds.kind})`;
+            sel.appendChild(opt);
+        });
+
+        sel.addEventListener("change", async (e) => {
             const idx = e.target.value;
             if (idx === "") return;
             const ds = ENTRIES[parseInt(idx, 10)];
@@ -739,7 +735,7 @@ SESSION_HTML = """\
                 body.mode = ds.kind === "lazy" ? "lazy" : "buckaroo";
             }
             const t0 = performance.now();
-            statusNow.textContent = `loading ${ds.label}…`;
+            statusEl.textContent = `loading ${ds.label}…`;
             try {
                 const r = await fetch(url, {method: "POST",
                     headers: {"Content-Type": "application/json"},
@@ -747,17 +743,17 @@ SESSION_HTML = """\
                 const dt = Math.round(performance.now() - t0);
                 if (r.ok) {
                     const d = await r.json();
-                    statusNow.textContent = `${ds.label} loaded (${d.rows ?? "?"} rows, ${dt} ms) — reloading…`;
+                    statusEl.textContent = `${ds.label} loaded (${d.rows ?? "?"} rows, ${dt} ms) — reloading…`;
                     // The widget reads its initial state on WS open. Reload
                     // forces a clean reconnection rather than reasoning
                     // about deep widget-level swap.
                     setTimeout(() => window.location.reload(), 600);
                 } else {
                     const err = await r.text();
-                    statusNow.textContent = `${ds.label} failed (${r.status}): ${err.slice(0, 200)}`;
+                    statusEl.textContent = `${ds.label} failed (${r.status}): ${err.slice(0, 200)}`;
                 }
             } catch (ex) {
-                statusNow.textContent = `${ds.label} error: ${ex.message}`;
+                statusEl.textContent = `${ds.label} error: ${ex.message}`;
             }
         });
     })();

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -7,6 +7,7 @@ import time
 import traceback
 import uuid
 
+import tornado.escape
 import tornado.web
 
 from buckaroo.server.data_loading import (load_file, get_metadata, get_display_state, create_dataflow, get_buckaroo_display_state, load_file_lazy, get_metadata_lazy, get_display_state_lazy)
@@ -569,13 +570,57 @@ class LoadCompareHandler(tornado.web.RequestHandler):
             "rows": len(merged_df), "columns": [str(c) for c in merged_df.columns], "eqs": eqs})
 
 
+def _render_engine_bar(datasets: list) -> tuple:
+    """Render the engine-dropdown HTML + JS-side dataset config for the
+    demo session page.
+
+    Returns ``(bar_html, datasets_json)``. ``bar_html`` is the inline
+    ``<div id="engine-bar">…</div>`` block, or the empty string when no
+    datasets are configured (so a vanilla server doesn't ship a dead
+    UI). ``datasets_json`` is the JSON-encoded list the inline ``<script>``
+    consumes — kept on a separate substitution so it stays alongside the
+    options it drives even when ``bar_html`` is empty.
+
+    See issue #811: the previous design hard-coded
+    ``/tmp/restaurant-complaints-pandas.parquet`` etc. inline; now the
+    operator supplies them via ``--dataset NAME=KIND:PATH``."""
+    datasets_json = json.dumps(datasets or [])
+    if not datasets:
+        return "", datasets_json
+    options = ["<option value=\"\">— switch dataset —</option>"]
+    for idx, ds in enumerate(datasets):
+        label = tornado.escape.xhtml_escape(ds["label"])
+        kind = tornado.escape.xhtml_escape(ds["kind"])
+        target = tornado.escape.xhtml_escape(ds["target"])
+        options.append(
+            f"<option value=\"{idx}\" data-kind=\"{kind}\" data-target=\"{target}\">"
+            f"{label} ({kind})</option>")
+    bar = (
+        "<div id=\"engine-bar\" style=\"padding: 4px 10px; font-family: sans-serif; "
+        "font-size: 12px; color: #ccc; background: #1f1f24; "
+        "border-bottom: 1px solid #333; flex-shrink: 0;\">"
+        "Dataset: "
+        "<select id=\"engine-select\" style=\"background: #2a2a30; color: #ddd; "
+        "border: 1px solid #444; padding: 2px 6px; margin-left: 6px;\">"
+        + "".join(options) + "</select>"
+        "<span id=\"engine-status\" style=\"margin-left: 12px; color: #888;\"></span>"
+        "</div>")
+    return bar, datasets_json
+
+
 class SessionPageHandler(tornado.web.RequestHandler):
     def get(self, session_id):
         self.set_header("Content-Type", "text/html")
         self.set_header("Cache-Control", "no-cache")
         import buckaroo
         ver = getattr(buckaroo, "__version__", "0")
-        html = SESSION_HTML.replace("__SESSION_ID__", session_id).replace("__VERSION__", ver)
+        datasets = self.application.settings.get("datasets", []) or []
+        engine_bar, datasets_json = _render_engine_bar(datasets)
+        html = (SESSION_HTML
+            .replace("__SESSION_ID__", session_id)
+            .replace("__VERSION__", ver)
+            .replace("__ENGINE_BAR__", engine_bar)
+            .replace("__DATASETS_JSON__", datasets_json))
         self.write(html)
 
 
@@ -621,7 +666,102 @@ SESSION_HTML = """\
 <body>
     <div id="filename-bar"></div>
     <div id="prompt-bar"></div>
+    __ENGINE_BAR__
     <div id="root"></div>
+    <script id="buckaroo-datasets" type="application/json">__DATASETS_JSON__</script>
+    <script>
+    // Engine dropdown wiring for /s/<session>. Reads the operator-supplied
+    // dataset list from the JSON ``<script>`` above (populated by
+    // ``_render_engine_bar``) and adds any ``?pd=&pl=&xq=`` query-string
+    // overrides as extra ``(from URL)`` options so URL-driven workflows
+    // survive. The dropdown element is only emitted when at least one
+    // operator dataset is registered — see issue #811.
+    (function () {
+        const sel = document.getElementById("engine-select");
+        const statusEl = document.getElementById("engine-status");
+        const SESSION_ID = "__SESSION_ID__";
+        const DATASETS = JSON.parse(
+            document.getElementById("buckaroo-datasets").textContent || "[]");
+        const qs = new URLSearchParams(window.location.search);
+        const qsOverrides = [];
+        if (qs.get("pd")) qsOverrides.push({label: "(from URL) pandas", kind: "pandas", target: qs.get("pd")});
+        if (qs.get("pl")) qsOverrides.push({label: "(from URL) lazy", kind: "lazy", target: qs.get("pl")});
+        if (qs.get("xq")) qsOverrides.push({label: "(from URL) xorq", kind: "xorq", target: qs.get("xq")});
+        const ENTRIES = DATASETS.concat(qsOverrides);
+        if (!sel) {
+            // No dropdown rendered (no datasets configured and no QS overrides).
+            // If only QS overrides are present, we still want them reachable —
+            // but the server didn't emit the bar. Inject a minimal bar now.
+            if (qsOverrides.length > 0) {
+                const bar = document.createElement("div");
+                bar.id = "engine-bar";
+                bar.style.cssText = "padding: 4px 10px; font-family: sans-serif; font-size: 12px; color: #ccc; background: #1f1f24; border-bottom: 1px solid #333; flex-shrink: 0;";
+                bar.innerHTML = 'Dataset: <select id="engine-select" style="background: #2a2a30; color: #ddd; border: 1px solid #444; padding: 2px 6px; margin-left: 6px;"><option value="">— switch dataset —</option></select><span id="engine-status" style="margin-left: 12px; color: #888;"></span>';
+                document.body.insertBefore(bar, document.getElementById("root"));
+            } else {
+                return;
+            }
+        }
+        const selNow = document.getElementById("engine-select");
+        const statusNow = document.getElementById("engine-status");
+        // Re-render options if we inserted the bar above, or append QS extras
+        // to a server-rendered list.
+        if (sel === null) {
+            ENTRIES.forEach((ds, i) => {
+                const opt = document.createElement("option");
+                opt.value = String(i);
+                opt.dataset.kind = ds.kind;
+                opt.dataset.target = ds.target;
+                opt.textContent = `${ds.label} (${ds.kind})`;
+                selNow.appendChild(opt);
+            });
+        } else {
+            qsOverrides.forEach((ds, i) => {
+                const opt = document.createElement("option");
+                opt.value = String(DATASETS.length + i);
+                opt.dataset.kind = ds.kind;
+                opt.dataset.target = ds.target;
+                opt.textContent = `${ds.label} (${ds.kind})`;
+                selNow.appendChild(opt);
+            });
+        }
+        selNow.addEventListener("change", async (e) => {
+            const idx = e.target.value;
+            if (idx === "") return;
+            const ds = ENTRIES[parseInt(idx, 10)];
+            if (!ds) return;
+            const url = ds.kind === "xorq" ? "/load_expr" : "/load";
+            const body = {session: SESSION_ID, no_browser: true};
+            if (ds.kind === "xorq") {
+                body.build_dir = ds.target;
+            } else {
+                body.path = ds.target;
+                body.mode = ds.kind === "lazy" ? "lazy" : "buckaroo";
+            }
+            const t0 = performance.now();
+            statusNow.textContent = `loading ${ds.label}…`;
+            try {
+                const r = await fetch(url, {method: "POST",
+                    headers: {"Content-Type": "application/json"},
+                    body: JSON.stringify(body)});
+                const dt = Math.round(performance.now() - t0);
+                if (r.ok) {
+                    const d = await r.json();
+                    statusNow.textContent = `${ds.label} loaded (${d.rows ?? "?"} rows, ${dt} ms) — reloading…`;
+                    // The widget reads its initial state on WS open. Reload
+                    // forces a clean reconnection rather than reasoning
+                    // about deep widget-level swap.
+                    setTimeout(() => window.location.reload(), 600);
+                } else {
+                    const err = await r.text();
+                    statusNow.textContent = `${ds.label} failed (${r.status}): ${err.slice(0, 200)}`;
+                }
+            } catch (ex) {
+                statusNow.textContent = `${ds.label} error: ${ex.message}`;
+            }
+        });
+    })();
+    </script>
     <script type="module" src="/static/standalone.js?v=__VERSION__"></script>
 </body>
 </html>

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -6,8 +6,6 @@ import tempfile
 import pandas as pd
 import pytest
 import tornado.httpclient
-import tornado.httpserver
-import tornado.netutil
 import tornado.testing
 import tornado.websocket
 
@@ -115,52 +113,42 @@ class TestSessionPage(tornado.testing.AsyncHTTPTestCase):
         self.assertIn(b"<div id=\"root\">", resp.body)
 
 
-class TestSessionPageDatasets(tornado.testing.AsyncHTTPTestCase):
-    """The /s/<id> demo page exposes operator-supplied datasets in an
-    engine dropdown. No filesystem paths may be baked into shipped code:
-    the list is fed in at server startup, via ``--dataset`` CLI flags
-    (parsed by ``buckaroo.server.__main__``) and threaded through
-    ``make_app`` settings. See issue #811."""
+_OPERATOR_DATASETS = [{"label": "boston-pandas", "kind": "pandas",
+    "target": "/opt/data/boston-pandas.parquet"}, {"label": "boston-lazy", "kind": "lazy",
+        "target": "/opt/data/boston-lazy.parquet"}, {"label": "boston-xorq", "kind": "xorq",
+            "target": "/opt/builds/boston-xorq"}]
 
-    DATASETS = [{"label": "boston-pandas", "kind": "pandas",
-        "target": "/opt/data/boston-pandas.parquet"}, {"label": "boston-lazy", "kind": "lazy",
-            "target": "/opt/data/boston-lazy.parquet"}, {"label": "boston-xorq", "kind": "xorq",
-                "target": "/opt/builds/boston-xorq"}]
+
+class TestSessionPageNoHardCodedPaths(tornado.testing.AsyncHTTPTestCase):
+    """Vanilla server (no --dataset flags) must not ship the author's
+    personal paths. Pre-#811 the page baked in
+    ``/tmp/restaurant-complaints-pandas.parquet`` and
+    ``/Users/paddy/buckaroo/...`` as defaults."""
 
     def get_app(self):
-        return _make_app(open_browser=False, datasets=self.DATASETS)
+        return _make_app(open_browser=False)
 
     def test_default_no_hard_coded_paths_in_html(self):
-        """Vanilla server (no --dataset flags) must not ship the author's
-        personal paths. Pre-#811 the page baked in
-        ``/tmp/restaurant-complaints-pandas.parquet`` and
-        ``/Users/paddy/buckaroo/...`` as defaults."""
-        plain_app = _make_app(open_browser=False)
-        # Mount on its own port so this case doesn't collide with the
-        # configured-datasets app under test.
-        sock = tornado.netutil.bind_sockets(0, address="127.0.0.1")
-        port = sock[0].getsockname()[1]
-        server = tornado.httpserver.HTTPServer(plain_app)
-        server.add_sockets(sock)
-        try:
-            client = tornado.httpclient.HTTPClient()
-            resp = client.fetch(f"http://127.0.0.1:{port}/s/sess-plain")
-            body = resp.body.decode("utf-8")
-            self.assertNotIn("/tmp/restaurant-complaints-pandas.parquet", body)
-            self.assertNotIn("/Users/paddy/buckaroo/restaurant-complaints.parquet", body)
-            self.assertNotIn("/tmp/buckaroo-builds-boston/", body)
-        finally:
-            server.stop()
-            for s in sock:
-                s.close()
+        resp = self.fetch("/s/sess-plain")
+        self.assertEqual(resp.code, 200)
+        body = resp.body.decode("utf-8")
+        self.assertNotIn("/tmp/restaurant-complaints-pandas.parquet", body)
+        self.assertNotIn("/Users/paddy/buckaroo/restaurant-complaints.parquet", body)
+        self.assertNotIn("/tmp/buckaroo-builds-boston/", body)
+
+
+class TestSessionPageConfiguredDatasets(tornado.testing.AsyncHTTPTestCase):
+    """Operator-supplied datasets surface in the engine dropdown. See
+    issue #811."""
+
+    def get_app(self):
+        return _make_app(open_browser=False, datasets=_OPERATOR_DATASETS)
 
     def test_configured_datasets_appear_in_html(self):
-        """Operator-supplied dataset labels and targets must be reachable
-        from the rendered page so the dropdown can wire fetches."""
         resp = self.fetch("/s/sess-dropdown")
         self.assertEqual(resp.code, 200)
         body = resp.body.decode("utf-8")
-        for ds in self.DATASETS:
+        for ds in _OPERATOR_DATASETS:
             self.assertIn(ds["label"], body,
                 f"dataset label {ds['label']!r} missing from /s/ HTML")
             self.assertIn(ds["target"], body,

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -6,6 +6,8 @@ import tempfile
 import pandas as pd
 import pytest
 import tornado.httpclient
+import tornado.httpserver
+import tornado.netutil
 import tornado.testing
 import tornado.websocket
 
@@ -111,6 +113,92 @@ class TestSessionPage(tornado.testing.AsyncHTTPTestCase):
         self.assertEqual(resp.code, 200)
         self.assertIn(b"standalone.js", resp.body)
         self.assertIn(b"<div id=\"root\">", resp.body)
+
+
+class TestSessionPageDatasets(tornado.testing.AsyncHTTPTestCase):
+    """The /s/<id> demo page exposes operator-supplied datasets in an
+    engine dropdown. No filesystem paths may be baked into shipped code:
+    the list is fed in at server startup, via ``--dataset`` CLI flags
+    (parsed by ``buckaroo.server.__main__``) and threaded through
+    ``make_app`` settings. See issue #811."""
+
+    DATASETS = [{"label": "boston-pandas", "kind": "pandas",
+        "target": "/opt/data/boston-pandas.parquet"}, {"label": "boston-lazy", "kind": "lazy",
+            "target": "/opt/data/boston-lazy.parquet"}, {"label": "boston-xorq", "kind": "xorq",
+                "target": "/opt/builds/boston-xorq"}]
+
+    def get_app(self):
+        return _make_app(open_browser=False, datasets=self.DATASETS)
+
+    def test_default_no_hard_coded_paths_in_html(self):
+        """Vanilla server (no --dataset flags) must not ship the author's
+        personal paths. Pre-#811 the page baked in
+        ``/tmp/restaurant-complaints-pandas.parquet`` and
+        ``/Users/paddy/buckaroo/...`` as defaults."""
+        plain_app = _make_app(open_browser=False)
+        # Mount on its own port so this case doesn't collide with the
+        # configured-datasets app under test.
+        sock = tornado.netutil.bind_sockets(0, address="127.0.0.1")
+        port = sock[0].getsockname()[1]
+        server = tornado.httpserver.HTTPServer(plain_app)
+        server.add_sockets(sock)
+        try:
+            client = tornado.httpclient.HTTPClient()
+            resp = client.fetch(f"http://127.0.0.1:{port}/s/sess-plain")
+            body = resp.body.decode("utf-8")
+            self.assertNotIn("/tmp/restaurant-complaints-pandas.parquet", body)
+            self.assertNotIn("/Users/paddy/buckaroo/restaurant-complaints.parquet", body)
+            self.assertNotIn("/tmp/buckaroo-builds-boston/", body)
+        finally:
+            server.stop()
+            for s in sock:
+                s.close()
+
+    def test_configured_datasets_appear_in_html(self):
+        """Operator-supplied dataset labels and targets must be reachable
+        from the rendered page so the dropdown can wire fetches."""
+        resp = self.fetch("/s/sess-dropdown")
+        self.assertEqual(resp.code, 200)
+        body = resp.body.decode("utf-8")
+        for ds in self.DATASETS:
+            self.assertIn(ds["label"], body,
+                f"dataset label {ds['label']!r} missing from /s/ HTML")
+            self.assertIn(ds["target"], body,
+                f"dataset target {ds['target']!r} missing from /s/ HTML")
+
+
+class TestDatasetCLIParsing(tornado.testing.AsyncHTTPTestCase):
+    """``--dataset NAME=KIND:PATH`` (repeatable) parses into the list of
+    dicts that ``make_app(datasets=...)`` consumes. Centralising the
+    parse in ``__main__`` keeps it covered by unit tests instead of
+    relying on a live argparse invocation."""
+
+    def get_app(self):
+        # We don't need a live server for the parse test, but
+        # AsyncHTTPTestCase still wants one.
+        return _make_app(open_browser=False)
+
+    def test_parse_dataset_spec_three_kinds(self):
+        from buckaroo.server.__main__ import parse_dataset_spec
+
+        specs = ["boston-pandas=pandas:/data/boston.parquet", "boston-lazy=lazy:/data/boston.parquet",
+            "boston-xorq=xorq:/builds/boston-xorq"]
+        parsed = [parse_dataset_spec(s) for s in specs]
+        assert parsed == [{"label": "boston-pandas", "kind": "pandas", "target": "/data/boston.parquet"},
+            {"label": "boston-lazy", "kind": "lazy", "target": "/data/boston.parquet"},
+            {"label": "boston-xorq", "kind": "xorq", "target": "/builds/boston-xorq"}]
+
+    def test_parse_dataset_spec_rejects_unknown_kind(self):
+        from buckaroo.server.__main__ import parse_dataset_spec
+        with pytest.raises(ValueError):
+            parse_dataset_spec("foo=duckdb:/data/foo.parquet")
+
+    def test_parse_dataset_spec_rejects_malformed(self):
+        from buckaroo.server.__main__ import parse_dataset_spec
+        with pytest.raises(ValueError):
+            parse_dataset_spec("just-a-label-no-equals")
+        with pytest.raises(ValueError):
+            parse_dataset_spec("label=no-colon-after-kind")
 
 
 class TestWebSocket(tornado.testing.AsyncHTTPTestCase):

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -155,6 +155,45 @@ class TestSessionPageConfiguredDatasets(tornado.testing.AsyncHTTPTestCase):
                 f"dataset target {ds['target']!r} missing from /s/ HTML")
 
 
+_SCRIPT_BREAKOUT_DATASETS = [{"label": "evil", "kind": "pandas",
+    "target": "</script><script>window.__pwned=1</script>"}]
+
+
+class TestSessionPageScriptTagSafety(tornado.testing.AsyncHTTPTestCase):
+    """Dataset targets are embedded inline in a ``<script
+    type=\"application/json\">`` block. A target containing
+    ``</script>`` must not break out — operator CLI args are
+    low-trust, but escaping is cheap and unconditional."""
+
+    def get_app(self):
+        return _make_app(open_browser=False, datasets=_SCRIPT_BREAKOUT_DATASETS)
+
+    def test_script_tag_in_target_does_not_break_out(self):
+        resp = self.fetch("/s/sess-evil")
+        self.assertEqual(resp.code, 200)
+        body = resp.body.decode("utf-8")
+        # Extract whatever the browser would see between the JSON-data
+        # script's open tag and the FIRST ``</script>`` after it (which is
+        # what the HTML parser uses as the terminator — there is no
+        # nesting in raw text script content). If the operator-supplied
+        # target was JSON-encoded but not HTML-script-escaped, the first
+        # ``</script>`` is the one *inside* the target string, and the
+        # extracted slice is truncated invalid JSON. ``json_encode``
+        # rewrites ``</`` to ``<\\/``, so the only ``</script>`` after
+        # the open tag is the legitimate terminator.
+        open_tag = '<script id="buckaroo-datasets" type="application/json">'
+        start = body.index(open_tag) + len(open_tag)
+        end = body.index("</script>", start)
+        payload = body[start:end]
+        # If json_encode is in use, the payload is the entire dataset list
+        # encoded as valid JSON — must parse cleanly and round-trip the
+        # original target.
+        parsed = json.loads(payload)
+        self.assertEqual(len(parsed), 1)
+        self.assertEqual(parsed[0]["target"],
+            "</script><script>window.__pwned=1</script>")
+
+
 class TestDatasetCLIParsing(tornado.testing.AsyncHTTPTestCase):
     """``--dataset NAME=KIND:PATH`` (repeatable) parses into the list of
     dicts that ``make_app(datasets=...)`` consumes. Centralising the


### PR DESCRIPTION
## Summary

Closes #811. Removes the hard-coded ``/tmp/restaurant-complaints-pandas.parquet`` / ``/Users/paddy/buckaroo/...`` paths from the standalone demo page and replaces them with an operator-supplied dataset list, fed in at server startup.

- New CLI flag: ``--dataset NAME=KIND:PATH`` (repeatable). ``KIND`` is one of ``pandas`` / ``lazy`` / ``xorq``.
- Parsed list threaded through ``make_app(datasets=...)`` into ``settings['datasets']``.
- ``SessionPageHandler`` renders the supplied entries into the engine dropdown as ``<option>`` elements; the dropdown is omitted entirely when no datasets are configured.
- Existing ``?pd=&pl=&xq=`` query-string overrides still work — they're surfaced as ``(from URL)`` extra options at the JS layer so URL-driven workflows survive.
- Default behaviour with no flags: no dropdown, no leaked filesystem paths.

## Test plan

- [x] Three failing tests committed first (``test(server): failing tests for configurable demo datasets``).
- [ ] CI: verify the test-only commit fails and the fix commit passes.