### PR TITLE
feat(status-bar): in-flight indicator for state_change (#813)

### DIFF
--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import * as _ from "lodash-es";
 import { OperationResult } from "./DependentTabs";
 import { ColumnsEditor } from "./ColumnsEditor";
@@ -269,6 +269,46 @@ export function BuckarooInfiniteWidget({
             },
             [dataframe_id, remountOperations, buckaroo_state.post_processing, buckaroo_state.cleaning_method],
         );
+
+        // In-flight indicator for the status bar (#813). Set when the user
+        // dispatches a buckaroo_state change that touches a dataflow field
+        // (post_processing / cleaning_method / quick_command_args — mirrors
+        // _DATAFLOW_FIELDS in buckaroo/server/websocket_handler.py). Cleared
+        // when df_data_dict comes back with a new reference, indicating the
+        // backend has returned the recomputed result. show_commands /
+        // df_display / sampled toggles do not trigger backend recompute, so
+        // they don't set in-flight.
+        const [inFlight, setInFlight] = useState<boolean>(false);
+        // Track the df_data_dict reference at the moment we entered in-flight,
+        // so we don't accidentally clear on the same dict the user was looking
+        // at when they fired the change. Cleared on the *next* dict reference.
+        const inFlightAtDictRef = useRef<typeof df_data_dict | null>(null);
+        useEffect(() => {
+            if (inFlight && inFlightAtDictRef.current !== null
+                    && df_data_dict !== inFlightAtDictRef.current) {
+                setInFlight(false);
+                inFlightAtDictRef.current = null;
+            }
+        }, [df_data_dict, inFlight]);
+
+        const wrappedOnBuckarooState = useCallback<
+            React.Dispatch<React.SetStateAction<BuckarooState>>
+        >((updater) => {
+            const next = typeof updater === "function"
+                ? (updater as (prev: BuckarooState) => BuckarooState)(buckaroo_state)
+                : updater;
+            const dataflowChanged =
+                next.post_processing !== buckaroo_state.post_processing
+                || next.cleaning_method !== buckaroo_state.cleaning_method
+                || JSON.stringify(next.quick_command_args)
+                       !== JSON.stringify(buckaroo_state.quick_command_args);
+            if (dataflowChanged) {
+                inFlightAtDictRef.current = df_data_dict;
+                setInFlight(true);
+            }
+            on_buckaroo_state(next);
+        }, [buckaroo_state, df_data_dict, on_buckaroo_state]);
+
         return (
             <div className="dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget"
              style={{ width: "100%", height: "100%" }}>
@@ -282,9 +322,10 @@ export function BuckarooInfiniteWidget({
                     <StatusBar
                         dfMeta={df_meta}
                         buckarooState={buckaroo_state}
-                        setBuckarooState={on_buckaroo_state}
+                        setBuckarooState={wrappedOnBuckarooState}
                         buckarooOptions={buckaroo_options}
                         themeConfig={cDisp.df_viewer_config?.component_config?.theme}
+                        inFlight={inFlight}
                     />
                     <DFViewerInfinite
                         key={effectiveDataframeId}

--- a/packages/buckaroo-js-core/src/components/StatusBar.test.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * StatusBar — in-flight indicator (issue #813).
+ *
+ * After the user changes search / cleaning / post-processing, the status bar
+ * must visibly distinguish "computed and final" from "still in flight". An
+ * empty grid is otherwise ambiguous between "filter returned zero rows" and
+ * "filter is still computing" — a real pain on slow xorq backends.
+ */
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+// StatusBar mounts an AG-Grid. We don't care about the grid's internals here —
+// we only care about the in-flight indicator that lives in the surrounding
+// status-bar chrome. Stub AG-Grid out (mirrors the pattern used in
+// BuckarooInfiniteWidget.flash.test.tsx).
+jest.mock("ag-grid-react", () => ({
+    AgGridReact: () => <div data-testid="status-bar-aggrid-stub" />,
+}));
+jest.mock("./useColorScheme", () => ({ useColorScheme: () => "light" }));
+
+import { StatusBar } from "./StatusBar";
+import { BuckarooOptions, BuckarooState, DFMeta } from "./WidgetTypes";
+
+const dfMeta: DFMeta = {
+    total_rows: 378,
+    columns: 7,
+    filtered_rows: 297,
+    rows_shown: 297,
+};
+
+const buckarooOptions: BuckarooOptions = {
+    sampled: [],
+    cleaning_method: ["", "clean1"],
+    post_processing: ["", "post1"],
+    df_display: ["main", "summary"],
+    show_commands: ["0", "1"],
+};
+
+const buckarooState: BuckarooState = {
+    sampled: false,
+    cleaning_method: false,
+    quick_command_args: {},
+    post_processing: false,
+    df_display: "main",
+    show_commands: false,
+};
+
+describe("StatusBar in-flight indicator (#813)", () => {
+    it("does NOT render the in-flight indicator by default", () => {
+        render(
+            <StatusBar
+                dfMeta={dfMeta}
+                buckarooState={buckarooState}
+                setBuckarooState={() => {}}
+                buckarooOptions={buckarooOptions}
+            />
+        );
+        expect(screen.queryByTestId("status-bar-inflight")).not.toBeInTheDocument();
+    });
+
+    it("does NOT render the in-flight indicator when inFlight=false", () => {
+        render(
+            <StatusBar
+                dfMeta={dfMeta}
+                buckarooState={buckarooState}
+                setBuckarooState={() => {}}
+                buckarooOptions={buckarooOptions}
+                inFlight={false}
+            />
+        );
+        expect(screen.queryByTestId("status-bar-inflight")).not.toBeInTheDocument();
+    });
+
+    it("renders the in-flight indicator when inFlight=true", () => {
+        render(
+            <StatusBar
+                dfMeta={dfMeta}
+                buckarooState={buckarooState}
+                setBuckarooState={() => {}}
+                buckarooOptions={buckarooOptions}
+                inFlight={true}
+            />
+        );
+        const indicator = screen.getByTestId("status-bar-inflight");
+        expect(indicator).toBeInTheDocument();
+        // ARIA — distinguishes "computing" from "no results" for assistive tech
+        // as well as the visual indicator. Without aria-live the empty-grid
+        // ambiguity persists for screen-reader users.
+        expect(indicator).toHaveAttribute("aria-live");
+    });
+});

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -322,12 +322,9 @@ export function StatusBar({
     // True while a buckaroo_state_change is in flight to the backend
     // (search / cleaning_method / post_processing). Issue #813: an empty
     // grid is otherwise ambiguous between "zero rows" and "still computing".
-    // No-op until the fix commit hooks up the visual indicator.
+    // When set, renders a small "computing…" dot in the status-bar chrome.
     inFlight?: boolean;
 }) {
-    // Reference inFlight so TS doesn't complain about an unused prop in the
-    // failing-test commit. Rendering arrives in the fix.
-    void inFlight;
     if (false) {
 	console.log("heightOverride", heightOverride);
     }
@@ -499,6 +496,24 @@ export function StatusBar({
     const themeClass = effectiveScheme === 'light' ? 'ag-theme-alpine' : 'ag-theme-alpine-dark';
     return (
         <div className="status-bar">
+            {inFlight ? (
+                // Minimal "computing…" indicator (#813). Lives above the
+                // AG-Grid header strip so it shows whether the grid is empty
+                // because a filter excluded everything or because the
+                // dataflow is still in flight. aria-live so screen readers
+                // also escape the empty-grid ambiguity.
+                <div
+                    className="bk-status-inflight"
+                    data-testid="status-bar-inflight"
+                    role="status"
+                    aria-live="polite"
+                    aria-label="Computing"
+                    title="Computing…"
+                >
+                    <span className="bk-status-inflight-dot" aria-hidden="true" />
+                    <span className="bk-status-inflight-label">computing…</span>
+                </div>
+            ) : null}
             <div
             className={`theme-hanger ${themeClass}`}>
                 <AgGridReact

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -310,7 +310,8 @@ export function StatusBar({
     setBuckarooState,
     buckarooOptions,
     heightOverride,
-    themeConfig
+    themeConfig,
+    inFlight,
 }: {
     dfMeta: DFMeta;
     buckarooState: BuckarooState;
@@ -318,7 +319,15 @@ export function StatusBar({
     buckarooOptions: BuckarooOptions;
     heightOverride?: number;
     themeConfig?: ThemeConfig;
+    // True while a buckaroo_state_change is in flight to the backend
+    // (search / cleaning_method / post_processing). Issue #813: an empty
+    // grid is otherwise ambiguous between "zero rows" and "still computing".
+    // No-op until the fix commit hooks up the visual indicator.
+    inFlight?: boolean;
 }) {
+    // Reference inFlight so TS doesn't complain about an unused prop in the
+    // failing-test commit. Rendering arrives in the fix.
+    void inFlight;
     if (false) {
 	console.log("heightOverride", heightOverride);
     }

--- a/packages/buckaroo-js-core/src/stories/StatusBar.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/StatusBar.stories.tsx
@@ -10,15 +10,17 @@ const StatusBarWrap = ({
     dfMeta,
     buckarooState,
     buckarooOptions,
+    inFlight,
 }: {
     dfMeta: DFMeta;
     buckarooState: BuckarooState;
     buckarooOptions: BuckarooOptions;
+    inFlight?: boolean;
 }) => {
   const [bState, setBuckarooState] = useState<BuckarooState>(buckarooState);
 
   return (
-      <div className="dcf-root flex flex-col" 
+      <div className="dcf-root flex flex-col"
       style={{ width: "800px", height: "300px", border:"1px solid red" }}>
             <div
                 className="orig-df"
@@ -34,6 +36,7 @@ const StatusBarWrap = ({
       setBuckarooState={setBuckarooState}
       buckarooOptions={buckarooOptions}
       heightOverride={150}
+      inFlight={inFlight}
       />
       </div>
       <pre> {JSON.stringify(bState, undefined, 4)}</pre>
@@ -114,5 +117,17 @@ export const NoCleaningNoPostProcessing: Story = {
       df_display: ["main", "summary"],
       show_commands: ["on", "off"]
     }
+  }
+}
+
+// #813: status bar shows the in-flight indicator while a state_change is
+// being computed on the backend. Visible signal that distinguishes
+// "computing" from "filter returned zero rows" on slow xorq backends.
+export const InFlight: Story = {
+  args: {
+    dfMeta:dfm,
+    buckarooState:bs,
+    buckarooOptions:bo,
+    inFlight: true,
   }
 }

--- a/packages/buckaroo-js-core/src/style/dcf-npm.css
+++ b/packages/buckaroo-js-core/src/style/dcf-npm.css
@@ -398,7 +398,42 @@ div.dependent-tabs ul.tabs li.active {
     background:orange;
 
    */
+    position: relative;
+}
 
+/* In-flight indicator (#813). Positioned over the status-bar header strip so
+ * it's visible when a state_change is still being computed; without it, an
+ * empty grid is ambiguous between "filter returned zero rows" and "still
+ * computing" (most acute on slow xorq backends, ~7s per change). */
+.bk-status-inflight {
+    position: absolute;
+    top: 2px;
+    right: 6px;
+    z-index: 5;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 11px;
+    line-height: 1;
+    color: var(--bk-fg-color, #555);
+    pointer-events: none;
+}
+.bk-status-inflight-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #2b8aef;
+    animation: bk-status-inflight-pulse 1s ease-in-out infinite;
+}
+.bk-status-inflight-label {
+    opacity: 0.75;
+}
+@keyframes bk-status-inflight-pulse {
+    0%, 100% { opacity: 0.3; }
+    50%      { opacity: 1; }
+}
+@media (prefers-reduced-motion: reduce) {
+    .bk-status-inflight-dot { animation: none; opacity: 1; }
 }
 .status-bar .ag-center-cols-viewport {
     min-height: unset !important;


### PR DESCRIPTION
## Summary

Closes #813. After the user changes search / cleaning / post-processing, the status bar gave no indication of whether the resulting grid state was computed and final or still in flight. On a slow xorq backend (~7s per state_change against boston-restaurant) an empty grid was ambiguous between "filter returned zero rows" and "filter is still computing"; the user's next move was usually to refresh (which clears any in-flight work) or click X (which re-fires the cycle).

This PR adds a minimal "computing…" dot to the status-bar chrome, driven by an ``inFlight`` boolean wired through ``BuckarooInfiniteWidget``.

## How the signal is derived

- ``BuckarooInfiniteWidget`` wraps ``on_buckaroo_state``. When the new state differs from the current state on any of the dataflow-driving fields (``post_processing`` / ``cleaning_method`` / ``quick_command_args`` — same set as ``_DATAFLOW_FIELDS`` in ``buckaroo/server/websocket_handler.py``), it captures the current ``df_data_dict`` reference and sets ``inFlight=true``.
- An effect clears ``inFlight`` the next time ``df_data_dict`` arrives with a fresh reference, which is the round-trip-complete signal in both anywidget and server modes.
- UI-only toggles (``show_commands`` / ``df_display`` / ``sampled``) do not set in-flight — they don't trigger a backend recompute.

## What it looks like

A small absolutely-positioned dot + "computing…" label in the top-right of the status bar. ``aria-live="polite"`` and ``aria-label="Computing"`` so screen-reader users also escape the empty-grid ambiguity. ``prefers-reduced-motion`` disables the pulse animation. See the new ``StatusBar / InFlight`` Storybook story.

## Test plan

- [x] Failing test for ``StatusBar`` in-flight indicator (test commit ``063784b1``): renders when ``inFlight=true``, doesn't when false / undefined. Test was seen failing in CI before the fix (JS / Build + Test failure).
- [x] Fix commit ``215df1aa`` makes that test pass. Full JS suite: 256/256 pass.
- [x] ``./scripts/full_build.sh`` clean locally (tsc, vite, esbuild, wheel).
- [ ] CI green on the fix commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)