### PR TITLE
fix(xorq): don't cache _expr_count failures (Codex P1 follow-up to #796)

### DIFF
--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -58,7 +58,13 @@ def _expr_count(expr_or_df: Any) -> int:
     try:
         result = int(expr_or_df.count().execute())
     except Exception:
-        result = 0
+        # Don't cache failures — a transient backend error would
+        # otherwise poison the cache for the lifetime of this
+        # expression object. Return 0 so callers don't break, log
+        # so the failure is visible, leave the cache empty so the
+        # next call retries the backend.
+        logger.exception("_expr_count: backend count failed; not caching")
+        return 0
     _expr_count_cache[key] = result
     return result
 

--- a/tests/unit/test_xorq_buckaroo_widget.py
+++ b/tests/unit/test_xorq_buckaroo_widget.py
@@ -120,6 +120,67 @@ class TestExprCountMemoization:
         df = pd.DataFrame({"a": [1, 2, 3, 4]})
         assert xorq_buckaroo._expr_count(df) == 4
 
+    def test_expr_count_does_not_cache_failures(self):
+        """Codex P1 follow-up to #796: a transient backend failure on
+        ``expr.count().execute()`` must not poison the cache. The
+        original memoization commit caught ``Exception`` and stored
+        ``0`` in ``_expr_count_cache`` — so every subsequent call for
+        the same expression object returned 0 forever, even after the
+        backend recovered.
+
+        Contract: failures are not cached. The next call retries the
+        backend; on recovery the real count is returned and stored.
+        """
+        from buckaroo import xorq_buckaroo
+
+        xorq_buckaroo._expr_count_cache.clear()
+
+        class _StubCount:
+            def __init__(self, value):
+                self._value = value
+
+            def execute(self):
+                return self._value
+
+        class _StubExpr:
+            """Mimics the ibis-expression duck-type: not a pd.DataFrame,
+            exposes ``.count().execute()``. Counter flips from raising
+            to succeeding to simulate backend recovery."""
+
+            def __init__(self):
+                self.calls = 0
+
+            def count(self):
+                self.calls += 1
+                if self.calls == 1:
+                    raise RuntimeError("simulated backend failure")
+                return _StubCount(42)
+
+        stub = _StubExpr()
+
+        first = xorq_buckaroo._expr_count(stub)
+        assert id(stub) not in xorq_buckaroo._expr_count_cache, (
+            "failed _expr_count call must not write to the cache; "
+            f"found cached value {xorq_buckaroo._expr_count_cache.get(id(stub))!r}"
+        )
+
+        second = xorq_buckaroo._expr_count(stub)
+        assert second == 42, (
+            f"after backend recovery, _expr_count must return the real "
+            f"count, not a cached failure sentinel; got {second!r}"
+        )
+        assert xorq_buckaroo._expr_count_cache.get(id(stub)) == 42, (
+            "successful call following a failure must populate the cache "
+            "with the real count"
+        )
+
+        # Sanity: the first call returned _something_ — but the contract
+        # this test pins is "don't cache failures", not "what the failure
+        # return value is". Leave the first-call value out of the assert
+        # so the test stays stable if we later switch from "return 0" to
+        # "re-raise".
+        del first
+
 
 class TestInstantiation:
     def test_smoke(self):


### PR DESCRIPTION
## Summary

Follow-up to #796 — addresses the [P1 Codex flagged](https://github.com/buckaroo-data/buckaroo/pull/796#discussion_r3278382120) on the merged PR.

#796 memoized `_expr_count` by `id(expr)` to skip ~250 ms / call of repeated `expr.count().execute()`. The implementation also cached `0` when the backend call raised — so any transient backend failure permanently poisoned the count for that expression object: the widget would keep returning 0 rows even after the backend recovered, with no retry path.

This PR makes the failure branch skip the cache write, log the exception, and return 0. The next call retries the backend; on recovery the real count is computed and cached. Restores the pre-#796 recovery behaviour without losing the perf win on the success path.

## Changes

- `buckaroo/xorq_buckaroo.py`: in `_expr_count`'s `except Exception:` arm, `logger.exception(...)` + `return 0` instead of `result = 0; _expr_count_cache[key] = result`. The success-path cache write is unchanged.
- `tests/unit/test_xorq_buckaroo_widget.py`: new test `test_expr_count_does_not_cache_failures` exercises a stub expression whose `.count().execute()` raises on first call, returns 42 on second. Pins three invariants:
  1. Cache has no entry for `id(stub)` after the failing call.
  2. The follow-up call returns 42 (the real count).
  3. The successful call populates the cache with the real value.

## Test plan

- [x] Failing test commit pushed first; CI sees it red on the test-only commit
- [x] Fix commit then makes the new test pass
- [x] Full `test_xorq_buckaroo_widget.py` suite (43 tests) passes locally
- [x] Pre-existing memoization tests (`test_expr_count_memoizes_repeat_calls`, `test_expr_count_separate_expressions_cache_separately`, `test_expr_count_pandas_path_unaffected`) still pass

## Follow-up not in this PR

Codex P2 on the same review — `id(expr)` reuse after GC can return a stale count for a fresh expression. Real bug under expression churn, but mitigation needs weakref-keyed cache (or a GC callback that clears entries). Tracking separately — not blocking this safety fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)