### PR TITLE
feat(polars): default pinned_rows include ?filtered_histogram

### DIFF
--- a/buckaroo/polars_buckaroo.py
+++ b/buckaroo/polars_buckaroo.py
@@ -15,12 +15,27 @@ from .customizations.pl_autocleaning_conf import NoCleaningConfPl
 from .dataflow.dataflow import Sampling
 from .dataflow.autocleaning import PandasAutocleaning
 from .dataflow.widget_extension_utils import configure_buckaroo
+from .styling_helpers import obj_, pinned_histogram, pinned_filtered_histogram
 
 class PLSampling(Sampling):
     pre_limit = False
     serialize_limit = 1_000_000
 
-local_analysis_klasses = list(PL_ANALYSIS_V2) + [DefaultSummaryStatsStyling, DefaultMainStyling]
+
+class PolarsMainStyling(DefaultMainStyling):
+    """Polars default styling — adds an optional ``?filtered_histogram``
+    pinned row alongside the bare raw ``histogram``. The ``?`` prefix
+    means JS only renders the row when at least one column has the
+    ``filtered_histogram`` key in ``merged_sd``, i.e. when a search
+    filter is active. Polars materialises the filt scope cheaply, so
+    showing both raw and filtered histograms side-by-side is the
+    default; xorq skips computing filtered_histogram (#829) and pandas
+    keeps the original ``[dtype, histogram]`` layout."""
+
+    pinned_rows = [obj_('dtype'), pinned_histogram(), pinned_filtered_histogram()]
+
+
+local_analysis_klasses = list(PL_ANALYSIS_V2) + [DefaultSummaryStatsStyling, PolarsMainStyling]
 
 
 class PolarsAutocleaning(PandasAutocleaning):

--- a/buckaroo/styling_helpers.py
+++ b/buckaroo/styling_helpers.py
@@ -12,3 +12,6 @@ def inherit_(pkey):
 
 def pinned_histogram():
     return {'primary_key_val': 'histogram', 'displayer_args': {'displayer': 'histogram'}}
+
+def pinned_filtered_histogram():
+    return {'primary_key_val': '?filtered_histogram', 'displayer_args': {'displayer': 'histogram'}}


### PR DESCRIPTION
## Summary

Adds an optional ``?filtered_histogram`` pinned row to polars's default styling. The ``?`` prefix (#777) means JS hides the row when no column has the ``filtered_histogram`` key in ``merged_sd``, so a no-filter widget keeps a one-line ``[dtype, histogram]`` header. When the user runs a search, ``filtered_histogram`` gets layered onto each column's entry in ``merged_sd`` (#785) and the row renders.

**Polars-only on purpose:**
- xorq skips computing ``filtered_histogram`` entirely (#829), so the optional row never appears there.
- Pandas keeps the original ``[dtype, histogram]`` default.

## Changes

- New ``pinned_filtered_histogram()`` helper in ``styling_helpers``, mirroring the existing ``pinned_histogram()``.
- New ``PolarsMainStyling(DefaultMainStyling)`` in ``polars_buckaroo`` overrides ``pinned_rows`` to ``[dtype, histogram, ?filtered_histogram]`` and replaces ``DefaultMainStyling`` in ``local_analysis_klasses``.

## Test plan

Config-only — no behavior tests. The optional-pinned-row plumbing (#777) is already exercised by ``gridUtils.test.ts`` (``isOptionalPinnedKey`` + ``stripOptionalPinnedKey``). Manually verified in JupyterLab that the row appears when a search is active and is hidden otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)