### PR TITLE
fix(server): preserve sd keys in sd_to_parquet_b64 (column-alignment bug)

### DIFF
--- a/buckaroo/serialization_utils.py
+++ b/buckaroo/serialization_utils.py
@@ -400,6 +400,17 @@ def sd_to_parquet_b64(sd: Dict[str, Any]) -> Dict[str, str]:
     used to apply to every cell now only applies to strings and to
     list/dict values (histograms, value_counts).
 
+    The input ``sd`` is expected to already be keyed by the pipeline-
+    rewritten short col names (``'a'``, ``'b'``, ...) — every caller
+    in the codebase reaches this function via ``DfStatsV2`` /
+    ``XorqDfStatsV2`` / ``merged_sd``, all of which use rewritten
+    names. Keys pass through unchanged. (Earlier versions re-keyed by
+    enumeration position via ``to_chars(i)``; that silently
+    mis-aligned every column whenever ``sd.keys()`` arrived in non-
+    positional order — see ``_merged_sd`` iterating
+    ``rewritten_init_sd`` before the raw scope, which puts ``'b'``
+    ahead of ``'a'`` in the result dict.)
+
     Returns ``{'format': 'parquet_b64', 'layout': 'wide', 'data': '<base64>'}``.
     Falls back to the JSON/row payload if parquet serialization fails — the
     absence of ``layout: 'wide'`` is how the JS side picks the row decoder.
@@ -407,12 +418,10 @@ def sd_to_parquet_b64(sd: Dict[str, Any]) -> Dict[str, str]:
     import pyarrow as pa
     import pyarrow.parquet as pq
 
-    col_mapping = [(orig, to_chars(i)) for i, orig in enumerate(sd.keys())]
     names: List[str] = []
     arrays: List[Any] = []
 
-    for orig_col, short_col in col_mapping:
-        stats = sd[orig_col]
+    for short_col, stats in sd.items():
         if not isinstance(stats, dict):
             continue
         for stat_name, val in stats.items():

--- a/tests/unit/test_sd_to_parquet_b64.py
+++ b/tests/unit/test_sd_to_parquet_b64.py
@@ -25,7 +25,7 @@ def _decode(result):
 
 
 def test_tagged_payload_carries_wide_layout():
-    sd = {'col': {'mean': 5.0, 'dtype': 'float64'}}
+    sd = {'a': {'mean': 5.0, 'dtype': 'float64'}}
     result = sd_to_parquet_b64(sd)
     assert result['format'] == 'parquet_b64'
     assert result['layout'] == 'wide'
@@ -37,7 +37,7 @@ def test_numeric_scalars_use_native_parquet_types():
 
     No JSON round-trip for numeric values — they ride the parquet schema.
     """
-    sd = {'col_a': {'mean': np.float64(42.0), 'length': 50, 'is_numeric': True, 'dtype': 'float64'}}
+    sd = {'a': {'mean': np.float64(42.0), 'length': 50, 'is_numeric': True, 'dtype': 'float64'}}
     table = _decode(sd_to_parquet_b64(sd))
     schema = {f.name: str(f.type) for f in table.schema}
     assert schema['a__mean'] == 'double'
@@ -47,7 +47,7 @@ def test_numeric_scalars_use_native_parquet_types():
 
 
 def test_native_scalars_round_trip_without_json():
-    sd = {'col_a': {'mean': np.float64(42.5), 'length': 50, 'is_numeric': True}}
+    sd = {'a': {'mean': np.float64(42.5), 'length': 50, 'is_numeric': True}}
     table = _decode(sd_to_parquet_b64(sd))
     row = table.to_pydict()
     # Values come out as native Python types — not JSON strings.
@@ -62,7 +62,7 @@ def test_string_values_remain_json_encoded():
 
     A plain ``"float64"`` round-trips as the JSON literal ``'"float64"'``.
     """
-    sd = {'col_a': {'dtype': 'float64'}}
+    sd = {'a': {'dtype': 'float64'}}
     table = _decode(sd_to_parquet_b64(sd))
     raw_cell = table.to_pydict()['a__dtype'][0]
     assert raw_cell == '"float64"'
@@ -71,7 +71,7 @@ def test_string_values_remain_json_encoded():
 
 def test_histogram_round_trips_as_json_string():
     histogram = [{'name': '0-20', 'population': np.float64(15.0)}, {'name': '20-40', 'population': np.float64(25.0)}]
-    sd = {'col_a': {'histogram': histogram, 'dtype': 'float64'}}
+    sd = {'a': {'histogram': histogram, 'dtype': 'float64'}}
     table = _decode(sd_to_parquet_b64(sd))
     raw_cell = table.to_pydict()['a__histogram'][0]
     assert isinstance(raw_cell, str)
@@ -87,14 +87,14 @@ def test_nan_becomes_parquet_null():
     On the JS side this surfaces as ``null``, which is what consumers expect
     for "no value" stats like mean of an all-NaN column.
     """
-    sd = {'col_a': {'mean': math.nan, 'dtype': 'float64'}}
+    sd = {'a': {'mean': math.nan, 'dtype': 'float64'}}
     table = _decode(sd_to_parquet_b64(sd))
     row = table.to_pydict()
     assert row['a__mean'] == [None]
 
 
 def test_none_serializes_as_null():
-    sd = {'col_a': {'mean': None, 'dtype': 'float64'}}
+    sd = {'a': {'mean': None, 'dtype': 'float64'}}
     table = _decode(sd_to_parquet_b64(sd))
     row = table.to_pydict()
     assert row['a__mean'] == [None]
@@ -156,7 +156,7 @@ def test_init_sd_reordering_preserves_short_col_keys():
 def test_categorical_histogram_round_trips():
     histogram = [{'name': 'foo', 'cat_pop': np.float64(40.0)}, {'name': 'bar', 'cat_pop': np.float64(35.0)},
         {'name': 'longtail', 'longtail': np.float64(15.0)}, {'name': 'unique', 'unique': np.float64(10.0)}]
-    sd = {'col': {'histogram': histogram, 'dtype': 'object'}}
+    sd = {'a': {'histogram': histogram, 'dtype': 'object'}}
     table = _decode(sd_to_parquet_b64(sd))
     parsed = json.loads(table.to_pydict()['a__histogram'][0])
     assert parsed[0] == {'name': 'foo', 'cat_pop': 40.0}
@@ -166,7 +166,7 @@ def test_categorical_histogram_round_trips():
 
 def test_single_row_layout():
     """Wide layout writes exactly one row regardless of stat count."""
-    sd = {'col_a': {'mean': 1.0, 'min': 0.0, 'max': 2.0, 'dtype': 'float64'}}
+    sd = {'a': {'mean': 1.0, 'min': 0.0, 'max': 2.0, 'dtype': 'float64'}}
     table = _decode(sd_to_parquet_b64(sd))
     assert table.num_rows == 1
 
@@ -189,7 +189,7 @@ def test_uint64_max_does_not_raise():
     serialization would crash instead of degrading gracefully.
     """
     big = np.uint64(2**63 + 7)  # one past int64 max
-    sd = {'col_a': {'max': big, 'dtype': 'uint64'}}
+    sd = {'a': {'max': big, 'dtype': 'uint64'}}
     result = sd_to_parquet_b64(sd)
     # Either the wide parquet path or the JSON fallback is acceptable — both
     # are graceful. What's not acceptable is raising.
@@ -199,7 +199,7 @@ def test_uint64_max_does_not_raise():
 def test_uint64_max_round_trips_in_wide_layout():
     """uint64 stats survive the wide parquet round-trip via pa.uint64()."""
     big = np.uint64(2**63 + 7)
-    sd = {'col_a': {'max': big, 'dtype': 'uint64'}}
+    sd = {'a': {'max': big, 'dtype': 'uint64'}}
     table = _decode(sd_to_parquet_b64(sd))
     schema = {f.name: str(f.type) for f in table.schema}
     assert schema['a__max'] == 'uint64'
@@ -213,7 +213,7 @@ def test_negative_int_beyond_int64_falls_back_to_json_string():
     is the safest universal fallback (precision is JS's problem at that point).
     """
     huge_neg = -(2**70)
-    sd = {'col_a': {'min': huge_neg, 'dtype': 'int64'}}
+    sd = {'a': {'min': huge_neg, 'dtype': 'int64'}}
     table = _decode(sd_to_parquet_b64(sd))
     schema = {f.name: str(f.type) for f in table.schema}
     assert schema['a__min'] == 'string'

--- a/tests/unit/test_sd_to_parquet_b64.py
+++ b/tests/unit/test_sd_to_parquet_b64.py
@@ -100,15 +100,57 @@ def test_none_serializes_as_null():
     assert row['a__mean'] == [None]
 
 
-def test_multiple_columns_get_short_name_prefix():
-    """Column names follow the to_chars() rename: first col is 'a', second 'b'."""
-    sd = {'x': {'mean': np.float64(1.0), 'dtype': 'float64'}, 'y': {'mean': np.float64(2.0), 'dtype': 'int64'}}
+def test_multiple_columns_use_provided_short_names():
+    """``sd_to_parquet_b64`` is called with an SD already keyed by the
+    pipeline-rewritten short col names ('a', 'b', ...). Keys must
+    pass through unchanged: ``sd['a']`` ends up at parquet col
+    ``a__mean``, not re-mapped by enumeration position. (The previous
+    behaviour re-keyed by position and silently mis-aligned every
+    column whenever ``sd.keys()`` arrived in non-positional order —
+    e.g. when ``init_sd`` injected an override before the raw scope's
+    insertion, see ``test_init_sd_reordering_preserves_short_col_keys``.)
+    """
+    sd = {'a': {'mean': np.float64(1.0), 'dtype': 'float64'}, 'b': {'mean': np.float64(2.0), 'dtype': 'int64'}}
     table = _decode(sd_to_parquet_b64(sd))
     row = table.to_pydict()
     assert row['a__mean'] == [1.0]
     assert row['b__mean'] == [2.0]
     assert json.loads(row['a__dtype'][0]) == 'float64'
     assert json.loads(row['b__dtype'][0]) == 'int64'
+
+
+def test_init_sd_reordering_preserves_short_col_keys():
+    """Real-world misalignment from PolarsBuckarooInfiniteWidget with
+    ``init_sd`` overrides: ``_merged_sd`` builds its result by
+    iterating ``rewritten_init_sd`` first and ``raw_sd`` after — so an
+    override on column 'b' (e.g. ``comments``) lands in ``merged_sd``
+    BEFORE the bare 'a' entry from the raw scope. ``merged_sd.keys()``
+    becomes ``['b', 'a', 'c', ...]``.
+
+    The previous ``sd_to_parquet_b64`` reassigned short_col by
+    enumeration position, so the value under ``sd['b']`` (comments'
+    histogram) ended up at parquet column ``a__histogram``. The grid's
+    column_config maps 'a' to the FIRST df column (businessname), so
+    AG-Grid rendered comments' histogram under the businessname slot
+    and vice versa — exactly the alignment bug the user reported.
+
+    Contract: keys are short col names already, pass them through.
+    """
+    sd_with_swapped_order = {'b': {'orig_col_name': 'comments', 'histogram': 'COMMENTS_HIST'},
+        'a': {'orig_col_name': 'businessname', 'histogram': 'BIZ_HIST'},
+        'c': {'orig_col_name': 'violation', 'histogram': 'VIOL_HIST'}}
+    table = _decode(sd_to_parquet_b64(sd_with_swapped_order))
+    row = table.to_pydict()
+    assert json.loads(row['a__histogram'][0]) == 'BIZ_HIST', (
+        f"sd['a'] (businessname) must end up at parquet col 'a__histogram'; "
+        f"got {row.get('a__histogram')!r} (likely got re-keyed by iteration "
+        f"position, putting sd['b']'s value here)"
+    )
+    assert json.loads(row['b__histogram'][0]) == 'COMMENTS_HIST', (
+        f"sd['b'] (comments) must end up at parquet col 'b__histogram'; "
+        f"got {row.get('b__histogram')!r}"
+    )
+    assert json.loads(row['c__histogram'][0]) == 'VIOL_HIST'
 
 
 def test_categorical_histogram_round_trips():


### PR DESCRIPTION
## Summary

Fixes a column-alignment bug a user hit on ``PolarsBuckarooInfiniteWidget`` with ``init_sd`` overrides on the boston restaurant data: the histogram pinned row under the ``comments`` column rendered ``businessname``'s histogram, and vice versa.

## Root cause

``_merged_sd`` (in ``dataflow.py``) builds its result by iterating ``rewritten_init_sd`` first and ``raw_sd`` after — so an override on column ``b`` (e.g. ``comments``) lands ahead of the bare ``a`` entry from the raw scope. ``merged_sd.keys()`` ends up ``['b', 'a', 'c', ...]`` instead of ``['a', 'b', 'c', ...]``.

``sd_to_parquet_b64`` then re-assigned short col names by **enumeration position** (``to_chars(i)``), so the value under ``sd['b']`` (comments) landed at parquet column ``a__histogram``. The grid's ``column_config`` still mapped short col ``a`` to the first df column (businessname), so AG-Grid rendered comments' histogram in the businessname slot and businessname's histogram in the comments slot.

## Fix

Drop the position-based rename. ``sd_to_parquet_b64`` iterates ``sd.items()`` directly — the keys arriving at this function are already the pipeline-rewritten short col names. Every caller in the codebase (``DfStatsV2`` / ``XorqDfStatsV2`` / ``merged_sd``) produces short-name keys via ``old_col_new_col``.

## Test plan

- [x] Failing-test commit (``bc2473a4``) pushed first; CI sees ``test_init_sd_reordering_preserves_short_col_keys`` red. A few legacy tests that documented the over-eager rewrite (``test_multiple_columns_get_short_name_prefix`` etc.) flip in the same commit since the contract they encoded was never met by real callers.
- [x] Fix commit (``8d074f1b``) makes everything green.
- [x] Full ``tests/unit/`` suite green locally (1045 passed, 6 skipped) — including the consumer-side tests that round-trip ``all_stats`` (``artifact_test.py``, ``polars_basic_widget_test.py``, ``test_xorq_buckaroo_widget.py``).
- [ ] Verify in JupyterLab against the restaurant complaints notebook (column reorder + ``init_sd={'comments': {...}}``) that the histogram under ``comments`` is now comments' histogram, not businessname's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)