### PR TITLE
feat(server): load_project_post_processing_klasses + project_root on /load_expr

### DIFF
--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -351,6 +351,7 @@ class LoadExprHandler(tornado.web.RequestHandler):
             expr = xorq_loading.load_expr_build_dir(build_dir)
             extra_klasses = (
                 xorq_loading.load_project_stat_klasses(project_root)
+                + xorq_loading.load_project_post_processing_klasses(project_root)
                 if project_root else [])
             xorq_dataflow = xorq_loading.XorqServerDataflow(
                 expr, skip_main_serial=True, extra_klasses=extra_klasses)

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -34,9 +34,10 @@ class XorqServerDataflow(XorqDataflow):
     ``extra_klasses`` is an optional list of additional ``@stat()``-decorated
     functions (or ``ColAnalysis`` subclasses) to fold into ``analysis_klasses``
     at the per-instance level. ``LoadExprHandler.post`` uses it to inject
-    project-authored stats discovered under ``<project_root>/stats/*.py``;
-    the built-in xorq stats are kept first so collisions resolve to the
-    built-in.
+    project-authored stats discovered under ``<project_root>/stats/*.py``
+    and project-authored post-processing classes discovered under
+    ``<project_root>/post_processing/*.py``; the built-in xorq stats are
+    kept first so collisions resolve to the built-in.
     """
 
     sampling_klass = XorqInfiniteSampling
@@ -189,6 +190,107 @@ def _compile_project_stat(name: str, path: Path, stat_decorator, XorqColumn):
     compute.__name__ = name
     compute.__qualname__ = name
     return stat_decorator()(compute)
+
+
+# ---------------------------------------------------------------------------
+# project-authored post-processing (loaded from <project_root>/post_processing/*.py)
+# ---------------------------------------------------------------------------
+
+
+def load_project_post_processing_klasses(project_root) -> list:
+    """Scan ``<project_root>/post_processing/*.py`` and return wrapped
+    ``ColAnalysis`` subclasses for use as post-processing methods.
+
+    Each file must define a callable ``process(expr)`` returning either
+    a new ibis expression or a pandas DataFrame — the same shape
+    ``XorqDataflow.add_processing`` accepts at the widget API. The
+    function is wrapped in a ``ColAnalysis`` subclass with
+    ``post_processing_method = <filename_stem>`` and a
+    ``post_process_df`` classmethod that delegates to ``process``;
+    ``filter_analysis(analysis_klasses, "post_processing_method")``
+    in ``CustomizableDataflow`` then surfaces it through
+    ``post_processing_klasses`` and the ``buckaroo_options`` dropdown.
+
+    Files whose name starts with ``_`` are skipped (parking convention).
+    Errors in any one file are logged and the file is skipped — one
+    bad post-processor shouldn't keep the rest from loading.
+    """
+    pp_dir = Path(project_root) / "post_processing"
+    if not pp_dir.is_dir():
+        return []
+
+    klasses: list = []
+    for path in sorted(pp_dir.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        name = path.stem
+        if not name.isidentifier():
+            log.warning(
+                "project post_processing %s: filename stem is not a valid python identifier; skipping",
+                path)
+            continue
+        try:
+            wrapped = _compile_project_post_processing(name, path)
+        except Exception as e:
+            log.warning("project post_processing %s skipped: %s", path, e)
+            continue
+        klasses.append(wrapped)
+    return klasses
+
+
+def _compile_project_post_processing(name: str, path: Path):
+    """Read, exec, validate, and wrap one post-processing file into a
+    ``ColAnalysis`` subclass. Mirror of ``_compile_project_stat`` for
+    the post-processing channel: instead of an ``@stat()``-decorated
+    function, returns a class shaped like the ``DecoratedXorqProcessing``
+    that ``XorqDataflow.add_processing`` builds at runtime —
+    ``post_processing_method = <stem>`` and a ``post_process_df``
+    classmethod returning ``[process(expr), {}]``.
+    """
+    # Local import — ColAnalysis lives in the pluggable framework and
+    # only the post-processing path needs it from this module.
+    from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis  # noqa: PLC0415
+
+    source = path.read_text()
+    globs: dict = {"__builtins__": _safe_builtins()}
+    # Same ibis / xorq exposure as the stat loader so post-processors
+    # can reach beyond bare expression methods (literals, case().when(),
+    # xorq.deferred_read_parquet, etc.).
+    try:
+        from xorq.vendor import ibis as _ibis  # noqa: PLC0415
+        globs["ibis"] = _ibis
+    except ImportError:
+        pass
+    try:
+        import xorq.api as _xo  # noqa: PLC0415
+        globs["xorq"] = _xo
+    except ImportError:
+        pass
+
+    # Single shared namespace so top-level constants and helper
+    # functions are visible at call time — same Codex P1 hazard the
+    # stat loader documents.
+    exec(compile(source, str(path), "exec"), globs)
+
+    process = globs.get("process")
+    if not callable(process):
+        raise ValueError("no callable 'process' defined")
+
+    sig = inspect.signature(process)
+    params = list(sig.parameters.values())
+    if len(params) != 1:
+        raise ValueError(
+            f"process() must take exactly one parameter, got {len(params)}")
+
+    # Default-arg capture (`_f=process`) on the lambda binds the loaded
+    # process function at class-construction time so a later iteration
+    # of the loader loop can't shadow it via the outer ``process`` name.
+    return type(f"ProjectPostProcessing_{name}", (ColAnalysis,), {
+        "provides_defaults": {},
+        "post_processing_method": name,
+        "post_process_df": classmethod(
+            lambda kls, expr, _f=process: [_f(expr), {}]),
+    })
 
 
 def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,

--- a/tests/unit/server/test_project_post_processing.py
+++ b/tests/unit/server/test_project_post_processing.py
@@ -1,0 +1,202 @@
+"""Tests for ``load_project_post_processing_klasses`` — scan a project's
+``post_processing/<name>.py`` directory, exec each file with restricted
+globals, return ``ColAnalysis`` subclasses that drop into the same
+``analysis_klasses`` channel ``filter_analysis(..., "post_processing_method")``
+walks to populate ``post_processing_klasses``.
+
+The feature lets a host (e.g. pydata-app's MCP server) hand buckaroo
+runtime-authored post-processing functions without restarting the
+server or adding a new wire shape. The function in each file is named
+``process`` and takes one positional argument (the cleaned expression).
+
+Mirrors ``test_project_stats.py`` for the post-processing channel.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+xo = pytest.importorskip("xorq.api")
+
+from buckaroo.server.xorq_loading import (  # noqa: E402
+    load_project_post_processing_klasses)
+
+
+def test_returns_empty_when_post_processing_dir_missing(tmp_path: Path):
+    assert load_project_post_processing_klasses(tmp_path) == []
+
+
+def test_returns_empty_when_post_processing_dir_empty(tmp_path: Path):
+    (tmp_path / "post_processing").mkdir()
+    assert load_project_post_processing_klasses(tmp_path) == []
+
+
+def test_picks_up_one_post_processing_keyed_by_filename(tmp_path: Path):
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "head_three.py").write_text(
+        "def process(expr):\n"
+        "    return expr.limit(3)\n")
+    klasses = load_project_post_processing_klasses(tmp_path)
+    assert len(klasses) == 1
+    # The wrapped class carries the filename stem as its
+    # post_processing_method — the key filter_analysis builds the
+    # post_processing_klasses map with.
+    assert klasses[0].post_processing_method == "head_three"
+
+
+def test_skips_file_without_process(tmp_path: Path):
+    """A .py file that doesn't define process() is skipped, not raised —
+    one bad file shouldn't block the rest of the post-processors from
+    loading."""
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "no_process.py").write_text("x = 42\n")
+    (pp / "head_three.py").write_text(
+        "def process(expr): return expr.limit(3)\n")
+
+    klasses = load_project_post_processing_klasses(tmp_path)
+    names = sorted(k.post_processing_method for k in klasses)
+    assert names == ["head_three"]
+
+
+def test_skips_file_that_tries_to_import(tmp_path: Path):
+    """Restricted globals strip __builtins__ so ``import os`` (which
+    resolves through ``__import__``) fails at exec. The file is logged
+    and skipped; the rest of the dir loads. Matches the stat loader's
+    sandbox posture."""
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "evil.py").write_text(
+        "import os\n"
+        "def process(expr): return expr\n")
+    (pp / "head_three.py").write_text(
+        "def process(expr): return expr.limit(3)\n")
+
+    klasses = load_project_post_processing_klasses(tmp_path)
+    names = sorted(k.post_processing_method for k in klasses)
+    assert names == ["head_three"]
+
+
+def test_skips_underscore_prefixed_files(tmp_path: Path):
+    """Files starting with ``_`` (e.g. _disabled, _helpers) are not
+    treated as active post-processors — they let users park work-in-
+    progress without removing it from the project."""
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "_disabled.py").write_text(
+        "def process(expr): return expr\n")
+    (pp / "head_three.py").write_text(
+        "def process(expr): return expr.limit(3)\n")
+
+    klasses = load_project_post_processing_klasses(tmp_path)
+    names = sorted(k.post_processing_method for k in klasses)
+    assert names == ["head_three"]
+
+
+def test_loaded_post_processing_executes_against_an_ibis_expression(tmp_path: Path):
+    """End-to-end on the wrapped class: calling ``post_process_df`` with
+    a real ibis expression returns the transformed expression (or
+    DataFrame). This is the contract every entry in
+    ``post_processing_klasses`` satisfies."""
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "head_two.py").write_text(
+        "def process(expr): return expr.limit(2)\n")
+
+    klasses = load_project_post_processing_klasses(tmp_path)
+    assert len(klasses) == 1
+
+    table = xo.memtable({"a": [1, 2, 3, 4, 5]}, name="t")
+    new_expr, extra = klasses[0].post_process_df(table)
+    # extra_conf dict shape matches DecoratedXorqProcessing in
+    # xorq_buckaroo.py:209 — empty by default.
+    assert extra == {}
+    assert int(new_expr.count().execute()) == 2
+
+
+def test_loaded_post_processing_can_use_module_level_constant(tmp_path: Path):
+    """A module-level constant defined in the post-processing file must
+    be visible to ``process()`` when it runs. Same Codex P1 the stat
+    loader hits: separate globals/locals dicts at exec time put top-
+    level assignments into locals while ``process`` captures globals
+    as its ``__globals__`` — every call would NameError."""
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "head_n.py").write_text(
+        "N = 2\n"
+        "def process(expr): return expr.limit(N)\n")
+
+    klasses = load_project_post_processing_klasses(tmp_path)
+    assert len(klasses) == 1
+
+    table = xo.memtable({"a": [1, 2, 3, 4, 5]}, name="t")
+    new_expr, _extra = klasses[0].post_process_df(table)
+    assert int(new_expr.count().execute()) == 2
+
+
+def test_loaded_post_processing_can_use_module_level_helper(tmp_path: Path):
+    """Same Codex P1 in helper-function form: a top-level ``def`` in
+    the post-processing file must be callable from ``process()``."""
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "head_double.py").write_text(
+        "def _double(x):\n"
+        "    return x * 2\n"
+        "def process(expr): return expr.limit(_double(2))\n")
+
+    klasses = load_project_post_processing_klasses(tmp_path)
+    assert len(klasses) == 1
+
+    table = xo.memtable({"a": [1, 2, 3, 4, 5]}, name="t")
+    new_expr, _extra = klasses[0].post_process_df(table)
+    assert int(new_expr.count().execute()) == 4
+
+
+def test_dataflow_extra_klasses_includes_post_processing(tmp_path: Path):
+    """Project post-processing classes injected via XorqServerDataflow's
+    extra_klasses appear in ``post_processing_klasses`` (the dict the
+    dataflow's ``_compute_processed_result`` looks the method up in)
+    and in ``buckaroo_options['post_processing']`` (the list the UI
+    populates the dropdown from)."""
+    from buckaroo.server.xorq_loading import XorqServerDataflow
+
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "head_three.py").write_text(
+        "def process(expr): return expr.limit(3)\n")
+    extra = load_project_post_processing_klasses(tmp_path)
+    assert len(extra) == 1
+
+    expr = xo.memtable({"a": [1, 2, 3, 4, 5]}, name="t")
+    dataflow = XorqServerDataflow(
+        expr, skip_main_serial=True, extra_klasses=extra)
+
+    assert "head_three" in dataflow.post_processing_klasses
+    assert "head_three" in dataflow.buckaroo_options["post_processing"]
+
+
+def test_dataflow_actually_applies_project_post_processing(tmp_path: Path):
+    """End-to-end through the dataflow: set
+    ``post_processing_method = "<stem>"`` on an XorqServerDataflow
+    constructed with the loaded project klasses, and ``processed_df``
+    reflects the file's ``process()`` transformation. This is the
+    handler-to-pipeline path the feature exists to enable."""
+    from buckaroo.server.xorq_loading import XorqServerDataflow
+
+    pp = tmp_path / "post_processing"
+    pp.mkdir()
+    (pp / "head_two.py").write_text(
+        "def process(expr): return expr.limit(2)\n")
+    extra = load_project_post_processing_klasses(tmp_path)
+
+    expr = xo.memtable({"a": [1, 2, 3, 4, 5]}, name="t")
+    dataflow = XorqServerDataflow(
+        expr, skip_main_serial=True, extra_klasses=extra)
+    dataflow.post_processing_method = "head_two"
+
+    # processed_df is what window_to_parquet / handle_infinite_request_xorq
+    # read; if the post-processor is wired in correctly, the row count
+    # drops from 5 to 2.
+    assert int(dataflow.processed_df.count().execute()) == 2


### PR DESCRIPTION
## Summary

Mirrors #784 for the post-processing channel. Adds an optional second loader off the existing `project_root` field on `POST /load_expr`. When set, the server scans `<project_root>/post_processing/*.py` for `process(expr)` functions, wraps each in a `ColAnalysis` subclass keyed by filename stem, and folds them into the session's `analysis_klasses` alongside the project stats from #784. No new wire shape, no separate registration call — host-authored post-processing functions appear in `buckaroo_options['post_processing']` (the dropdown) on the next session load.

Surfaces in [pydata-app](https://github.com/paddymul/pydata-app) the same way #784 surfaced project stats.

## Shape per file

```python
# <project_root>/post_processing/head_three.py
def process(expr):
    return expr.limit(3)
```

The loader wraps this into a `ColAnalysis` subclass with `post_processing_method = "head_three"` plus a `post_process_df` classmethod that delegates to `process`. `filter_analysis(analysis_klasses, "post_processing_method")` in `CustomizableDataflow` then surfaces it via `post_processing_klasses` and `buckaroo_options['post_processing']` — exactly the same channel `XorqDataflow.add_processing` uses at the widget API today.

Conventions inherited from #784's stat loader:
- Files starting with `_` are skipped (WIP parking).
- Restricted globals (no `__import__` / `open` / `exec` / `eval`). Not a real sandbox; acceptable because the project owner is trusted.
- One bad file logs a warning and is skipped; the rest still load.
- Single shared exec namespace so module-level constants and helpers are visible from `process` at call time (Codex P1 from #784).

## Commits

- `d4d830ed` — failing tests in `tests/unit/server/test_project_post_processing.py` (11 cases mirroring `test_project_stats.py`). CI will record the red.
- `99b8e0a4` — implementation. `load_project_post_processing_klasses` + `_compile_project_post_processing` in `buckaroo/server/xorq_loading.py`; `LoadExprHandler.post` concats the new loader's output into `extra_klasses`. Tests go green.

## Test plan

- [x] 11/11 new tests pass locally on Python 3.13
- [x] Existing `test_project_stats.py` (11/11) and `test_load_expr.py` (5/5) still pass
- [x] Pre-existing `test_mcp_uvx_install.py::test_view_data_call` failure is also red on plain `main` (empty `standalone.js`, unrelated)
- [ ] CI green (pending push)

## Scope

Xorq backend only — same as #784. No pandas/polars path. A future PR could add the equivalent loader to `data_loading.py` if the use case shows up.

## Risk

Low. The new loader and the handler concat are additive — `project_root` was already optional and continues to be a no-op when absent. The class-level `_XORQ_ANALYSIS_KLASSES` is untouched; only the per-instance `analysis_klasses` is extended, so other sessions and direct widget usage are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)