### PR TITLE
fix(server): make polars optional; drop tauri-essentials extra

### DIFF
--- a/buckaroo/server/data_loading.py
+++ b/buckaroo/server/data_loading.py
@@ -1,8 +1,10 @@
 import os
 import traceback
 from io import BytesIO
+from typing import TYPE_CHECKING
 import pandas as pd
-import polars as pl
+if TYPE_CHECKING:
+    import polars as pl
 from buckaroo.serialization_utils import to_parquet, pd_to_obj, check_and_fix_df
 from buckaroo.df_util import old_col_new_col, to_chars
 
@@ -112,8 +114,9 @@ def handle_infinite_request_buckaroo(
             "error_info": traceback.format_exc()}, b"")
 
 
-def load_file_lazy(path: str) -> pl.LazyFrame:
+def load_file_lazy(path: str) -> "pl.LazyFrame":
     """Open a file as a Polars LazyFrame — no data read until sliced."""
+    import polars as pl
     ext = os.path.splitext(path)[1].lower()
     if ext in (".parquet", ".parq"):
         return pl.scan_parquet(path)
@@ -127,7 +130,8 @@ def load_file_lazy(path: str) -> pl.LazyFrame:
         raise ValueError(f"Unsupported file format for lazy loading: {ext}")
 
 
-def get_metadata_lazy(ldf: pl.LazyFrame, path: str) -> dict:
+def get_metadata_lazy(ldf: "pl.LazyFrame", path: str) -> dict:
+    import polars as pl
     schema = ldf.collect_schema()
     col_names = schema.names()
     col_dtypes = schema.dtypes()
@@ -136,7 +140,7 @@ def get_metadata_lazy(ldf: pl.LazyFrame, path: str) -> dict:
     return {"path": path, "rows": total_rows, "columns": columns}
 
 
-def get_display_state_lazy(ldf: pl.LazyFrame) -> tuple[dict, dict, dict]:
+def get_display_state_lazy(ldf: "pl.LazyFrame") -> tuple[dict, dict, dict]:
     """Return (display_state, orig_to_rw, rw_to_orig) for a lazy frame."""
     schema = ldf.collect_schema()
     col_names = schema.names()
@@ -163,9 +167,10 @@ def get_display_state_lazy(ldf: pl.LazyFrame) -> tuple[dict, dict, dict]:
     return display_state, orig_to_rw, rw_to_orig
 
 
-def handle_infinite_request_lazy(ldf: pl.LazyFrame, orig_to_rw: dict, rw_to_orig: dict, total_rows: int,
+def handle_infinite_request_lazy(ldf: "pl.LazyFrame", orig_to_rw: dict, rw_to_orig: dict, total_rows: int,
         payload_args: dict) -> tuple[dict, bytes]:
     """Serve an infinite-scroll slice from a Polars LazyFrame."""
+    import polars as pl
     from buckaroo.server.window import clamp_window
     # Clamp window against total_rows so end >> total doesn't ship
     # the entire LazyFrame in one parquet frame. See #797.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,11 +80,16 @@ dev = [
     "marimo>=0.19.7",
 ]
 polars = [
-    "polars",
     "polars>=1.24.0",
     "polars[timezone]",
     "pl-series-hash==0.2.1",
-    ]
+    # Server runtime (buckaroo.server) needs tornado + pandas; the dataflow
+    # pipeline is pandas-keyed even when input is polars. Bundling them here
+    # means `pip install 'buckaroo[polars]'` is enough to boot the sidecar.
+    "tornado>=6.0",
+    "pandas; python_version >= '3.13'",
+    "pandas>=1.3.5; python_version < '3.13'",
+]
 
 test = [
     "nbval>=0.9",
@@ -114,22 +119,14 @@ test = [
 # columns. Fixed in xorq-datafusion 0.2.7, shipped with xorq 0.3.25.
 xorq = [
     "xorq>=0.3.25 ; python_version < '3.14'",
-]
-mcp = ["mcp", "tornado>=6.0", "polars"]
-
-# Runtime deps the buckaroo.server sidecar needs to start under the
-# buckaroo-tauri integration. NOT the Tauri shim itself (that lives at
-# buckaroo-data/buckaroo-tauri) — this is the Python-side runtime its
-# README's `pip install buckaroo[tauri-essentials]` instruction depends
-# on. Top-level imports in buckaroo.server require tornado (HTTP + WS
-# server) and both pandas and polars (data_loading.py imports both
-# unconditionally).
-tauri-essentials = [
+    # Server runtime (buckaroo.server) — polars is no longer required to
+    # boot; pandas + tornado are. xorq drives the lazy path via its own
+    # parquet readers, so a polars-free xorq install is supported.
     "tornado>=6.0",
-    "polars>=1.24.0",
     "pandas; python_version >= '3.13'",
     "pandas>=1.3.5; python_version < '3.13'",
 ]
+mcp = ["mcp", "tornado>=6.0", "polars"]
 marimo = [
     "marimo>=0.19.7",
     "pandas; python_version >= '3.13'",

--- a/uv.lock
+++ b/uv.lock
@@ -292,13 +292,10 @@ packaging-tools = [
     { name = "twine" },
 ]
 polars = [
-    { name = "pl-series-hash" },
-    { name = "polars", extra = ["timezone"] },
-]
-tauri-essentials = [
     { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
-    { name = "polars" },
+    { name = "pl-series-hash" },
+    { name = "polars", extra = ["timezone"] },
     { name = "tornado" },
 ]
 test = [
@@ -317,6 +314,9 @@ test = [
     { name = "ruff" },
 ]
 xorq = [
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+    { name = "tornado" },
     { name = "xorq", marker = "python_full_version < '3.14'" },
 ]
 
@@ -379,20 +379,20 @@ requires-dist = [
     { name = "packaging", marker = "extra == 'test'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'dev'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'marimo'" },
-    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'tauri-essentials'" },
+    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'polars'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'test'" },
+    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'xorq'" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'marimo'", specifier = ">=1.3.5" },
-    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'tauri-essentials'", specifier = ">=1.3.5" },
+    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'polars'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'test'", specifier = ">=1.3.5" },
+    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'xorq'", specifier = ">=1.3.5" },
     { name = "pandera", marker = "extra == 'test'" },
     { name = "pl-series-hash", marker = "extra == 'dev'", specifier = "==0.2.1" },
     { name = "pl-series-hash", marker = "extra == 'polars'", specifier = "==0.2.1" },
     { name = "playwright", marker = "extra == 'dev'" },
     { name = "polars", marker = "extra == 'mcp'" },
-    { name = "polars", marker = "extra == 'polars'" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.24.0" },
-    { name = "polars", marker = "extra == 'tauri-essentials'", specifier = ">=1.24.0" },
     { name = "polars", extras = ["timezone"], marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "python_full_version < '3.13'", specifier = ">=18.0.0" },
     { name = "pyarrow", marker = "python_full_version == '3.13.*'" },
@@ -412,12 +412,13 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=1.5" },
     { name = "toml", marker = "extra == 'dev'" },
     { name = "tornado", marker = "extra == 'mcp'", specifier = ">=6.0" },
-    { name = "tornado", marker = "extra == 'tauri-essentials'", specifier = ">=6.0" },
+    { name = "tornado", marker = "extra == 'polars'", specifier = ">=6.0" },
+    { name = "tornado", marker = "extra == 'xorq'", specifier = ">=6.0" },
     { name = "twine", marker = "extra == 'packaging-tools'" },
     { name = "watchfiles", marker = "extra == 'dev'" },
     { name = "xorq", marker = "python_full_version < '3.14' and extra == 'xorq'", specifier = ">=0.3.25" },
 ]
-provides-extras = ["dev", "jupyterlab", "marimo", "mcp", "notebook", "packaging-tools", "polars", "tauri-essentials", "test", "xorq"]
+provides-extras = ["dev", "jupyterlab", "marimo", "mcp", "notebook", "packaging-tools", "polars", "test", "xorq"]
 
 [package.metadata.requires-dev]
 datacompy = [{ name = "datacompy", specifier = ">=0.15.0" }]


### PR DESCRIPTION
## Summary

- `buckaroo.server` no longer hard-imports `polars` — closes #754
- New extras layout: `[xorq]` (polars-free) and `[polars]` (server + lazy mode) each bundle everything needed to stand up the sidecar
- `[tauri-essentials]` removed; `pip install 'buckaroo[xorq]'` or `'buckaroo[polars]'` replaces it

## What was broken

`buckaroo/server/data_loading.py` had a top-level `import polars as pl`. Importing `buckaroo.server.app` (the first thing `python -m buckaroo.server` does) failed with:

```
ModuleNotFoundError: No module named 'polars'
```

…in any env that installed buckaroo without polars (xorq-only, pandas-only). The pandas/buckaroo-mode code path never touches polars; only the four `*_lazy` functions do.

## Fix

- Move `import polars as pl` from the top of `data_loading.py` into each of the four polars-using functions (`load_file_lazy`, `get_metadata_lazy`, `get_display_state_lazy`, `handle_infinite_request_lazy`)
- Quote the `pl.LazyFrame` type annotations; keep the import resolvable via `TYPE_CHECKING`
- Reshuffle extras so each backend's extra is sufficient on its own to boot the server (server needs `tornado + pandas`; lazy mode additionally needs `polars`)

## Test plan

- [x] Fresh venv + `pip install 'buckaroo[xorq]'` → `python -m buckaroo.server --no-browser --port 0` boots cleanly (no polars installed; prints `BUCKAROO_PORT=…`)
- [x] Fresh venv + `pip install 'buckaroo[polars]'` → full lazy path round-trips end-to-end on a real parquet:
  - `load_file_lazy` → `LazyFrame`
  - `get_metadata_lazy` → correct row count + dtypes
  - `get_display_state_lazy` → renamed-column maps
  - `handle_infinite_request_lazy` → 1072-byte parquet response on a 5-row slice
- [x] Pre-commit hooks (`paddy-format`) pass
- [ ] CI

## Downstream

xorq-desktop (`docs/buckaroo-integration.md`) currently lists `[buckaroo#754]` as a known limitation. Once this lands and a buckaroo release ships, xorq-desktop's `notebooks/pyproject.toml` should flip from `buckaroo[tauri-essentials]>=…` to `buckaroo[xorq]>=…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)