### PR TITLE
fix(js): SmartRowCache empty-result throw kills datasource (#836)

### DIFF
--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.test.ts
@@ -850,4 +850,62 @@ describe('KeyAwareSmartRowCache tests', () => {
         expect(Object.keys(aData[0])).not.toContain("B_col");
     });
 
+    test('KeyAwareSmartRowCache empty-result search does not throw on re-request (#836)', () => {
+        // Search returns zero rows. AG-Grid re-renders and asks again for the
+        // same (now empty) source key. Before the fix, SmartRowCache.hasRows
+        // recursed to [0,0] against a [[0,0]] empty segment, lied "true", and
+        // SmartRowCache.getRows fell into getRange with an empty cache and threw
+        // "RequestSeg {requestSeg} not in {segments}" -- killing the datasource.
+        let src: KeyAwareSmartRowCache;
+        const mockRequestFn = jest.fn((pa: PayloadArgs) => {
+            const resp: PayloadResponse = { key: pa, data: [], length: 0 };
+            src.addPayloadResponse(resp);
+        });
+        src = new KeyAwareSmartRowCache(mockRequestFn);
+
+        const pa1: PayloadArgs = { sourceName: "empty-search", start: 0, end: 100, origEnd: 100 };
+        const cb1 = jest.fn();
+        const failCb1 = jest.fn();
+        src.getRequestRows(pa1, cb1, failCb1);
+        // The first request: verifyResp routes a length:0 response to failCb.
+        expect(failCb1).toHaveBeenCalledTimes(1);
+        expect(cb1).not.toHaveBeenCalled();
+
+        // The grid re-asks for the same range. This must NOT throw.
+        const pa2: PayloadArgs = { sourceName: "empty-search", start: 0, end: 100, origEnd: 100 };
+        const cb2 = jest.fn();
+        const failCb2 = jest.fn();
+        expect(() => {
+            src.getRequestRows(pa2, cb2, failCb2);
+        }).not.toThrow();
+        // No rows exist, so success must not have been called.
+        expect(cb2).not.toHaveBeenCalled();
+    });
+
+    test('SmartRowCache.hasRows on empty cache reports miss, not "true" (#836)', () => {
+        // Direct unit-level repro: after a zero-row response, segments may
+        // contain a zero-width [s,s] sentinel and sentLength === 0. hasRows
+        // for any positive-width range MUST report a cache miss (a RowRequest),
+        // not `true`, otherwise getRows would fall into getRange and throw.
+        const src = new SmartRowCache();
+        src.sentLength = 0;
+        src.addRows([0, 0], []);
+        expect(src.hasRows([0, 100])).not.toBe(true);
+    });
+
+    test('getRange throw message interpolates requestSeg and segments (#836)', () => {
+        // Secondary bug: the throw template used literal `{...}` instead of
+        // `${...}`, suppressing diagnostics for this whole class of failure.
+        const seg10: SegData = [[0, 10], genRows(0, 10)[1]];
+        let caught: Error | undefined;
+        try {
+            getRange([seg10[0]], [seg10[1]], [50, 60]);
+        } catch (e) {
+            caught = e as Error;
+        }
+        expect(caught).toBeDefined();
+        expect(caught!.message).not.toContain("{requestSeg}");
+        expect(caught!.message).not.toContain("{segments}");
+    });
+
 });

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts
@@ -228,7 +228,7 @@ export const getRange = (segments: Segment[], dfs: DFData[], requestSeg: Segment
             return getSliceRange(seg, df, requestSeg);
         }
     }
-    throw new Error(`RequestSeg {requestSeg} not in {segments}`)
+    throw new Error(`RequestSeg ${JSON.stringify(requestSeg)} not in ${JSON.stringify(segments)}`)
 }
 
 export const segmentsSize = (segments: Segment[]): number => {
@@ -422,6 +422,13 @@ export class SmartRowCache {
         if(needSeg[0] === 0 && needSeg[1] === 0) {
             console.warn("[SmartRowCache.hasRows] needSeg=[0,0] is unexpected")
         }
+        // Dataset is known empty (sentLength === 0). Any positive-width
+        // request is unsatisfiable; without this short-circuit the recursion
+        // below collapses to hasRows([0,0]), which matches the [[0,0]]
+        // sentinel reflexively and falsely reports a hit (#836).
+        if (this.sentLength === 0 && needSeg[1] > needSeg[0]) {
+            return { start: needSeg[0], end: needSeg[1] }
+        }
 	if (this.sentLength > -1 && needSeg[1] > this.sentLength) {
 	    const newSeg:Segment = [needSeg[0], this.sentLength]
 	    return this.hasRows(newSeg)
@@ -436,6 +443,11 @@ export class SmartRowCache {
     }
 
     public getRows(range: Segment): DFData {
+        if (this.sentLength === 0) {
+            // dataset is empty; nothing to clamp toward
+            console.error("[SmartRowCache.getRows] empty dataset, requested", range);
+            throw new Error(`Missing rows for ${JSON.stringify(range)}: dataset is empty (sentLength === 0)`)
+        }
         if (this.sentLength > 0 && range[1] > this.sentLength) {
             return this.getRows([range[0], this.sentLength]);
         }
@@ -447,7 +459,7 @@ export class SmartRowCache {
             return getRange(this.segments, this.dfs, range)
         }
         console.error("[SmartRowCache.getRows] Missing rows error. range", range, "extents", this.safeGetExtents(), "segments", this.segments, "sentLength", this.sentLength);
-        throw new Error(`Missing rows for {range}`)
+        throw new Error(`Missing rows for ${JSON.stringify(range)}`)
     }
 }
 
@@ -616,12 +628,17 @@ export class KeyAwareSmartRowCache {
         //const preExtents = src.safeGetExtents()
 
         src.sentLength = resp.length;
-	if(resp.data.length < (seg[1] - seg[0])) {
-	    const actualSeg: Segment = [resp.key.start, resp.key.start + resp.data.length];
-            src.addRows(actualSeg, resp.data)
-	} else {
-            src.addRows(seg, resp.data)
-	}
+        // Skip addRows entirely for empty responses — adding a zero-width
+        // [start, start] segment would pollute the cache and trip a
+        // reflexive segmentSubset hit on the next hasRows() call (#836).
+        if (resp.data.length > 0) {
+            if(resp.data.length < (seg[1] - seg[0])) {
+                const actualSeg: Segment = [resp.key.start, resp.key.start + resp.data.length];
+                src.addRows(actualSeg, resp.data)
+            } else {
+                src.addRows(seg, resp.data)
+            }
+        }
         if (_.has(this.waitingCallbacks, cbKey)) {
             const [success, fail] = this.waitingCallbacks[cbKey];
             if(verifyResp(resp)) {


### PR DESCRIPTION
## Summary

Closes #836.

When a search (or any filter) reduces a source to **zero rows**, the next
`getRows` request from AG-Grid synchronously throws
`Error: RequestSeg {requestSeg} not in {segments}` out of
`SmartRowCache.getRange`. The datasource is left dead — the grid renders
blank and ignores further scroll/refresh until the source key changes.

Three interacting bugs in `packages/buckaroo-js-core/src/components/DFViewerParts/SmartRowCache.ts`:

1. `SmartRowCache.hasRows` recurses to `hasRows([0, 0])` when
   `needSeg[1] > sentLength === 0`, then returns `true` because
   `segmentSubset([0,0], [0,0])` is reflexively true — the cache lies
   about holding data it doesn't have.
2. `SmartRowCache.getRows` clamps `range[1] > sentLength` only when
   `sentLength > 0` (off-by-one), so `sentLength === 0` skips the clamp
   and falls into `getRange` with empty segments.
3. The throw at `getRange` uses literal `{requestSeg}` / `{segments}` —
   the placeholders were never interpolated, suppressing diagnostics for
   this whole class of failure.

`addPayloadResponse` also pollutes the cache by adding a zero-width
`[start, start]` segment for empty responses, which sets the trap that
trips on the *second* request.

## Bug introduction

- Literal template + empty-cache poisoning: introduced in **b110d619**
  (PR #353, "Feat/fix polars analysis", 2025-03-12) — the original
  SmartRowCache landing.
- `sentLength > 0` off-by-one clamp: introduced in **5f209624**
  (PR #483, "Fix blank rows when scrolling small DataFrames",
  2026-02-17), which preserved the `sentLength !== 0` guard while
  reshuffling the clamp logic.

## TDD

This PR is split test-first → fix per repo convention:
- Commit 1 (this commit) adds three failing jest tests.
- Commit 2 (coming) applies the SmartRowCache fix.

## Test plan
- [ ] CI shows the new tests failing on commit 1 (this commit)
- [ ] CI shows the full suite green after the fix commit
- [ ] Manual repro from #836 (search with zero matches) no longer
      kills the datasource

🤖 Generated with [Claude Code](https://claude.com/claude-code)