### PR TITLE
fix(server): plumb search_string through row-fetch dispatch (#838)

### DIFF
--- a/buckaroo/server/data_loading.py
+++ b/buckaroo/server/data_loading.py
@@ -83,31 +83,40 @@ def get_buckaroo_display_state(dataflow: ServerDataflow) -> dict:
 
 
 def handle_infinite_request_buckaroo(
-    dataflow: ServerDataflow, payload_args: dict
+    dataflow: ServerDataflow, payload_args: dict, search_string: str = ""
 ) -> tuple[dict, bytes]:
-    """Infinite scroll handler using the dataflow's processed_df and merged_sd."""
+    """Infinite scroll handler using the dataflow's processed_df and merged_sd.
+
+    ``search_string`` (#838) is a live-typing filter applied here on top
+    of ``processed_df``; it intentionally bypasses the dataflow's
+    ``quick_command_args.search`` path so per-keystroke edits don't
+    invalidate the stats pipeline.
+    """
     from buckaroo.server.window import clamp_window
+    from buckaroo.customizations.pandas_commands import search_df_str
     _unused, processed_df, merged_sd = dataflow.widget_args_tuple
     if processed_df is None:
         return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0}, b"")
-    # Clamp window against the (post-filter) processed_df size — see #797.
-    start, end = clamp_window(
-        payload_args.get("start"), payload_args.get("end"), len(processed_df))
-
     try:
+        filtered_df = search_df_str(processed_df, search_string) if search_string else processed_df
+        # Clamp window against the *filtered* size so a search that
+        # shrinks the result set doesn't ship an oversized window.
+        start, end = clamp_window(
+            payload_args.get("start"), payload_args.get("end"), len(filtered_df))
+
         sort = payload_args.get("sort")
         if sort:
             ascending = payload_args.get("sort_direction") == "asc"
             # merged_sd maps renamed col -> stats dict with 'orig_col_name'
             converted_sort_column = merged_sd[sort]["orig_col_name"]
-            sorted_df = processed_df.sort_values(
+            sorted_df = filtered_df.sort_values(
                 by=[converted_sort_column], ascending=ascending)
             slice_df = sorted_df[start:end]
         else:
-            slice_df = processed_df[start:end]
+            slice_df = filtered_df[start:end]
 
         parquet_bytes = to_parquet(slice_df)
-        msg = {"type": "infinite_resp", "key": payload_args, "data": [], "length": len(processed_df)}
+        msg = {"type": "infinite_resp", "key": payload_args, "data": [], "length": len(filtered_df)}
         return msg, parquet_bytes
     except Exception:
         return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0,

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -242,6 +242,11 @@ class LoadHandler(tornado.web.RequestHandler):
         session.backend = "pandas"
         session.xorq_dataflow = None
         session.expr = None
+        # Reset the live-typed row-fetch filter so a search term carried
+        # over from a prior dataset on this session doesn't silently
+        # filter the new one (Codex P1 on #839). The client's fresh
+        # buckaroo_state has search_string="" — keep the server in sync.
+        session.search_string = ""
         session.prompt = prompt
         if component_config:
             session.component_config = component_config
@@ -383,6 +388,9 @@ class LoadExprHandler(tornado.web.RequestHandler):
         session.df = None
         session.dataflow = None
         session.ldf = None
+        # Reset the live-typed row-fetch filter so a prior term doesn't
+        # silently filter the freshly loaded expression (Codex P1 on #839).
+        session.search_string = ""
         session.metadata = metadata
         session.prompt = prompt
         if component_config:

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -33,6 +33,11 @@ class SessionState:
     xorq_dataflow: Any = None  # XorqServerDataflow when backend="xorq"
     expr: Any = None  # ibis/xorq expression when backend="xorq"
     buckaroo_state: dict = field(default_factory=dict)
+    # Live search term applied at row-fetch time (#838) — bypasses the
+    # dataflow stat pipeline that ``quick_command_args.search`` goes
+    # through, so per-keystroke filtering stays fast on parquet-backed
+    # exprs with ~10⁶ rows.
+    search_string: str = ""
     buckaroo_options: dict = field(default_factory=dict)
     command_config: dict = field(default_factory=dict)
     operation_results: dict = field(default_factory=dict)

--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -10,10 +10,10 @@ from buckaroo.server.data_loading import (handle_infinite_request, handle_infini
 from buckaroo.server.session import build_state_message
 
 
-def _handle_infinite_request_xorq(xorq_dataflow, payload_args):
+def _handle_infinite_request_xorq(xorq_dataflow, payload_args, search_string=""):
     """Lazy delegate so the server stays importable without buckaroo[xorq]."""
     from buckaroo.server.xorq_loading import handle_infinite_request_xorq
-    return handle_infinite_request_xorq(xorq_dataflow, payload_args)
+    return handle_infinite_request_xorq(xorq_dataflow, payload_args, search_string=search_string)
 
 
 log = logging.getLogger("buckaroo.server.websocket")
@@ -21,7 +21,10 @@ log = logging.getLogger("buckaroo.server.websocket")
 _BUCKAROO_DEBUG = os.environ.get("BUCKAROO_DEBUG", "").lower() in ("1", "true")
 
 # Fields in buckaroo_state that drive dataflow changes; others are ignored.
-_DATAFLOW_FIELDS = ("post_processing", "cleaning_method", "quick_command_args")
+# search_string lives here too — it doesn't touch the dataflow itself but
+# the row-fetch dispatch reads ``session.search_string`` and applies a
+# literal-contains filter before paginating (#838).
+_DATAFLOW_FIELDS = ("post_processing", "cleaning_method", "quick_command_args", "search_string")
 
 
 class DataStreamHandler(tornado.websocket.WebSocketHandler):
@@ -76,6 +79,12 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
                 dataflow.cleaning_method = new_state.get("cleaning_method", "")
             if old_state.get("quick_command_args") != new_state.get("quick_command_args"):
                 dataflow.quick_command_args = new_state.get("quick_command_args", {})
+            # search_string is stored on the session — the row-fetch
+            # dispatch reads it instead of pushing it into the dataflow
+            # (#838). Coerce non-string to "" so a malformed payload can't
+            # crash the filter helpers downstream.
+            new_search = new_state.get("search_string", "")
+            session.search_string = new_search if isinstance(new_search, str) else ""
 
             # Re-extract state from the dataflow — same helper works for both
             # ServerDataflow and XorqServerDataflow (verified by probe).
@@ -122,13 +131,19 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             return
 
         def _dispatch(pa):
+            # search_string is the per-session live-typed filter (#838) —
+            # passed alongside payload_args rather than mixed into it so
+            # the WS-level row-fetch contract (start/end/sort) stays
+            # untouched and each backend can apply the filter in its
+            # native expression layer.
+            search = session.search_string or ""
             if session.mode == "lazy" and session.ldf is not None:
                 return handle_infinite_request_lazy(session.ldf, session.orig_to_rw,
                     session.rw_to_orig, session.metadata.get("rows", 0), pa)
             if session.mode == "buckaroo" and session.backend == "xorq" and session.xorq_dataflow:
-                return _handle_infinite_request_xorq(session.xorq_dataflow, pa)
+                return _handle_infinite_request_xorq(session.xorq_dataflow, pa, search_string=search)
             if session.mode == "buckaroo" and session.dataflow:
-                return handle_infinite_request_buckaroo(session.dataflow, pa)
+                return handle_infinite_request_buckaroo(session.dataflow, pa, search_string=search)
             return handle_infinite_request(session.df, pa)
 
         try:

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -294,19 +294,24 @@ def _compile_project_post_processing(name: str, path: Path):
 
 
 def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,
-        payload_args: dict) -> tuple[dict, bytes]:
+        payload_args: dict, search_string: str = "") -> tuple[dict, bytes]:
     """Drive one infinite_request window against a xorq expression.
 
     Reads the current ``processed_df`` (the expression, post-filter)
-    from ``widget_args_tuple``, calls the shared
-    ``window_to_parquet`` helper, and returns the
+    from ``widget_args_tuple``, optionally applies a live ``search_string``
+    contains-filter on top (#838 — keeps per-keystroke edits off the
+    stat pipeline that ``quick_command_args.search`` triggers), then
+    delegates to ``window_to_parquet`` and returns the
     ``(json_msg, parquet_bytes)`` pair the WebSocket handler ships as
     a text + binary frame pair (matching the pandas/polars paths)."""
+    from buckaroo.customizations.xorq_commands import search_expr
     _unused, processed_df, merged_sd = xorq_dataflow.widget_args_tuple
     if processed_df is None:
         return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0}, b"")
 
     try:
+        filtered_expr = search_expr(processed_df, search_string) if search_string else processed_df
+
         sort = payload_args.get("sort")
         sort_col = None
         ascending = True
@@ -314,13 +319,13 @@ def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,
             sort_col = merged_sd[sort]["orig_col_name"]
             ascending = payload_args.get("sort_direction") == "asc"
 
-        total_length = _expr_count(processed_df)
+        total_length = _expr_count(filtered_expr)
         # Clamp the request window to a bounded slice — protects
         # against ``end >> total_rows`` requests that would otherwise
         # ship the entire table in a single WS frame. See #797.
         start, end = clamp_window(
             payload_args.get("start"), payload_args.get("end"), total_length)
-        parquet_bytes = window_to_parquet(processed_df, start, end, sort_col, ascending)
+        parquet_bytes = window_to_parquet(filtered_expr, start, end, sort_col, ascending)
         return ({"type": "infinite_resp", "key": payload_args, "data": [],
             "length": total_length}, parquet_bytes)
     except Exception:

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -230,6 +230,61 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             shutil.rmtree(builds_root, ignore_errors=True)
 
     @tornado.testing.gen_test
+    async def test_search_string_resets_on_load_expr_reuse(self):
+        """Codex P1 (#839): session.search_string must be cleared when
+        /load_expr replaces data on an existing session. Otherwise the
+        stale term silently filters the newly loaded dataset even though
+        the rebroadcast buckaroo_state shows an empty search box.
+
+        Repro: set search_string="alpha" (filters to 4 rows), then
+        /load_expr the same fixture again on the same session id. The
+        next infinite_request must return length=10, not 4."""
+        builds_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            sid = "lx-search-reuse"
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": sid, "build_dir": build_path})
+
+            ws = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+            await ws.read_message()
+
+            # Type a search term — filters to 4 rows.
+            ws.write_message(json.dumps({
+                "type": "buckaroo_state_change",
+                "new_state": {
+                    "post_processing": "", "cleaning_method": "",
+                    "quick_command_args": {}, "df_display": "main",
+                    "show_commands": False, "sampled": False,
+                    "search_string": "alpha"}}))
+            await ws.read_message()
+            ws.close()
+
+            # Reload the dataset on the same session. The client's view
+            # of buckaroo_state will be fresh (search_string=""), so the
+            # server's must also be — else the row fetch silently filters.
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": sid, "build_dir": build_path})
+
+            ws2 = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+            await ws2.read_message()
+
+            ws2.write_message(json.dumps({
+                "type": "infinite_request",
+                "payload_args": {"start": 0, "end": 10,
+                    "sourceName": "default", "origEnd": 10}}))
+            r = json.loads(await ws2.read_message())
+            self.assertEqual(r["length"], 10,
+                f"stale search_string carried across /load_expr — "
+                f"expected 10 rows, got {r['length']}")
+            await ws2.read_message()  # binary
+            ws2.close()
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
     async def test_ws_infinite_request_clamps_oversized_window(self):
         """Regression for #797: a request with ``end >> total_rows``
         must clamp to ``MAX_INFINITE_WINDOW``. Pre-fix the xorq path

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -142,6 +142,94 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             shutil.rmtree(builds_root, ignore_errors=True)
 
     @tornado.testing.gen_test
+    async def test_ws_search_string_rowfetch(self):
+        """Regression for #838: a ``buckaroo_state_change`` carrying only
+        ``search_string`` (no ``quick_command_args.search``) must filter
+        the row-fetch dispatch. The search_string path is the fast lane
+        for live typing — it sidesteps the dataflow stat pipeline, which
+        is too slow for ~10⁶-row parquet-backed exprs in pydata-app.
+
+        Fixture has `alpha` in 4 of 10 rows; ``length`` must drop to 4.
+        """
+        builds_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": "lx-search", "build_dir": build_path})
+
+            ws = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/lx-search")
+            await ws.read_message()  # discard initial_state
+
+            ws.write_message(json.dumps({
+                "type": "buckaroo_state_change",
+                "new_state": {
+                    "post_processing": "",
+                    "cleaning_method": "",
+                    "quick_command_args": {},
+                    "df_display": "main",
+                    "show_commands": False,
+                    "sampled": False,
+                    "search_string": "alpha",
+                }}))
+            await ws.read_message()  # discard rebroadcast initial_state
+
+            ws.write_message(json.dumps({
+                "type": "infinite_request",
+                "payload_args": {"start": 0, "end": 10,
+                    "sourceName": "default", "origEnd": 10}}))
+
+            r = json.loads(await ws.read_message())
+            self.assertEqual(r["type"], "infinite_resp")
+            self.assertEqual(r["length"], 4)
+
+            binary_frame = await ws.read_message()
+            table = pq.read_table(io.BytesIO(binary_frame))
+            self.assertEqual(table.num_rows, 4)
+
+            ws.close()
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
+    async def test_ws_search_string_cleared_returns_full_set(self):
+        """Clearing search_string (sending ``""``) must restore the full
+        row count. Mirrors the JS contract: an empty search box sends an
+        empty term on every keystroke after clear."""
+        builds_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": "lx-search-clear", "build_dir": build_path})
+
+            ws = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/lx-search-clear")
+            await ws.read_message()
+
+            for term, expected in (("alpha", 4), ("", 10)):
+                ws.write_message(json.dumps({
+                    "type": "buckaroo_state_change",
+                    "new_state": {
+                        "post_processing": "", "cleaning_method": "",
+                        "quick_command_args": {}, "df_display": "main",
+                        "show_commands": False, "sampled": False,
+                        "search_string": term}}))
+                await ws.read_message()
+
+                ws.write_message(json.dumps({
+                    "type": "infinite_request",
+                    "payload_args": {"start": 0, "end": 10,
+                        "sourceName": "default", "origEnd": 10}}))
+                r = json.loads(await ws.read_message())
+                self.assertEqual(r["length"], expected,
+                    f"search_string={term!r} expected length={expected}, got {r['length']}")
+                await ws.read_message()  # binary frame
+
+            ws.close()
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
     async def test_ws_infinite_request_clamps_oversized_window(self):
         """Regression for #797: a request with ``end >> total_rows``
         must clamp to ``MAX_INFINITE_WINDOW``. Pre-fix the xorq path

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -342,6 +342,45 @@ class TestWebSocket(tornado.testing.AsyncHTTPTestCase):
                 os.unlink(f.name)
 
     @tornado.testing.gen_test
+    async def test_ws_search_string_pandas_buckaroo(self):
+        """Regression for #838: ``search_string`` set via state_change
+        must filter the pandas-buckaroo row-fetch dispatch. Fixture has
+        5 rows; "Alice" appears 1x, so length drops to 1."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                await _async_fetch(self.get_http_port(), "/load",
+                    method="POST",
+                    body=json.dumps({"session": "ws-search", "path": f.name,
+                        "mode": "buckaroo"}))
+
+                ws = await tornado.websocket.websocket_connect(
+                    f"ws://localhost:{self.get_http_port()}/ws/ws-search")
+                await ws.read_message()
+
+                ws.write_message(json.dumps({
+                    "type": "buckaroo_state_change",
+                    "new_state": {
+                        "post_processing": "", "cleaning_method": "",
+                        "quick_command_args": {}, "df_display": "main",
+                        "show_commands": False, "sampled": False,
+                        "search_string": "Alice"}}))
+                await ws.read_message()
+
+                ws.write_message(json.dumps({
+                    "type": "infinite_request",
+                    "payload_args": {"start": 0, "end": 5,
+                        "sourceName": "default", "origEnd": 5}}))
+                r = json.loads(await ws.read_message())
+                self.assertEqual(r["type"], "infinite_resp")
+                self.assertEqual(r["length"], 1)
+                await ws.read_message()  # binary frame
+
+                ws.close()
+            finally:
+                os.unlink(f.name)
+
+    @tornado.testing.gen_test
     async def test_ws_request_no_data_loaded(self):
         ws = await tornado.websocket.websocket_connect(
             f"ws://localhost:{self.get_http_port()}/ws/no-data-session")

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -381,6 +381,58 @@ class TestWebSocket(tornado.testing.AsyncHTTPTestCase):
                 os.unlink(f.name)
 
     @tornado.testing.gen_test
+    async def test_search_string_resets_on_load_reuse(self):
+        """Codex P1 (#839): session.search_string must be cleared when
+        /load replaces data on an existing buckaroo-mode session — else
+        the stale term silently filters the newly loaded dataset."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                sid = "ws-search-reuse"
+                await _async_fetch(self.get_http_port(), "/load",
+                    method="POST",
+                    body=json.dumps({"session": sid, "path": f.name,
+                        "mode": "buckaroo"}))
+
+                ws = await tornado.websocket.websocket_connect(
+                    f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+                await ws.read_message()
+
+                ws.write_message(json.dumps({
+                    "type": "buckaroo_state_change",
+                    "new_state": {
+                        "post_processing": "", "cleaning_method": "",
+                        "quick_command_args": {}, "df_display": "main",
+                        "show_commands": False, "sampled": False,
+                        "search_string": "Alice"}}))
+                await ws.read_message()
+                ws.close()
+
+                # Reload — fresh client state has empty search_string;
+                # the server must match.
+                await _async_fetch(self.get_http_port(), "/load",
+                    method="POST",
+                    body=json.dumps({"session": sid, "path": f.name,
+                        "mode": "buckaroo"}))
+
+                ws2 = await tornado.websocket.websocket_connect(
+                    f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+                await ws2.read_message()
+
+                ws2.write_message(json.dumps({
+                    "type": "infinite_request",
+                    "payload_args": {"start": 0, "end": 5,
+                        "sourceName": "default", "origEnd": 5}}))
+                r = json.loads(await ws2.read_message())
+                self.assertEqual(r["length"], 5,
+                    f"stale search_string carried across /load — "
+                    f"expected 5 rows, got {r['length']}")
+                await ws2.read_message()  # binary
+                ws2.close()
+            finally:
+                os.unlink(f.name)
+
+    @tornado.testing.gen_test
     async def test_ws_request_no_data_loaded(self):
         ws = await tornado.websocket.websocket_connect(
             f"ws://localhost:{self.get_http_port()}/ws/no-data-session")


### PR DESCRIPTION
## Summary

- Add `search_string` to `_DATAFLOW_FIELDS` so a pure search edit is no longer treated as a no-op by the WebSocket state-change handler.
- Thread `session.search_string` into the infinite-request dispatch for the xorq and pandas-buckaroo backends, applying a literal substring-contains filter across string columns **before** clamp/sort/slice.
- This is the row-fetch fast lane requested by #838 — independent of the existing `quick_command_args.search` path, which rebuilds the full stats pipeline (too slow for ~10⁶-row parquet-backed exprs in pydata-app).

## Test plan

- [x] `tests/unit/server/test_load_expr.py::test_ws_search_string_rowfetch` — xorq backend, 10-row memtable, 4 matches for `alpha`
- [x] `tests/unit/server/test_load_expr.py::test_ws_search_string_cleared_returns_full_set` — xorq, alpha→"" roundtrip restores 10 rows
- [x] `tests/unit/server/test_server.py::test_ws_search_string_pandas_buckaroo` — pandas-buckaroo, 5-row CSV, "Alice" → 1 row
- [ ] CI captures tests failing first (per the test-must-fail-on-CI rule), then a follow-up commit lands the fix

Closes #838

🤖 Generated with [Claude Code](https://claude.com/claude-code)