### PR TITLE
fix(py): short-circuit DefaultSummaryStats on unhashable object columns (#843)

### DIFF
--- a/buckaroo/customizations/analysis.py
+++ b/buckaroo/customizations/analysis.py
@@ -26,6 +26,31 @@ def probable_datetime(ser):
         return False
 
 
+def _has_unhashable_values(ser):
+    """True if ser is object dtype and its first non-null value is unhashable.
+
+    Used to skip value_counts/mode on list/dict/set columns where pandas
+    falls back to an O(n^2) pairwise compare and the result is meaningless
+    anyway (each row is effectively a unique container). #843
+    """
+    if ser.dtype != object:
+        return False
+    for v in ser:
+        if v is None:
+            continue
+        try:
+            if pd.isna(v):
+                continue
+        except (TypeError, ValueError):
+            pass
+        try:
+            hash(v)
+        except TypeError:
+            return True
+        return False
+    return False
+
+
 def get_mode(ser):
     try:
         from packaging.version import Version
@@ -128,7 +153,10 @@ class DefaultSummaryStats(ColAnalysis):
     @staticmethod
     def series_summary(sampled_ser, ser):
         l = len(ser)
-        value_counts = ser.value_counts()
+        if _has_unhashable_values(ser):
+            value_counts = pd.Series([], dtype='int64', name='count')
+        else:
+            value_counts = ser.value_counts()
         is_numeric = pd.api.types.is_numeric_dtype(ser)
         is_bool = pd.api.types.is_bool_dtype(ser)
 

--- a/tests/unit/analysis_test.py
+++ b/tests/unit/analysis_test.py
@@ -46,6 +46,22 @@ def test_unhashable():
     assert     {'length': 2, 'null_count': 0,
         'mode': np.nan, 'min': np.nan, 'max': np.nan} == cleaned_result
 
+def test_unhashable_value_counts_empty():
+    # value_counts on a list/dict/set-typed Series is meaningless (each row is
+    # effectively unique) and pandas falls back to an O(n^2) pairwise compare.
+    # series_summary should short-circuit and return an empty value_counts. #843
+    list_ser = pd.Series([['a'], ['b'], ['a']])
+    result = DefaultSummaryStats.series_summary(list_ser, list_ser)
+    assert len(result['value_counts']) == 0
+
+    dict_ser = pd.Series([{'a': 1}, {'b': 2}])
+    result = DefaultSummaryStats.series_summary(dict_ser, dict_ser)
+    assert len(result['value_counts']) == 0
+
+    set_ser = pd.Series([{1, 2}, {3, 4}])
+    result = DefaultSummaryStats.series_summary(set_ser, set_ser)
+    assert len(result['value_counts']) == 0
+
 def test_unhashable3():
     ser = pd.Series([{'a':1, 'b':2}, {'b':10, 'c': 5}])
     DefaultSummaryStats.series_summary(ser, ser) # 'nan_per'


### PR DESCRIPTION
## Summary

Fixes #843. `DefaultSummaryStats.series_summary` calls `ser.value_counts()` unconditionally. On object-dtype Series containing unhashable values (Python `list`, `dict`, `set`), pandas can't hash the elements and falls back to an O(n²) pairwise comparison. On a 5000-row `list<string>` column this single call is ~600 ms and accounts for 99% of `create_dataflow` cost; n=10000 takes ~2.5 s.

`value_counts` is also semantically meaningless on these columns — each row is an effectively-unique container — so the produced histogram and frequency stats are noise.

This PR short-circuits `series_summary` when the column is object dtype with non-hashable elements: returns an empty `value_counts`, skips `mode`, and lets downstream handlers (which already cope with empty `value_counts`) fill in defaults.

## Test plan

- [x] New failing test pushed first: `test_unhashable_value_counts_empty` asserts `len(result['value_counts']) == 0` for list/dict/set Series. Saw it red on CI in the prior commit.
- [ ] Fix commit makes that test pass.
- [ ] Existing unhashable tests (`test_unhashable`, `test_unhashable3`) still pass.
- [ ] Existing scalar-column tests (`test_text_ser`, `test_default_summary_stats`) still pass.
- [ ] Manual perf repro: `create_dataflow` on a 10k-row list column drops from ~2.5 s to <100 ms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)