### PR TITLE
fix(server): plumb autoHeight through BuckarooServerView (#846)

### DIFF
--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.forwarding.test.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.forwarding.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * BuckarooServerView — autoHeight forwarding (#846).
+ *
+ * Pins the one-line spread at BuckarooServerView.tsx that forwards
+ * `autoHeight` to BuckarooView. Without this test, a future refactor that
+ * destructures the prop but forgets to forward it would silently regress.
+ */
+import { render, cleanup, waitFor } from "@testing-library/react";
+import { BuckarooServerView } from "./BuckarooServerView";
+
+const capturedViewProps: any[] = [];
+
+jest.mock("./BuckarooView", () => ({
+    BuckarooView: (props: any) => {
+        capturedViewProps.push(props);
+        return <div data-testid="buckaroo-view-stub" />;
+    },
+    pickMode: (m: unknown) => (m === "buckaroo" ? "buckaroo" : "viewer"),
+}));
+
+jest.mock("./WebSocketModel", () => ({
+    WebSocketModel: class { constructor(_ws: any, _state: any) {} },
+}));
+
+class FakeWebSocket {
+    static instances: FakeWebSocket[] = [];
+    binaryType = "arraybuffer";
+    onopen: (() => void) | null = null;
+    onerror: ((e: any) => void) | null = null;
+    private listeners: Record<string, Set<(e: any) => void>> = {};
+    constructor(public url: string) {
+        FakeWebSocket.instances.push(this);
+        setTimeout(() => {
+            this.onopen?.();
+            // Defer message delivery so BuckarooServerView's second
+            // `await new Promise(...)` can register its listener first.
+            setTimeout(() => {
+                const initial = {
+                    type: "initial_state",
+                    df_meta: { total_rows: 4, columns: 2, filtered_rows: 4, rows_shown: 4 },
+                    df_data_dict: {},
+                    df_display_args: {
+                        main: {
+                            df_viewer_config: { pinned_rows: [], left_col_configs: [], column_config: [] },
+                            summary_stats_key: "all_stats",
+                        },
+                    },
+                    mode: "viewer",
+                };
+                this.listeners["message"]?.forEach((h) => h({ data: JSON.stringify(initial) } as any));
+            }, 0);
+        }, 0);
+    }
+    addEventListener(ev: string, h: (e: any) => void) {
+        (this.listeners[ev] ??= new Set()).add(h);
+    }
+    removeEventListener(ev: string, h: (e: any) => void) {
+        this.listeners[ev]?.delete(h);
+    }
+    close() {}
+}
+
+const origWebSocket = (globalThis as any).WebSocket;
+
+beforeAll(() => {
+    (globalThis as any).WebSocket = FakeWebSocket;
+});
+afterAll(() => {
+    (globalThis as any).WebSocket = origWebSocket;
+});
+afterEach(() => {
+    capturedViewProps.length = 0;
+    FakeWebSocket.instances.length = 0;
+    cleanup();
+});
+
+describe("BuckarooServerView autoHeight forwarding (#846)", () => {
+    it("forwards autoHeight=true to BuckarooView", async () => {
+        render(<BuckarooServerView wsUrl="ws://x/ws/s" autoHeight />);
+        await waitFor(() => expect(capturedViewProps.length).toBeGreaterThan(0));
+        expect(capturedViewProps[capturedViewProps.length - 1].autoHeight).toBe(true);
+    });
+
+    it("forwards autoHeight=undefined to BuckarooView when the prop is omitted", async () => {
+        render(<BuckarooServerView wsUrl="ws://x/ws/s" />);
+        await waitFor(() => expect(capturedViewProps.length).toBeGreaterThan(0));
+        expect(capturedViewProps[capturedViewProps.length - 1].autoHeight).toBeUndefined();
+    });
+});

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
@@ -62,7 +62,8 @@ export interface BuckarooServerViewProps {
     /** When true, render with AG Grid's `domLayout: "autoHeight"`: the grid
      *  grows to fit its row count instead of filling the parent container.
      *  Use for stacked-cell hosts (notebook-style embeds) where a single
-     *  fixed embed height looks wrong for both small and large dataframes. */
+     *  fixed embed height looks wrong for both small and large dataframes.
+     *  Overrides any `component_config.layoutType` set by the server. */
     autoHeight?: boolean;
 }
 

--- a/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooServerView.tsx
@@ -58,6 +58,12 @@ export interface BuckarooServerViewProps {
 
     /** Optional className on the wrapping div. */
     className?: string;
+
+    /** When true, render with AG Grid's `domLayout: "autoHeight"`: the grid
+     *  grows to fit its row count instead of filling the parent container.
+     *  Use for stacked-cell hosts (notebook-style embeds) where a single
+     *  fixed embed height looks wrong for both small and large dataframes. */
+    autoHeight?: boolean;
 }
 
 interface ReadyState {
@@ -81,6 +87,7 @@ export function BuckarooServerView({
     onMetadata,
     style,
     className,
+    autoHeight,
 }: BuckarooServerViewProps): React.ReactElement {
     const [ready, setReady] = React.useState<ReadyState | null>(null);
     const [error, setError] = React.useState<Error | null>(null);
@@ -176,6 +183,7 @@ export function BuckarooServerView({
             onMetadata={onMetadata}
             style={style}
             className={className}
+            autoHeight={autoHeight}
         />
     );
 }

--- a/packages/buckaroo-js-core/src/server/BuckarooView.autoHeight.test.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.autoHeight.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * BuckarooView — autoHeight prop (#846).
+ *
+ * Hosts that stack multiple BuckarooServerView embeds (notebook-style, one
+ * per dataframe) can't pick a one-size embed height: a 4-row aggregate and
+ * a 100k-row main frame need very different vertical real estate. The
+ * `autoHeight` prop lets hosts opt into AG Grid's `domLayout: "autoHeight"`
+ * so the grid grows to its row count instead of filling the parent.
+ */
+import { render, cleanup, act } from "@testing-library/react";
+import { BuckarooView } from "./BuckarooView";
+import type { IModel } from "./IModel";
+
+// Capture props passed to the (stubbed) viewer surface so the test can
+// inspect what BuckarooView pushed down — that's where the autoHeight
+// plumbing has to land.
+const capturedDsProps: any[] = [];
+
+jest.mock("../components/BuckarooWidgetInfinite", () => ({
+    BuckarooInfiniteWidget: () => <div data-testid="buckaroo-widget-stub" />,
+    DFViewerInfiniteDS: (props: any) => {
+        capturedDsProps.push(props);
+        return <div data-testid="viewer-widget-stub" />;
+    },
+    getKeySmartRowCache: jest.fn(() => ({ __stub: "row-cache" })),
+}));
+
+function makeFakeModel(): IModel {
+    const state: Record<string, unknown> = {};
+    return {
+        send: () => {},
+        get: (k) => state[k],
+        set: (k, v) => { state[k] = v; },
+        save_changes: () => {},
+        on: () => {},
+        off: () => {},
+    };
+}
+
+afterEach(() => {
+    capturedDsProps.length = 0;
+    cleanup();
+});
+
+const baseInitialState = () => ({
+    df_meta: { total_rows: 4, columns: 2, filtered_rows: 4, rows_shown: 4 },
+    df_data_dict: {},
+    df_display_args: {
+        main: {
+            df_viewer_config: { pinned_rows: [], left_col_configs: [], column_config: [] },
+            summary_stats_key: "all_stats",
+        },
+    },
+});
+
+describe("BuckarooView autoHeight (#846)", () => {
+    it("injects component_config.layoutType='autoHeight' into df_display_args when autoHeight is set", async () => {
+        await act(async () => {
+            render(
+                <BuckarooView
+                    model={makeFakeModel()}
+                    initialState={baseInitialState()}
+                    mode="viewer"
+                    autoHeight
+                />,
+            );
+        });
+
+        expect(capturedDsProps.length).toBeGreaterThan(0);
+        const last = capturedDsProps[capturedDsProps.length - 1];
+        const cc = last.df_display_args.main.df_viewer_config.component_config;
+        expect(cc?.layoutType).toBe("autoHeight");
+    });
+
+    it("leaves display args untouched when autoHeight is not set", async () => {
+        await act(async () => {
+            render(
+                <BuckarooView
+                    model={makeFakeModel()}
+                    initialState={baseInitialState()}
+                    mode="viewer"
+                />,
+            );
+        });
+
+        const last = capturedDsProps[capturedDsProps.length - 1];
+        // Either no component_config, or layoutType not forced to autoHeight.
+        const cc = last.df_display_args.main.df_viewer_config.component_config;
+        expect(cc?.layoutType).not.toBe("autoHeight");
+    });
+
+    it("drops height:100% from the wrapper when autoHeight is set, so the grid can grow with its rows", async () => {
+        const { container } = render(
+            <BuckarooView
+                model={makeFakeModel()}
+                initialState={baseInitialState()}
+                mode="viewer"
+                autoHeight
+            />,
+        );
+
+        const wrapper = container.querySelector(".buckaroo_anywidget") as HTMLElement | null;
+        expect(wrapper).not.toBeNull();
+        // height:100% would cap the grid inside the parent — the whole point
+        // of autoHeight is for the wrapper to size to its contents.
+        expect(wrapper!.style.height).not.toBe("100%");
+    });
+});

--- a/packages/buckaroo-js-core/src/server/BuckarooView.autoHeight.test.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.autoHeight.test.tsx
@@ -72,21 +72,35 @@ describe("BuckarooView autoHeight (#846)", () => {
         expect(cc?.layoutType).toBe("autoHeight");
     });
 
-    it("leaves display args untouched when autoHeight is not set", async () => {
+    it("preserves a server-provided layoutType when autoHeight is not set", async () => {
+        const state = {
+            df_meta: { total_rows: 4, columns: 2, filtered_rows: 4, rows_shown: 4 },
+            df_data_dict: {},
+            df_display_args: {
+                main: {
+                    df_viewer_config: {
+                        pinned_rows: [],
+                        left_col_configs: [],
+                        column_config: [],
+                        component_config: { layoutType: "normal" },
+                    },
+                    summary_stats_key: "all_stats",
+                },
+            },
+        };
         await act(async () => {
             render(
                 <BuckarooView
                     model={makeFakeModel()}
-                    initialState={baseInitialState()}
+                    initialState={state}
                     mode="viewer"
                 />,
             );
         });
 
         const last = capturedDsProps[capturedDsProps.length - 1];
-        // Either no component_config, or layoutType not forced to autoHeight.
         const cc = last.df_display_args.main.df_viewer_config.component_config;
-        expect(cc?.layoutType).not.toBe("autoHeight");
+        expect(cc?.layoutType).toBe("normal");
     });
 
     it("drops height:100% from the wrapper when autoHeight is set, so the grid can grow with its rows", async () => {

--- a/packages/buckaroo-js-core/src/server/BuckarooView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.tsx
@@ -85,7 +85,8 @@ export interface BuckarooViewProps {
     /** When true, render with AG Grid's `domLayout: "autoHeight"`: the grid
      *  grows to fit its row count instead of filling the parent container.
      *  Use for stacked-cell hosts (notebook-style embeds) where a fixed
-     *  embed height looks wrong for both small and large dataframes. */
+     *  embed height looks wrong for both small and large dataframes.
+     *  Overrides any `component_config.layoutType` set by the server. */
     autoHeight?: boolean;
 }
 
@@ -255,11 +256,9 @@ export function BuckarooView({
         model.save_changes();
     }, [model]);
 
-    // When autoHeight is requested, force AG Grid into domLayout:"autoHeight"
-    // by stamping layoutType onto each display-arg entry's component_config,
-    // and drop the wrapper's height:100% so the grid can size to its rows
-    // instead of being capped by the parent. The map is memoized to keep
-    // child reference identity stable across re-renders.
+    // gridUtils already honors component_config.layoutType — stamp it per
+    // display-arg entry and let getHeightStyle2 do the rest. Memoized to
+    // keep child reference identity stable across re-renders.
     const effectiveDisplayArgs = React.useMemo<Record<string, IDisplayArgs>>(() => {
         if (!autoHeight) return dfDisplayArgs;
         const out: Record<string, IDisplayArgs> = {};

--- a/packages/buckaroo-js-core/src/server/BuckarooView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.tsx
@@ -114,6 +114,7 @@ export function BuckarooView({
     onMetadata,
     style,
     className,
+    autoHeight,
 }: BuckarooViewProps): React.ReactElement {
     // If the caller passed raw initial_state straight off the wire,
     // df_data_dict may still contain parquet_b64 payload objects. Those
@@ -254,9 +255,34 @@ export function BuckarooView({
         model.save_changes();
     }, [model]);
 
-    const wrapperStyle: React.CSSProperties = { width: "100%", height: "100%", ...(style ?? {}) };
+    // When autoHeight is requested, force AG Grid into domLayout:"autoHeight"
+    // by stamping layoutType onto each display-arg entry's component_config,
+    // and drop the wrapper's height:100% so the grid can size to its rows
+    // instead of being capped by the parent. The map is memoized to keep
+    // child reference identity stable across re-renders.
+    const effectiveDisplayArgs = React.useMemo<Record<string, IDisplayArgs>>(() => {
+        if (!autoHeight) return dfDisplayArgs;
+        const out: Record<string, IDisplayArgs> = {};
+        for (const [k, v] of Object.entries(dfDisplayArgs)) {
+            out[k] = {
+                ...v,
+                df_viewer_config: {
+                    ...v.df_viewer_config,
+                    component_config: {
+                        ...(v.df_viewer_config.component_config ?? {}),
+                        layoutType: "autoHeight",
+                    },
+                },
+            };
+        }
+        return out;
+    }, [dfDisplayArgs, autoHeight]);
 
-    if (!dfDisplayArgs?.main || !dataReady) {
+    const wrapperStyle: React.CSSProperties = autoHeight
+        ? { width: "100%", ...(style ?? {}) }
+        : { width: "100%", height: "100%", ...(style ?? {}) };
+
+    if (!effectiveDisplayArgs?.main || !dataReady) {
         return (
             <div className={className} style={wrapperStyle}>
                 <div style={{ padding: 20, fontFamily: "sans-serif" }}>Preparing…</div>
@@ -270,7 +296,7 @@ export function BuckarooView({
                 <BuckarooInfiniteWidget
                     df_meta={dfMeta}
                     df_data_dict={dfDataDict}
-                    df_display_args={dfDisplayArgs}
+                    df_display_args={effectiveDisplayArgs}
                     operations={operations}
                     on_operations={onOperations}
                     operation_results={operationResults}
@@ -284,7 +310,7 @@ export function BuckarooView({
                 <DFViewerInfiniteDS
                     df_meta={dfMeta}
                     df_data_dict={dfDataDict}
-                    df_display_args={dfDisplayArgs}
+                    df_display_args={effectiveDisplayArgs}
                     src={src}
                     df_id={"server"}
                 />

--- a/packages/buckaroo-js-core/src/server/BuckarooView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.tsx
@@ -81,6 +81,12 @@ export interface BuckarooViewProps {
 
     /** Optional className on the wrapping div. */
     className?: string;
+
+    /** When true, render with AG Grid's `domLayout: "autoHeight"`: the grid
+     *  grows to fit its row count instead of filling the parent container.
+     *  Use for stacked-cell hosts (notebook-style embeds) where a fixed
+     *  embed height looks wrong for both small and large dataframes. */
+    autoHeight?: boolean;
 }
 
 export function pickMode(rawMode: unknown): BuckarooServerMode {


### PR DESCRIPTION
## Summary

Closes #846.

Stacked-cell hosts (notebook-style embeds — one Buckaroo per cell) can't pick a one-size embed height: a 4-row aggregate and a 100k-row main frame need very different vertical real estate. Until now, `BuckarooServerView` had no way to ask AG Grid for `domLayout: "autoHeight"` from the React component path, so hosts had to pick a fixed pixel height and live with empty space below small results or internal scrollbars on large ones.

This PR adds an `autoHeight?: boolean` prop to `BuckarooServerView` (and the underlying `BuckarooView`). When set:

- `layoutType: "autoHeight"` is stamped onto each `df_display_args` entry's `component_config`, which the existing `gridUtils` path already honors (`getHeightStyle2` → `domLayout`).
- The wrapping div drops its `height: 100%` default, so the grid grows to its row count instead of being capped by the parent.

The display-arg transform is memoized so child reference identity stays stable across re-renders.

## Usage

```tsx
<div>
  <BuckarooServerView wsUrl={`ws://localhost:8700/ws/${sessionId}`} autoHeight />
</div>
```

## Test plan

- [x] `pnpm test` — new `BuckarooView.autoHeight.test.tsx` covers prop injection and wrapper-style drop; full 274-test suite passes.
- [x] Pre-push CI hook (ruff + paddy-format) passes locally.
- [ ] Verify against pydata-app notebook view (#846 repro): stacked 4-row aggregate and 2k-row orders embed each size correctly with `autoHeight`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)