### PR TITLE
feat(py): add to_html(self_contained=True) for inline-asset embed

### DIFF
--- a/buckaroo/artifact.py
+++ b/buckaroo/artifact.py
@@ -8,6 +8,7 @@ for compact transport. The JS side decodes them via resolveDFDataAsync().
 """
 import base64
 import json
+import re
 from io import BytesIO
 from pathlib import Path
 
@@ -241,20 +242,44 @@ def to_html(df, title="Buckaroo", embed_type="DFViewer",
     return html
 
 
+# Per HTML5, a script-data / style-data block ends at "</" + tag-name
+# followed by any of TAB / LF / FF / SPACE / "/" / ">", matched
+# case-insensitively. Plain string.replace("</script>", ...) misses
+# variants like "</Script>", "</script >", "</script/", so use a regex
+# with a lookahead that mirrors the spec.
+_CLOSE_TAG_PATTERNS = {
+    name: re.compile(rf"</({name})(?=[\t\n\f />])", re.IGNORECASE)
+    for name in ("script", "style")
+}
+
+
+def _defuse_close_tag(tag_name: str, body: str) -> str:
+    """Defuse any HTML-recognisable closing form of <tag_name> in `body`.
+
+    Inserts a backslash between ``<`` and ``/`` so the HTML parser no
+    longer sees a tag terminator while the contained JS/CSS is unchanged
+    semantically (``<\\/script>`` in a JS string literal still evaluates
+    to ``"</script>"``; ``<\\/style>`` in a CSS rule is just an escaped
+    forward slash).
+    """
+    return _CLOSE_TAG_PATTERNS[tag_name].sub(r"<\\/\1", body)
+
+
 def _inline_static_assets(html: str) -> str:
     """Replace external ``static-embed.{js,css}`` references with inline blocks.
 
-    The bundled assets may contain literal ``</script>`` or ``</style>``
-    sequences (rare, but possible after minification). These are defused
-    so they cannot prematurely terminate the inline tags.
+    The bundled assets may contain a close-tag sequence (case-insensitive
+    ``</script`` or ``</style`` followed by whitespace, ``/``, or ``>``)
+    that would prematurely terminate an inline ``<script>`` / ``<style>``
+    block. ``_defuse_close_tag`` handles all such variants.
     """
     from pathlib import Path
     static_dir = Path(__file__).parent / "static"
     css_body = (static_dir / "static-embed.css").read_text()
     js_body = (static_dir / "static-embed.js").read_text()
 
-    css_inline = css_body.replace("</style>", "<\\/style>")
-    js_inline = js_body.replace("</script>", "<\\/script>")
+    css_inline = _defuse_close_tag("style", css_body)
+    js_inline = _defuse_close_tag("script", js_body)
 
     html = html.replace('<link rel="stylesheet" href="static-embed.css">', f"<style>{css_inline}</style>")
     html = html.replace('<script type="module" src="static-embed.js"></script>',

--- a/buckaroo/artifact.py
+++ b/buckaroo/artifact.py
@@ -200,11 +200,17 @@ _HTML_TEMPLATE = """\
 """
 
 
-def to_html(df, title="Buckaroo", embed_type="DFViewer", **kwargs) -> str:
+def to_html(df, title="Buckaroo", embed_type="DFViewer",
+            self_contained=False, **kwargs) -> str:
     """Generate an HTML string that renders a buckaroo table.
 
-    The HTML references ``static-embed.js`` and ``static-embed.css``
-    which must be served alongside it (produced by the JS build).
+    By default the HTML references ``static-embed.js`` and
+    ``static-embed.css`` which must be served alongside it (produced by
+    the JS build). With ``self_contained=True`` those assets are inlined
+    into the page, producing a single ``.html`` file that double-clicks
+    open from disk — browsers refuse to load ES modules over ``file://``,
+    so external-asset HTML can only be served over HTTP, but inline
+    modules sidestep that restriction.
 
     Parameters
     ----------
@@ -215,6 +221,11 @@ def to_html(df, title="Buckaroo", embed_type="DFViewer", **kwargs) -> str:
     embed_type : str, optional
         ``"DFViewer"`` (default) for a plain table, or ``"Buckaroo"`` for
         the full experience with summary_stats/main display switcher.
+    self_contained : bool, optional
+        When True, inline ``static-embed.js`` and ``static-embed.css``
+        into the output so the result is a single self-contained file
+        that works when opened via ``file://``. Default False keeps the
+        smaller sidecar output.
     **kwargs
         Passed through to prepare_buckaroo_artifact().
 
@@ -224,4 +235,28 @@ def to_html(df, title="Buckaroo", embed_type="DFViewer", **kwargs) -> str:
         Complete HTML document string.
     """
     artifact = prepare_buckaroo_artifact(df, embed_type=embed_type, **kwargs)
-    return _HTML_TEMPLATE.format(title=title, artifact_json=artifact_to_json(artifact))
+    html = _HTML_TEMPLATE.format(title=title, artifact_json=artifact_to_json(artifact))
+    if self_contained:
+        html = _inline_static_assets(html)
+    return html
+
+
+def _inline_static_assets(html: str) -> str:
+    """Replace external ``static-embed.{js,css}`` references with inline blocks.
+
+    The bundled assets may contain literal ``</script>`` or ``</style>``
+    sequences (rare, but possible after minification). These are defused
+    so they cannot prematurely terminate the inline tags.
+    """
+    from pathlib import Path
+    static_dir = Path(__file__).parent / "static"
+    css_body = (static_dir / "static-embed.css").read_text()
+    js_body = (static_dir / "static-embed.js").read_text()
+
+    css_inline = css_body.replace("</style>", "<\\/style>")
+    js_inline = js_body.replace("</script>", "<\\/script>")
+
+    html = html.replace('<link rel="stylesheet" href="static-embed.css">', f"<style>{css_inline}</style>")
+    html = html.replace('<script type="module" src="static-embed.js"></script>',
+        f'<script type="module">{js_inline}</script>')
+    return html

--- a/tests/unit/artifact_test.py
+++ b/tests/unit/artifact_test.py
@@ -5,7 +5,7 @@ from io import BytesIO
 import pandas as pd
 import pytest
 
-from buckaroo.artifact import (prepare_buckaroo_artifact, artifact_to_json, to_html, _df_to_parquet_b64_tagged)
+from buckaroo.artifact import (prepare_buckaroo_artifact, artifact_to_json, to_html, _df_to_parquet_b64_tagged, _defuse_close_tag)
 
 
 simple_df = pd.DataFrame({'int_col': [1, 2, 3], 'str_col': ['a', 'b', 'c'], 'float_col': [1.1, 2.2, 3.3]})
@@ -193,6 +193,39 @@ class TestToHtml:
         if css_body.strip():
             assert css_body.splitlines()[0] in html, \
                 "inlined CSS body should be present in output"
+
+    @pytest.mark.parametrize("variant", [
+        "</script>",       # canonical lowercase
+        "</Script>",       # mixed case
+        "</SCRIPT>",       # uppercase
+        "</script >",      # trailing space before >
+        "</script\t>",     # trailing tab
+        "</script/>",      # self-closing-ish
+        "</script\n>",     # trailing LF
+    ])
+    def test_defuse_close_tag_script_variants(self, variant):
+        """Per HTML5, the script-data-end-tag-name state ends on </script
+        followed by tab/LF/FF/space/'/'/'>' (case-insensitive). The defuser
+        must escape every such variant or self_contained=True can produce
+        broken HTML if a bundled JS string ever contains one of them."""
+        defused = _defuse_close_tag("script", f"console.log('{variant}');")
+        assert variant not in defused, \
+            f"variant {variant!r} survived defusing: {defused!r}"
+        # The defused form should contain a backslash between < and /
+        assert "<\\/" in defused
+
+    @pytest.mark.parametrize("variant", ["</style>", "</Style>", "</STYLE>", "</style >", "</style/>"])
+    def test_defuse_close_tag_style_variants(self, variant):
+        defused = _defuse_close_tag("style", f".a {{ content: '{variant}'; }}")
+        assert variant not in defused
+        assert "<\\/" in defused
+
+    def test_defuse_close_tag_leaves_unrelated_text_alone(self):
+        """</scripts> (with trailing 's') is NOT a tag close per HTML5 —
+        the terminator must be whitespace/'/'/'>'. Don't over-eagerly defuse."""
+        body = "var x = '</scripts>'; var y = '</scripto>';"
+        defused = _defuse_close_tag("script", body)
+        assert defused == body, f"defuser modified unrelated text: {defused!r}"
 
     def test_self_contained_defuses_close_script(self):
         """Bundled JS containing literal </script> must not break out of the inline tag."""

--- a/tests/unit/artifact_test.py
+++ b/tests/unit/artifact_test.py
@@ -165,6 +165,50 @@ class TestToHtml:
         html = to_html(simple_df)
         assert 'parquet_b64' in html
 
+    def test_self_contained_default_false(self):
+        """Default behaviour: HTML still references sidecar bundle by URL."""
+        html = to_html(simple_df)
+        assert '<link rel="stylesheet" href="static-embed.css">' in html
+        assert '<script type="module" src="static-embed.js"></script>' in html
+
+    def test_self_contained_true_inlines_js_and_css(self):
+        """self_contained=True inlines static-embed.js/css and removes sidecar references."""
+        html = to_html(simple_df, self_contained=True)
+
+        assert 'href="static-embed.css"' not in html, \
+            "self_contained=True should drop the external CSS reference"
+        assert 'src="static-embed.js"' not in html, \
+            "self_contained=True should drop the external JS reference"
+
+        assert '<style>' in html
+        assert '<script type="module">' in html
+
+        from pathlib import Path
+        import buckaroo as _bk
+        static_src = Path(_bk.__file__).parent / "static"
+        css_first_line = (static_src / "static-embed.css").read_text().splitlines()[0]
+        assert css_first_line in html, "inlined CSS body should be present in output"
+
+    def test_self_contained_defuses_close_script(self):
+        """Bundled JS containing literal </script> must not break out of the inline tag."""
+        html = to_html(simple_df, self_contained=True)
+        # Inside the module body there must be no raw </script> that could
+        # terminate the inline block prematurely. Exactly one </script>
+        # closes the module tag itself; that one is followed by the </body>
+        # tag in the template.
+        module_start = html.index('<script type="module">')
+        module_chunk = html[module_start + len('<script type="module">'):]
+        first_close = module_chunk.index('</script>')
+        # No further </script> may appear before the genuine terminator's
+        # end — i.e. the substring before first_close must contain no
+        # </script>. (Trivially true by find-first.) Stronger assertion:
+        # whatever sits at first_close should be immediately followed by
+        # whitespace + </body>, meaning the close belongs to the template.
+        tail = module_chunk[first_close:first_close + 60]
+        assert tail.startswith('</script>')
+        assert '</body>' in tail, \
+            f"premature </script> closed the inline module; tail={tail!r}"
+
 
 class TestWeirdTypesParquetRoundtrip:
     """Parquet b64 encoding must produce standard types that hyparquet can decode.

--- a/tests/unit/artifact_test.py
+++ b/tests/unit/artifact_test.py
@@ -183,11 +183,16 @@ class TestToHtml:
         assert '<style>' in html
         assert '<script type="module">' in html
 
+        # If the asset bundle was actually built (full_build.sh) the CSS
+        # bytes should round-trip into the output. In Python-only CI the
+        # bundle is an empty stub (see scripts/hatch_build.py REQUIRED_STUBS),
+        # so this check is conditional.
         from pathlib import Path
         import buckaroo as _bk
-        static_src = Path(_bk.__file__).parent / "static"
-        css_first_line = (static_src / "static-embed.css").read_text().splitlines()[0]
-        assert css_first_line in html, "inlined CSS body should be present in output"
+        css_body = (Path(_bk.__file__).parent / "static" / "static-embed.css").read_text()
+        if css_body.strip():
+            assert css_body.splitlines()[0] in html, \
+                "inlined CSS body should be present in output"
 
     def test_self_contained_defuses_close_script(self):
         """Bundled JS containing literal </script> must not break out of the inline tag."""


### PR DESCRIPTION
## Summary
- Adds `self_contained=True` parameter to `buckaroo.to_html()` that inlines `static-embed.js` and `static-embed.css` into the generated HTML
- Resulting `.html` file is double-clickable from disk: no sibling assets, no http server needed to work around browser CORS on ES modules
- Defuses any literal `</script>` / `</style>` in the bundled assets so they can't prematurely terminate the inline tags
- Default behaviour unchanged

## Why
Today `to_html()` always references the bundled JS/CSS as sibling files. That works fine when serving over HTTP, but opening the result via `file://` is blocked by the browser's CORS rules for ES modules — so users emailing/uploading the file get a blank page until they spin up `python -m http.server`. Inlining the assets sidesteps the restriction (inline module scripts don't trigger a cross-origin fetch).

## Test plan
- [x] New tests in `tests/unit/artifact_test.py::TestToHtml`:
  - `test_self_contained_default_false` — pins the current sidecar-output as the default
  - `test_self_contained_true_inlines_js_and_css` — output contains inline `<style>` / `<script type="module">`, no external refs to `static-embed.{js,css}`
  - `test_self_contained_defuses_close_script` — the inline module block isn't prematurely terminated
- [x] `pytest tests/unit/artifact_test.py` — 30/30 pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)