### PR TITLE
feat(server): /load accepts column_config_overrides, extra_grid_config, init_sd

### DIFF
--- a/buckaroo/server/data_loading.py
+++ b/buckaroo/server/data_loading.py
@@ -52,9 +52,16 @@ class ServerDataflow(CustomizableDataflow):
         return pd_to_obj(df)
 
 
-def create_dataflow(df: pd.DataFrame) -> ServerDataflow:
-    """Instantiate the full Buckaroo analysis pipeline headlessly."""
-    return ServerDataflow(df, skip_main_serial=True)
+def create_dataflow(df: pd.DataFrame, column_config_overrides=None, extra_grid_config=None, init_sd=None) -> ServerDataflow:
+    """Instantiate the full Buckaroo analysis pipeline headlessly.
+
+    Accepts the same per-column / per-grid configuration kwargs that
+    ``BuckarooInfiniteWidget`` does so server-mode sessions can match the
+    look of a notebook widget. ``LoadHandler`` forwards the matching
+    request-body fields here.
+    """
+    return ServerDataflow(df, column_config_overrides=column_config_overrides, extra_grid_config=extra_grid_config,
+        init_sd=init_sd, skip_main_serial=True)
 
 
 def get_buckaroo_display_state(dataflow: ServerDataflow) -> dict:

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -233,6 +233,14 @@ class LoadHandler(tornado.web.RequestHandler):
         if session_id is None:
             return
 
+        # Optional per-column / per-grid configuration that mirrors the
+        # matching kwargs on BuckarooInfiniteWidget. Only applied for
+        # mode="buckaroo" where the full dataflow is built (lazy/viewer
+        # paths don't carry merged_sd / extra_grid_config).
+        column_config_overrides = body.get("column_config_overrides")
+        extra_grid_config = body.get("extra_grid_config")
+        init_sd = body.get("init_sd")
+
         sessions = self.application.settings["sessions"]
         session = sessions.get_or_create(session_id, path)
         session.mode = mode
@@ -262,7 +270,8 @@ class LoadHandler(tornado.web.RequestHandler):
             session.df = file_obj
             session.metadata = metadata
             if mode == "buckaroo":
-                dataflow = create_dataflow(file_obj)
+                dataflow = create_dataflow(file_obj, column_config_overrides=column_config_overrides,
+                    extra_grid_config=extra_grid_config, init_sd=init_sd)
                 session.dataflow = dataflow
                 buckaroo_state = get_buckaroo_display_state(dataflow)
                 session.df_display_args = buckaroo_state["df_display_args"]

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -101,6 +101,92 @@ class TestLoad(tornado.testing.AsyncHTTPTestCase):
             finally:
                 os.unlink(f.name)
 
+    def test_load_buckaroo_with_column_config_overrides(self):
+        """POST /load with column_config_overrides should plumb through to
+        the headless ServerDataflow so server-mode sessions can match a
+        notebook widget's per-column display config (#860 demo case:
+        PolarsBuckarooInfiniteWidget(df, init_sd=column_config_overrides, ...))."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                overrides = {"name": {"displayer_args": {"displayer": "string", "max_length": 5000}}}
+                resp = self.fetch("/load", method="POST",
+                    body=json.dumps({"session": "cco-1", "path": f.name, "mode": "buckaroo",
+                        "column_config_overrides": overrides}),
+                    headers={"Content-Type": "application/json"})
+                self.assertEqual(resp.code, 200)
+
+                sessions = self._app.settings["sessions"]
+                session = sessions.get("cco-1")
+                self.assertIsNotNone(session)
+                dvc = session.df_display_args["main"]["df_viewer_config"]
+                # header_name carries the original column name; col_name is
+                # the renamed (a/b/c/...) version.
+                name_col = next(cc for cc in dvc["column_config"]
+                    if cc.get("header_name") == "name")
+                self.assertEqual(name_col["displayer_args"]["displayer"], "string")
+                self.assertEqual(name_col["displayer_args"]["max_length"], 5000)
+            finally:
+                os.unlink(f.name)
+
+    def test_load_buckaroo_with_extra_grid_config(self):
+        """POST /load with extra_grid_config (rowHeight etc.) should
+        reach df_viewer_config so AG-Grid picks it up."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                grid_cfg = {"rowHeight": 70, "pinnedRowHeight": 21}
+                resp = self.fetch("/load", method="POST",
+                    body=json.dumps({"session": "egc-1", "path": f.name, "mode": "buckaroo",
+                        "extra_grid_config": grid_cfg}),
+                    headers={"Content-Type": "application/json"})
+                self.assertEqual(resp.code, 200)
+
+                session = self._app.settings["sessions"].get("egc-1")
+                dvc = session.df_display_args["main"]["df_viewer_config"]
+                self.assertEqual(dvc.get("extra_grid_config"), grid_cfg)
+            finally:
+                os.unlink(f.name)
+
+    def test_load_buckaroo_with_init_sd(self):
+        """POST /load with init_sd should apply to the headless dataflow
+        the same way as the widget's init_sd kwarg."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                init_sd = {"name": {"displayer_args": {"displayer": "string", "max_length": 200}}}
+                resp = self.fetch("/load", method="POST",
+                    body=json.dumps({"session": "isd-1", "path": f.name, "mode": "buckaroo", "init_sd": init_sd}),
+                    headers={"Content-Type": "application/json"})
+                self.assertEqual(resp.code, 200)
+
+                session = self._app.settings["sessions"].get("isd-1")
+                dvc = session.df_display_args["main"]["df_viewer_config"]
+                name_col = next(cc for cc in dvc["column_config"]
+                    if cc.get("header_name") == "name")
+                self.assertEqual(name_col["displayer_args"]["displayer"], "string")
+                self.assertEqual(name_col["displayer_args"]["max_length"], 200)
+            finally:
+                os.unlink(f.name)
+
+    def test_load_buckaroo_without_optional_configs_keeps_defaults(self):
+        """Default behaviour: omitting the new kwargs leaves
+        extra_grid_config as the empty-dict default the headless dataflow
+        already emits — same as a notebook BuckarooInfiniteWidget(df)."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                resp = self.fetch("/load", method="POST",
+                    body=json.dumps({"session": "plain-1", "path": f.name, "mode": "buckaroo"}),
+                    headers={"Content-Type": "application/json"})
+                self.assertEqual(resp.code, 200)
+
+                session = self._app.settings["sessions"].get("plain-1")
+                dvc = session.df_display_args["main"]["df_viewer_config"]
+                self.assertEqual(dvc.get("extra_grid_config"), {})
+            finally:
+                os.unlink(f.name)
+
 
 class TestSessionPage(tornado.testing.AsyncHTTPTestCase):
     def get_app(self):


### PR DESCRIPTION
## Summary
- `POST /load` now accepts three optional kwargs mirroring `BuckarooInfiniteWidget`: `column_config_overrides`, `extra_grid_config`, `init_sd`
- Forwarded to `create_dataflow` → `ServerDataflow` (which inherits the support from `CustomizableDataflow`)
- Default behaviour unchanged — clients that don't send these fields see exactly what they saw before

## Why
The headless dataflow already supports these knobs (it inherits `CustomizableDataflow`), they just weren't reachable through the HTTP API. Server-mode sessions had no way to match a notebook widget's column-level config; demo code wanting to drop a widget invocation like

```python
PolarsBuckarooInfiniteWidget(
    df,
    init_sd=column_config_overrides,
    extra_grid_config={"rowHeight": 70},
    component_config={"dfvHeight": 700},
)
```

onto a server session was stuck with `component_config` only.

## Usage

```bash
curl -X POST localhost:8701/load \
  -H 'Content-Type: application/json' \
  -d '{
    "session": "demo",
    "path": "/data/restaurant-complaints.parquet",
    "mode": "buckaroo",
    "column_config_overrides": {
      "comments": {
        "displayer_args": {"displayer": "string", "max_length": 5000},
        "ag_grid_specs": {"wrapText": true, "width": 400, "maxWidth": 800}
      }
    },
    "extra_grid_config": {"rowHeight": 70, "pinnedRowHeight": 21},
    "init_sd": {...},
    "component_config": {"dfvHeight": 700}
  }'
```

## Test plan
- [x] `tests/unit/server/test_server.py::TestLoad` — 4 new tests
  - `test_load_buckaroo_with_column_config_overrides` — override reaches `session.df_display_args.main.df_viewer_config.column_config`
  - `test_load_buckaroo_with_extra_grid_config` — config reaches `df_viewer_config.extra_grid_config`
  - `test_load_buckaroo_with_init_sd` — init_sd applied to merged_sd
  - `test_load_buckaroo_without_optional_configs_keeps_defaults` — pins existing behaviour
- [x] 9/9 `TestLoad` tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)