### PR TITLE
docs(articles): add column-config styling gallery

### DIFF
--- a/buckaroo/serialization_utils.py
+++ b/buckaroo/serialization_utils.py
@@ -254,6 +254,9 @@ def to_parquet_b64(df: pd.DataFrame) -> str:
 
 def _make_json_safe(val):
     """Recursively convert non-JSON-serializable types (datetime keys, etc.) to strings."""
+    import numpy as np
+    if isinstance(val, np.ndarray):
+        return [_make_json_safe(v) for v in val.tolist()]
     if isinstance(val, dict):
         return {str(k): _make_json_safe(v) for k, v in val.items()}
     if isinstance(val, (list, tuple)):

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -35,6 +35,7 @@ build:
         - ./scripts/marimo_wasm_output.sh full_tour.py edit
         - uv run python scripts/generate_ddd_static_html.py
         - uv run python scripts/generate_theme_static_html.py
+        - uv run python scripts/generate_column_config_static_html.py
         - pnpm -C packages/buckaroo-js-core run build-storybook
         - cp -r packages/buckaroo-js-core/dist/storybook docs/extra-html/
         - cp -r docs/extra-html/* $READTHEDOCS_OUTPUT/html

--- a/docs/source/articles/column-config-styling.rst
+++ b/docs/source/articles/column-config-styling.rst
@@ -64,6 +64,11 @@ Each table below renders a small fixture with a different
 ``displayer_args`` config. The code block above each iframe is the exact
 ``column_config_overrides`` that produced it.
 
+The pinned summary band (``dtype`` row + inline histogram, on by
+default) is suppressed in every embed below — these examples are about
+column styling, not summary stats. See `Pinned summary rows`_ for how
+to configure or restore it.
+
 
 Datetime displayers
 ~~~~~~~~~~~~~~~~~~~
@@ -473,6 +478,60 @@ or when one column annotates another.
 
    <iframe src="../styling/tooltip.html"
            style="width:100%; height:320px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Pinned summary rows
+-------------------
+
+Every other embed on this page passes ``pinned_rows=[]`` to keep the
+focus on the column styling. The default is *not* empty — buckaroo
+pins a ``dtype`` row and an inline ``histogram`` above the data.
+
+The pinned summary band is configured per-widget, alongside
+``column_config_overrides``:
+
+.. code-block:: python
+
+    from buckaroo.styling_helpers import (
+        obj_, float_, inherit_, pinned_histogram)
+
+    buckaroo.BuckarooInfiniteWidget(df,
+        pinned_rows=[
+            obj_("dtype"),
+            pinned_histogram(),
+            float_("mean", 2),
+            float_("std", 2),
+            inherit_("min"),
+            inherit_("max"),
+        ])
+
+Each helper returns a dict with the same shape as ``column_config``:
+
+- ``primary_key_val`` — the summary-stat key (``dtype``, ``mean``,
+  ``std``, ``min``, ``max``, ``unique_count``, ``null_count``, ``most_freq``,
+  …). The values come from buckaroo's analysis pipeline, so any stat
+  produced by a registered ``ColAnalysis`` can be pinned.
+- ``displayer_args`` — how the pinned value is rendered. ``obj_`` is
+  the catch-all (Python ``repr``-style); ``float_(key, digits)``
+  formats to a fixed number of fraction digits; ``inherit_`` reuses
+  the column's own ``displayer`` so the pinned value is formatted the
+  same way as the data; ``pinned_histogram()`` renders the inline
+  histogram.
+
+Two arguments control the list:
+
+- ``pinned_rows=[…]`` — *replaces* the defaults. Pass ``[]`` to hide
+  the summary band entirely.
+- ``extra_pinned_rows=[…]`` — *appends* to the defaults. Useful when
+  you want the built-in dtype + histogram pair plus a few extra stats.
+
+Passing both raises ``ValueError`` — pick one.
+
+.. raw:: html
+
+   <iframe src="../styling/pinned-rows.html"
+           style="width:100%; height:340px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
    </iframe>
 
 

--- a/docs/source/articles/column-config-styling.rst
+++ b/docs/source/articles/column-config-styling.rst
@@ -285,7 +285,7 @@ in another column to show the underlying payload.
         "raw": {"displayer_args": {"displayer": "string",
                                     "max_length": 40}},
         "image": {"displayer_args": {"displayer": "Base64PNGImageDisplayer"},
-                  "ag_grid_specs": {"width": 150}},
+                  "ag_grid_specs": {"width": 80}},
     }
 
 .. raw:: html
@@ -342,16 +342,27 @@ Custom: pass a list of CSS colors.
    </iframe>
 
 
-Color map (explicit palette)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Color categorical (explicit palette)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pass an explicit list of CSS colors as ``map_name``. The palette is
-distributed across the value range — useful for flagging values from a
-discrete set of categories.
+When the cell *value* is the category index (0, 1, 2, …), use
+``color_rule: "color_categorical"`` to index directly into a palette.
+Unlike ``color_map``, this rule doesn't need a histogram — it reads
+``cmap[cell_value]`` straight from the list.
 
-This example shows the same data with two palette lengths (5 vs 10) and
-two value ranges (5 vs 10 distinct values) to make the distribution
-visible.
+.. code-block:: typescript
+
+    interface ColorCategoricalRules {
+        color_rule: 'color_categorical';
+        map_name: string[];     // explicit CSS-color list
+        val_column?: string;    // optional: drive color from another column
+    }
+
+This example shows the same fixture with two palette lengths (5 vs 10)
+and two value ranges (5 vs 10 distinct integers), so you can see what
+happens when the value space exceeds the palette (``cmap[value]``
+returns ``undefined`` and the cell inherits the row background) and
+when it doesn't.
 
 .. code-block:: python
 
@@ -360,19 +371,19 @@ visible.
     colors_5  = ["green", "blue", "red", "orange", "purple"]
 
     column_config_overrides = {
-        "ten_vals_10_colors":  {"color_map_config": {"color_rule": "color_map",
-                                                      "map_name": colors_10}},
-        "ten_vals_5_colors":   {"color_map_config": {"color_rule": "color_map",
+        "five_vals_5_colors":  {"color_map_config": {"color_rule": "color_categorical",
                                                       "map_name": colors_5}},
-        "five_vals_10_colors": {"color_map_config": {"color_rule": "color_map",
+        "five_vals_10_colors": {"color_map_config": {"color_rule": "color_categorical",
                                                       "map_name": colors_10}},
-        "five_vals_5_colors":  {"color_map_config": {"color_rule": "color_map",
+        "ten_vals_5_colors":   {"color_map_config": {"color_rule": "color_categorical",
                                                       "map_name": colors_5}},
+        "ten_vals_10_colors":  {"color_map_config": {"color_rule": "color_categorical",
+                                                      "map_name": colors_10}},
     }
 
 .. raw:: html
 
-   <iframe src="../styling/color-map-explicit.html"
+   <iframe src="../styling/color-categorical.html"
            style="width:100%; height:320px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
    </iframe>
 

--- a/docs/source/articles/column-config-styling.rst
+++ b/docs/source/articles/column-config-styling.rst
@@ -1,0 +1,534 @@
+Column Config Styling
+=====================
+
+Buckaroo tables can be extensively styled per column — number formats,
+date locales, link rendering, inline histograms and charts, embedded
+images, conditional cell backgrounds, tooltips. Every example on this
+page is a live static embed: no server, no kernel, just HTML and
+JavaScript.
+
+The single entry point is the ``column_config_overrides`` argument:
+
+.. code-block:: python
+
+    import buckaroo
+
+    buckaroo.BuckarooInfiniteWidget(df, column_config_overrides={
+        "float_col": {
+            "displayer_args": {
+                "displayer": "float",
+                "min_fraction_digits": 1,
+                "max_fraction_digits": 3,
+            }
+        }
+    })
+
+Three independent properties can be set per column — they compose:
+
+- ``displayer_args`` — how cell values are *rendered* (number formatting,
+  date locales, link / image / histogram / chart).
+- ``color_map_config`` — conditional cell *background colors*, optionally
+  driven by another column.
+- ``tooltip_config`` — hover content, typically pulled from another column.
+
+Plus the structural ``merge_rule: "hidden"`` for dropping a column from
+view (commonly used together with ``color_map_config`` so the source
+column doesn't show up in the table).
+
+The same configs work in every entry point — widget, static artifact,
+or server:
+
+.. code-block:: python
+
+    # Jupyter / IPython
+    w = buckaroo.BuckarooWidget(df, column_config_overrides={...})
+
+    # Static embed — same shape
+    from buckaroo.artifact import prepare_buckaroo_artifact
+    artifact = prepare_buckaroo_artifact(df, column_config_overrides={...})
+
+    # MCP / server — pass in the /load request body
+    {"session": "...", "path": "data.csv", "component_config": {...},
+     "column_config_overrides": {...}}
+
+For programmatic styling (functions that look at summary stats and
+return configs per column) see the
+`Styling-Howto notebook
+<https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Styling-Howto.ipynb>`_.
+
+
+Displayer gallery
+-----------------
+
+Each table below renders a small fixture with a different
+``displayer_args`` config. The code block above each iframe is the exact
+``column_config_overrides`` that produced it.
+
+
+Datetime displayers
+~~~~~~~~~~~~~~~~~~~
+
+Datetime columns can be rendered with the default formatter, Python's
+``str()`` (via ``obj``), or any
+`Intl.DateTimeFormat <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat>`_
+locale.
+
+.. code-block:: typescript
+
+    interface DatetimeDefaultDisplayerA {
+        displayer: 'datetimeDefault';
+    }
+    interface DatetimeLocaleDisplayerA {
+        displayer: 'datetimeLocaleString';
+        locale: 'en-US' | 'en-GB' | 'en-CA' | 'fr-FR' | 'es-ES' | 'de-DE' | 'ja-JP';
+        args: Intl.DateTimeFormatOptions;
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "obj":         {"displayer_args": {"displayer": "obj"}},
+        "default":     {"displayer_args": {"displayer": "datetimeDefault"}},
+        "en-US":       {"displayer_args": {"displayer": "datetimeLocaleString",
+                                            "locale": "en-US"}},
+        "en-US-long":  {"displayer_args": {"displayer": "datetimeLocaleString",
+                                            "locale": "en-US",
+                                            "args": {"weekday": "long"}}},
+        "en-GB":       {"displayer_args": {"displayer": "datetimeLocaleString",
+                                            "locale": "en-GB"}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/datetime.html"
+           style="width:100%; height:260px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+String displayer
+~~~~~~~~~~~~~~~~
+
+The ``string`` displayer accepts a ``max_length`` that truncates long
+values with an ellipsis. The full value is still available via tooltip
+(see `Tooltip`_ below). Compare against ``obj`` (Python ``repr``-style)
+and the bare ``string`` form (no truncation).
+
+.. code-block:: typescript
+
+    interface StringDisplayerA {
+        displayer: 'string';
+        max_length?: number;
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "string_max_len_35": {"displayer_args": {"displayer": "string",
+                                                  "max_length": 35}},
+        "obj_displayer":     {"displayer_args": {"displayer": "obj"}},
+        "string_displayer":  {"displayer_args": {"displayer": "string"}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/string.html"
+           style="width:100%; height:260px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Float displayer
+~~~~~~~~~~~~~~~
+
+The ``float`` displayer controls digits after the decimal point. Min
+and max fraction digits work like
+`Intl.NumberFormat <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat>`_
+— ``(1, 3)`` shows at least 1 and up to 3, ``(3, 3)`` always shows 3.
+
+.. code-block:: typescript
+
+    interface FloatDisplayerA {
+        displayer: 'float';
+        min_fraction_digits: number;
+        max_fraction_digits: number;
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "obj_displayer": {"displayer_args": {"displayer": "obj"}},
+        "float_1_3":     {"displayer_args": {"displayer": "float",
+                                              "min_fraction_digits": 1,
+                                              "max_fraction_digits": 3}},
+        "float_0_3":     {"displayer_args": {"displayer": "float",
+                                              "min_fraction_digits": 0,
+                                              "max_fraction_digits": 3}},
+        "float_3_3":     {"displayer_args": {"displayer": "float",
+                                              "min_fraction_digits": 3,
+                                              "max_fraction_digits": 3}},
+        "float_3_13":    {"displayer_args": {"displayer": "float",
+                                              "min_fraction_digits": 3,
+                                              "max_fraction_digits": 13}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/float.html"
+           style="width:100%; height:260px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Link displayer
+~~~~~~~~~~~~~~
+
+Turns a string column into a clickable link.
+
+.. code-block:: typescript
+
+    interface LinkifyDisplayerA {
+        displayer: 'linkify';
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "linkify": {"displayer_args": {"displayer": "linkify"}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/link.html"
+           style="width:100%; height:200px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Histogram displayer
+~~~~~~~~~~~~~~~~~~~
+
+Histograms normally live in summary stats and pinned rows, but the same
+shape can be rendered inline in a data column. Each cell holds a list
+of ``{name, ...}`` objects — buckaroo's histogram conventions:
+
+- ``cat_pop`` — population of a category
+- ``unique`` — population of unique values
+- ``longtail`` — population of long-tail buckets
+- ``NA`` — population of null values
+
+.. code-block:: typescript
+
+    interface HistogramDisplayerA {
+        displayer: 'histogram';
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "histogram_props": {"displayer_args": {"displayer": "histogram"}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/histogram.html"
+           style="width:100%; height:240px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Chart displayer
+~~~~~~~~~~~~~~~
+
+The ``chart`` displayer is a richer version of the histogram: line,
+area, and bar series can be combined per cell. Series names with the
+prefixes ``line``, ``area``, and ``bar`` are recognized; the suffix
+controls the color. Pass a ``colors`` dict to remap the custom
+(``barCustom1`` / ``barCustom2`` / ``barCustom3``) palette.
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "chart": {"displayer_args": {"displayer": "chart"}},
+        "chart_custom_colors": {"displayer_args": {
+            "displayer": "chart",
+            "colors": {"custom1_color": "pink",
+                       "custom2_color": "brown",
+                       "custom3_color": "beige"},
+        }},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/chart.html"
+           style="width:100%; height:240px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Image displayer
+~~~~~~~~~~~~~~~
+
+``Base64PNGImageDisplayer`` decodes a base64 PNG payload into an
+``<img>``. Pair it with an ``ag_grid_specs.width`` so the column is wide
+enough for the image. The same column can be displayed as a raw string
+in another column to show the underlying payload.
+
+.. code-block:: typescript
+
+    interface Base64PNGImageDisplayerA {
+        displayer: 'Base64PNGImageDisplayer';
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "raw": {"displayer_args": {"displayer": "string",
+                                    "max_length": 40}},
+        "image": {"displayer_args": {"displayer": "Base64PNGImageDisplayer"},
+                  "ag_grid_specs": {"width": 150}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/image.html"
+           style="width:100%; height:240px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Color rules
+-----------
+
+``color_map_config`` controls cell *background* color. It composes with
+``displayer_args`` — you can format numbers *and* color them at the
+same time.
+
+The ``color_rule`` field selects between four strategies described below.
+
+
+Color map (continuous)
+~~~~~~~~~~~~~~~~~~~~~~
+
+``color_rule: "color_map"`` interpolates a built-in or custom palette
+across the column's value range. The optional ``val_column`` lets one
+column be colored based on values from another (e.g. ``float_col``
+shaded by ``int_col``).
+
+Built-in maps: ``BLUE_TO_YELLOW``, ``DIVERGING_RED_WHITE_BLUE``.
+Custom: pass a list of CSS colors.
+
+.. code-block:: typescript
+
+    type ColorMap = 'BLUE_TO_YELLOW' | 'DIVERGING_RED_WHITE_BLUE' | string[];
+    interface ColorMapRules {
+        color_rule: 'color_map';
+        map_name: ColorMap;
+        val_column?: string;  // column whose values drive the gradient
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "float_col": {"color_map_config": {
+            "color_rule": "color_map",
+            "map_name": "BLUE_TO_YELLOW",
+            "val_column": "int_col",
+        }},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/color-map-continuous.html"
+           style="width:100%; height:320px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Color map (explicit palette)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pass an explicit list of CSS colors as ``map_name``. The palette is
+distributed across the value range — useful for flagging values from a
+discrete set of categories.
+
+This example shows the same data with two palette lengths (5 vs 10) and
+two value ranges (5 vs 10 distinct values) to make the distribution
+visible.
+
+.. code-block:: python
+
+    colors_10 = ["green", "blue", "red", "orange", "purple",
+                 "brown", "pink", "beige", "teal", "gray"]
+    colors_5  = ["green", "blue", "red", "orange", "purple"]
+
+    column_config_overrides = {
+        "ten_vals_10_colors":  {"color_map_config": {"color_rule": "color_map",
+                                                      "map_name": colors_10}},
+        "ten_vals_5_colors":   {"color_map_config": {"color_rule": "color_map",
+                                                      "map_name": colors_5}},
+        "five_vals_10_colors": {"color_map_config": {"color_rule": "color_map",
+                                                      "map_name": colors_10}},
+        "five_vals_5_colors":  {"color_map_config": {"color_rule": "color_map",
+                                                      "map_name": colors_5}},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/color-map-explicit.html"
+           style="width:100%; height:320px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Color from column
+~~~~~~~~~~~~~~~~~
+
+``color_rule: "color_from_column"`` reads a literal CSS color from
+another column for each row. Useful when colors are precomputed (e.g.
+mapped from a category by an upstream process).
+
+.. code-block:: typescript
+
+    interface ColorFromColumn {
+        color_rule: 'color_from_column';
+        val_column: string;  // column holding CSS color strings
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "a": {"color_map_config": {
+            "color_rule": "color_from_column",
+            "val_column": "a_colors",
+        }},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/color-from-column.html"
+           style="width:100%; height:180px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Error highlighting (``color_not_null``)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``color_rule: "color_not_null"`` colors a cell when an *adjacent*
+column has a non-null value. The classic shape is: a data column plus
+an error-message column. Show the data, color it red when there's an
+error, surface the message in the tooltip, and hide the message column
+itself so it doesn't clutter the view.
+
+This combines three properties on the same column:
+
+.. code-block:: typescript
+
+    interface ColorWhenNotNullRules {
+        color_rule: 'color_not_null';
+        conditional_color: string;  // any CSS color
+        exist_column: string;        // null-check this column
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "a": {
+            "color_map_config": {
+                "color_rule": "color_not_null",
+                "conditional_color": "red",
+                "exist_column": "err_messages",
+            },
+            "tooltip_config": {
+                "tooltip_type": "simple",
+                "val_column": "err_messages",
+            },
+        },
+        "err_messages": {"merge_rule": "hidden"},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/error-highlight.html"
+           style="width:100%; height:280px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+Tooltip
+-------
+
+``tooltip_config`` populates the hover tooltip from another column.
+Useful when the visible column is truncated (``max_length`` on a
+``string`` displayer) but you want the full value reachable on hover,
+or when one column annotates another.
+
+.. code-block:: typescript
+
+    interface SimpleTooltip {
+        tooltip_type: 'simple';
+        val_column: string;
+    }
+
+.. code-block:: python
+
+    column_config_overrides = {
+        "str_col": {"tooltip_config": {
+            "tooltip_type": "simple",
+            "val_column": "int_col",
+        }},
+    }
+
+.. raw:: html
+
+   <iframe src="../styling/tooltip.html"
+           style="width:100%; height:320px; border:1px solid #e0e0e0; border-radius:4px; margin:1em 0;">
+   </iframe>
+
+
+How styling is applied
+----------------------
+
+For each visible column, buckaroo computes a ``column_config`` dict in
+three layers, last writer wins:
+
+1. **Default styling** — picks a displayer based on the inferred type
+   (``string`` for objects, ``float`` for floats, etc.) and attaches a
+   default tooltip and column width.
+2. **Summary-stat-aware styling** — analysis classes can override the
+   default based on what's in the column (e.g. ``Base64PNGImageDisplayer``
+   when the value looks like a PNG payload).
+3. **``column_config_overrides``** — the dict passed at widget
+   construction. Per-key shallow merge into the result of (1)+(2).
+
+So overrides win, but you don't have to specify every property —
+the defaults fill in the gaps. ``merge_rule: "hidden"`` is special:
+it removes the column from the result rather than overriding its
+``column_config``.
+
+In server mode, ``column_config_overrides`` rides alongside the
+DataFrame display configuration in the session state. When the user
+changes the cleaning method or post-processing option, the dataflow
+rebuilds ``df_display_args`` from scratch — but ``column_config_overrides``
+is re-applied afterwards so per-column styling survives interaction.
+
+
+Building your own styling functions
+-----------------------------------
+
+The static ``column_config_overrides`` dict covers most cases. For
+styling that depends on column *content* (e.g. "color any int column
+whose max value is over 1000"), write a styling function that reads
+summary stats and returns a config dict. See the
+`Styling-Howto notebook
+<https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Styling-Howto.ipynb>`_
+for the full pattern, plus the
+`Styling-Gallery-Pandas
+<https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Styling-Gallery-Pandas.ipynb>`_
+and `Styling-Gallery-Polars
+<https://github.com/buckaroo-data/buckaroo/blob/main/docs/example-notebooks/Styling-Gallery-Polars.ipynb>`_
+notebooks for backend-specific examples.
+
+
+Generating these embeds
+-----------------------
+
+The static embeds on this page were generated with:
+
+.. code-block:: bash
+
+    python scripts/generate_column_config_static_html.py
+
+This produces HTML files in ``docs/extra-html/styling/`` that reference
+the shared ``static-embed.js`` and ``static-embed.css`` bundles
+(produced by ``scripts/full_build.sh``).

--- a/scripts/generate_column_config_static_html.py
+++ b/scripts/generate_column_config_static_html.py
@@ -115,33 +115,27 @@ def chart_fixture():
     return df, cfg
 
 
-# 24x24 PNG smiley — same fixture used by the Marimo gallery.
+# 24x24 PNG smiley, PIL-generated (the Marimo-gallery copy turned out to
+# have a corrupted IDAT chunk that Chrome silently rendered but Firefox
+# rejected with "Image corrupt or truncated").
 _PNG_SMILEY = (
-    "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
-    "AAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURB"
-    "VEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kov"
-    "IHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00Y"
-    "JsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvP"
-    "FxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL"
-    "0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQ"
-    "bqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96Cu"
-    "tRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFth"
-    "atyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlith"
-    "Jtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979"
-    "jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9"
-    "O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosX"
-    "VTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCD"
-    "V1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wb"
-    "wLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjL"
-    "YCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=")
+    "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAnElEQVR42sVVSRKAMAgrjI/y/yd/"
+    "hSed2mEJHVq5QhMwEVpbHATWyex7QoDlMh6fMQ7NAGeINAJBgQ2iDyZXgXcTi0dQHlzVvTUFJwRM"
+    "5UYCtfsHQAPycv0UWzWwOlH/By+XcpEHgJiCPQEREaO6bRqQ1cWMTfuVwcj39WwaaUHRLop0MOpf"
+    "3AN10UgEr/LV6/qXg7PlZJYd/eVxAwbeP1vBDxyQAAAAAElFTkSuQmCC")
 
 
 def image_fixture():
-    df = pd.DataFrame({"raw": [_PNG_SMILEY, None], "image": [_PNG_SMILEY, None]})
+    # Two rows of the same smiley so both cells render (the previous
+    # None-second-row produced a broken-image icon from
+    # ``data:image/png;base64,null``). The PNG is 24x24 — ag-grid row
+    # default is enough to show it without scaling.
+    df = pd.DataFrame({"raw": [_PNG_SMILEY, _PNG_SMILEY],
+        "image": [_PNG_SMILEY, _PNG_SMILEY]})
     cfg = {
         "raw": {"displayer_args": {"displayer": "string", "max_length": 40}},
         "image": {"displayer_args": {"displayer": "Base64PNGImageDisplayer"},
-            "ag_grid_specs": {"width": 150}},
+            "ag_grid_specs": {"width": 80}},
     }
     return df, cfg
 
@@ -180,23 +174,25 @@ def color_map_continuous_fixture():
     return df, cfg
 
 
-def color_map_explicit_fixture():
-    df = pd.DataFrame({"ten_vals_10_colors": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "ten_vals_5_colors": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-        "five_vals_10_colors": [0, 1, 2, 3, 4, None, None, None, None, None, None],
-        "five_vals_5_colors": [0, 1, 2, 3, 4, None, None, None, None, None, None]})
+def color_categorical_fixture():
+    # ``color_categorical`` indexes into the palette directly by the cell
+    # value, no histogram_bins needed — the right tool when the value
+    # itself is the category index (0..N).
+    df = pd.DataFrame({"five_vals_5_colors":  [0, 1, 2, 3, 4, None, None, None, None, None],
+        "five_vals_10_colors": [0, 1, 2, 3, 4, None, None, None, None, None],
+        "ten_vals_5_colors":   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], "ten_vals_10_colors":  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]})
     c10 = ["green", "blue", "red", "orange", "purple", "brown", "pink",
         "beige", "teal", "gray"]
     c5 = ["green", "blue", "red", "orange", "purple"]
     cfg = {
-        "ten_vals_10_colors": {"color_map_config": {"color_rule": "color_map",
-            "map_name": c10}},
-        "ten_vals_5_colors": {"color_map_config": {"color_rule": "color_map",
+        "five_vals_5_colors": {"color_map_config": {"color_rule": "color_categorical",
             "map_name": c5}},
-        "five_vals_10_colors": {"color_map_config": {"color_rule": "color_map",
+        "five_vals_10_colors": {"color_map_config": {"color_rule": "color_categorical",
             "map_name": c10}},
-        "five_vals_5_colors": {"color_map_config": {"color_rule": "color_map",
+        "ten_vals_5_colors": {"color_map_config": {"color_rule": "color_categorical",
             "map_name": c5}},
+        "ten_vals_10_colors": {"color_map_config": {"color_rule": "color_categorical",
+            "map_name": c10}},
     }
     return df, cfg
 
@@ -243,7 +239,7 @@ ENTRIES = [
     ("chart", "Chart Displayer", chart_fixture, []),
     ("image", "Image Displayer", image_fixture, []),
     ("color-map-continuous", "Color Map (Continuous)", color_map_continuous_fixture, []),
-    ("color-map-explicit", "Color Map (Explicit Palette)", color_map_explicit_fixture, []),
+    ("color-categorical", "Color Categorical (Explicit Palette)", color_categorical_fixture, []),
     ("color-from-column", "Color From Column", color_from_column_fixture, []),
     ("error-highlight", "Error Highlighting", error_highlight_fixture, []),
     ("tooltip", "Tooltip", tooltip_fixture, []),

--- a/scripts/generate_column_config_static_html.py
+++ b/scripts/generate_column_config_static_html.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Generate static embed HTML pages for the column-config styling article.
+
+Produces one HTML file per displayer / color rule example in
+docs/extra-html/styling/, drawn from the same data and configs as the
+Marimo styling gallery (docs/example-notebooks/Styling-Gallery-*.ipynb).
+"""
+
+import sys
+import os
+
+# Ensure the repo root is importable
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+import pandas as pd
+
+from buckaroo.artifact import (prepare_buckaroo_artifact, artifact_to_json, _HTML_TEMPLATE)
+
+
+OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "docs", "extra-html", "styling")
+os.makedirs(OUT_DIR, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — one DataFrame + column_config_overrides pair per example.
+# Kept in sync with ~/Downloads/marimo.py so the article reads as the
+# same gallery shown in the Marimo WASM build.
+# ---------------------------------------------------------------------------
+
+def datetime_fixture():
+    ts = ["2020-01-01 01:00Z", "2020-01-01 02:00Z", "2020-02-28 02:00Z",
+        "2020-03-15 02:00Z", None]
+    df = pd.DataFrame({"timestamp": ts, "obj": ts, "default": ts, "en-US": ts, "en-US-long": ts, "en-GB": ts})
+
+    def loc(locale, args=None):
+        out = {"displayer": "datetimeLocaleString", "locale": locale}
+        if args is not None:
+            out["args"] = args
+        return {"displayer_args": out}
+
+    cfg = {"obj": {"displayer_args": {"displayer": "obj"}},
+        "default": {"displayer_args": {"displayer": "datetimeDefault"}}, "en-US": loc("en-US"),
+        "en-US-long": loc("en-US", {"weekday": "long"}), "en-GB": loc("en-GB")}
+    return df, cfg
+
+
+def string_fixture():
+    col = ["asdf", "qwerty", "really long string, much much longer", None, "A"]
+    df = pd.DataFrame({"string_max_len_35": col, "obj_displayer": col, "string_displayer": col})
+    cfg = {"string_max_len_35": {"displayer_args": {"displayer": "string", "max_length": 35}},
+        "obj_displayer": {"displayer_args": {"displayer": "obj"}},
+        "string_displayer": {"displayer_args": {"displayer": "string"}}}
+    return df, cfg
+
+
+def float_fixture():
+    col = [5, -8, 13.23, -8.01, -999.345245234, None]
+    df = pd.DataFrame({"obj_displayer": col, "float_1_3": col, "float_0_3": col, "float_3_3": col, "float_3_13": col})
+
+    def fc(min_d, max_d):
+        return {"displayer_args": {"displayer": "float",
+            "min_fraction_digits": min_d, "max_fraction_digits": max_d}}
+
+    cfg = {"obj_displayer": {"displayer_args": {"displayer": "obj"}}, "float_1_3": fc(1, 3), "float_0_3": fc(0, 3),
+        "float_3_3": fc(3, 3), "float_3_13": fc(3, 13)}
+    return df, cfg
+
+
+def link_fixture():
+    df = pd.DataFrame({
+        "raw": ["https://github.com/paddymul/buckaroo",
+            "https://github.com/pola-rs/polars"],
+        "linkify": ["https://github.com/paddymul/buckaroo",
+            "https://github.com/pola-rs/polars"],
+    })
+    cfg = {"linkify": {"displayer_args": {"displayer": "linkify"}}}
+    return df, cfg
+
+
+def histogram_fixture():
+    data = [[{"name": "NA", "NA": 100.0}], [{"name": 1, "cat_pop": 44.0}, {"name": "NA", "NA": 56.0}],
+        [{"name": "long_97", "cat_pop": 0.0}, {"name": "long_139", "cat_pop": 0.0}, {"name": "long_12", "cat_pop": 0.0},
+         {"name": "long_134", "cat_pop": 0.0}, {"name": "long_21", "cat_pop": 0.0}, {"name": "long_44", "cat_pop": 0.0},
+         {"name": "long_58", "cat_pop": 0.0}, {"name": "longtail", "longtail": 77.0}, {"name": "NA", "NA": 20.0}],
+        [{"name": "long_113", "cat_pop": 0.0}, {"name": "long_116", "cat_pop": 0.0},
+         {"name": "long_33", "cat_pop": 0.0}, {"name": "long_72", "cat_pop": 0.0}, {"name": "long_122", "cat_pop": 0.0},
+         {"name": "long_6", "cat_pop": 0.0}, {"name": "long_83", "cat_pop": 0.0},
+         {"name": "longtail", "unique": 50.0, "longtail": 47.0}]]
+    df = pd.DataFrame({"name": ["all_NA", "half_NA", "longtail", "longtail_unique"], "histogram_props": data})
+    cfg = {"histogram_props": {"displayer_args": {"displayer": "histogram"}}}
+    return df, cfg
+
+
+def chart_fixture():
+    data = [[{"lineRed": 33.0, "areaGray": 100, "barCustom3": 40, "barCustom1": 40,
+        "name": "2000-01-01 00:00:00"}, {"lineRed": 33.0, "areaGray": 20, "name": "2001-01-01 00:00:00"}, {"lineRed": 66,
+            "areaGray": 40, "barCustom2": 60, "name": "unique"}, {"lineRed": 100, "areaGray": 100, "barCustom1": 40,
+                "name": "end"}], [{"barCustom3": 40, "barCustom1": 40, "name": "2000-01-01 00:00:00"},
+                    {"name": "2001-01-01 00:00:00"}, {"barCustom2": 60, "name": "unique"},
+                    {"barCustom1": 40, "name": "end"}], [{"areaRed": 100, "name": "2000-01-01 00:00:00"},
+                        {"areaRed": 20, "name": "2001-01-01 00:00:00"}, {"areaRed": 40, "name": "unique"},
+                        {"areaBlue": 100, "name": "end"}], [{"lineRed": 33.0, "name": "2000-01-01 00:00:00"},
+                            {"lineBlue": 33.0, "name": "2001-01-01 00:00:00"}, {"lineGray": 66, "name": "unique"},
+                            {"lineGray": 100, "name": "end"}]]
+    df = pd.DataFrame({"name": ["everything", "bar custom only", "area", "line"], "chart": data,
+        "chart_custom_colors": data})
+    cfg = {
+        "chart": {"displayer_args": {"displayer": "chart"}},
+        "chart_custom_colors": {"displayer_args": {"displayer": "chart",
+            "colors": {"custom1_color": "pink", "custom2_color": "brown",
+                "custom3_color": "beige"}}},
+    }
+    return df, cfg
+
+
+# 24x24 PNG smiley — same fixture used by the Marimo gallery.
+_PNG_SMILEY = (
+    "iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlz"
+    "AAAApgAAAKYB3X3/OAAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAANCSURB"
+    "VEiJtZZPbBtFFMZ/M7ubXdtdb1xSFyeilBapySVU8h8OoFaooFSqiihIVIpQBKci6KEg9Q6H9kov"
+    "IHoCIVQJJCKE1ENFjnAgcaSGC6rEnxBwA04Tx43t2FnvDAfjkNibxgHxnWb2e/u992bee7tCa00Y"
+    "JsffekFY+nUzFtjW0LrvjRXrCDIAaPLlW0nHL0SsZtVoaF98mLrx3pdhOqLtYPHChahZcYYO7KvP"
+    "FxvRl5XPp1sN3adWiD1ZAqD6XYK1b/dvE5IWryTt2udLFedwc1+9kLp+vbbpoDh+6TklxBeAi9TL"
+    "0taeWpdmZzQDry0AcO+jQ12RyohqqoYoo8RDwJrU+qXkjWtfi8Xxt58BdQuwQs9qC/afLwCw8tnQ"
+    "bqYAPsgxE1S6F3EAIXux2oQFKm0ihMsOF71dHYx+f3NND68ghCu1YIoePPQN1pGRABkJ6Bus96Cu"
+    "tRZMydTl+TvuiRW1m3n0eDl0vRPcEysqdXn+jsQPsrHMquGeXEaY4Yk4wxWcY5V/9scqOMOVUFth"
+    "atyTy8QyqwZ+kDURKoMWxNKr2EeqVKcTNOajqKoBgOE28U4tdQl5p5bwCw7BWquaZSzAPlwjlith"
+    "Jtp3pTImSqQRrb2Z8PHGigD4RZuNX6JYj6wj7O4TFLbCO/Mn/m8R+h6rYSUb3ekokRY6f/YukArN979"
+    "jcW+V/S8g0eT/N3VN3kTqWbQ428m9/8k0P/1aIhF36PccEl6EhOcAUCrXKZXXWS3XKd2vc/TRBG9"
+    "O5ELC17MmWubD2nKhUKZa26Ba2+D3P+4/MNCFwg59oWVeYhkzgN/JDR8deKBoD7Y+ljEjGZ0sosX"
+    "VTvbc6RHirr2reNy1OXd6pJsQ+gqjk8VWFYmHrwBzW/n+uMPFiRwHB2I7ih8ciHFxIkd/3Omk5tCD"
+    "V1t+2nNu5sxxpDFNx+huNhVT3/zMDz8usXC3ddaHBj1GHj/As08fwTS7Kt1HBTmyN29vdwAw+/wb"
+    "wLVOJ3uAD1wi/dUH7Qei66PfyuRj4Ik9is+hglfbkbfR3cnZm7chlUWLdwmprtCohX4HUtlOcQjL"
+    "YCu+fzGJH2QRKvP3UNz8bWk1qMxjGTOMThZ3kvgLI5AzFfo379UAAAAASUVORK5CYII=")
+
+
+def image_fixture():
+    df = pd.DataFrame({"raw": [_PNG_SMILEY, None], "image": [_PNG_SMILEY, None]})
+    cfg = {
+        "raw": {"displayer_args": {"displayer": "string", "max_length": 40}},
+        "image": {"displayer_args": {"displayer": "Base64PNGImageDisplayer"},
+            "ag_grid_specs": {"width": 150}},
+    }
+    return df, cfg
+
+
+def error_highlight_fixture():
+    df = pd.DataFrame({
+        "a": [10, 20, 30, 5, 3, 11, 12],
+        "err_messages": [None, "a must be less than 19, it is 20",
+            "a must be less than 19, it is 30", None, None, None, None],
+    })
+    cfg = {
+        "a": {
+            "color_map_config": {"color_rule": "color_not_null",
+                "conditional_color": "red", "exist_column": "err_messages"},
+            "tooltip_config": {"tooltip_type": "simple", "val_column": "err_messages"},
+        },
+        "err_messages": {"merge_rule": "hidden"},
+    }
+    return df, cfg
+
+
+def color_from_column_fixture():
+    df = pd.DataFrame({"a": [10, 20, 30], "a_colors": ["red", "#d3a", "green"]})
+    cfg = {"a": {"color_map_config": {"color_rule": "color_from_column",
+        "val_column": "a_colors"}}}
+    return df, cfg
+
+
+def color_map_continuous_fixture():
+    rows = 200
+    rng = np.random.default_rng(42)
+    df = pd.DataFrame({"int_col": rng.integers(1, 50, rows), "float_col": rng.integers(1, 30, rows) / 0.7,
+        "str_col": ["foobar"] * rows})
+    cfg = {"float_col": {"color_map_config": {"color_rule": "color_map",
+        "map_name": "BLUE_TO_YELLOW", "val_column": "int_col"}}}
+    return df, cfg
+
+
+def color_map_explicit_fixture():
+    df = pd.DataFrame({"ten_vals_10_colors": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "ten_vals_5_colors": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        "five_vals_10_colors": [0, 1, 2, 3, 4, None, None, None, None, None, None],
+        "five_vals_5_colors": [0, 1, 2, 3, 4, None, None, None, None, None, None]})
+    c10 = ["green", "blue", "red", "orange", "purple", "brown", "pink",
+        "beige", "teal", "gray"]
+    c5 = ["green", "blue", "red", "orange", "purple"]
+    cfg = {
+        "ten_vals_10_colors": {"color_map_config": {"color_rule": "color_map",
+            "map_name": c10}},
+        "ten_vals_5_colors": {"color_map_config": {"color_rule": "color_map",
+            "map_name": c5}},
+        "five_vals_10_colors": {"color_map_config": {"color_rule": "color_map",
+            "map_name": c10}},
+        "five_vals_5_colors": {"color_map_config": {"color_rule": "color_map",
+            "map_name": c5}},
+    }
+    return df, cfg
+
+
+def tooltip_fixture():
+    rows = 30
+    rng = np.random.default_rng(7)
+    df = pd.DataFrame({"int_col": rng.integers(1, 50, rows), "float_col": rng.integers(1, 30, rows) / 0.7,
+        "str_col": ["foobar"] * rows})
+    cfg = {"str_col": {"tooltip_config": {"tooltip_type": "simple",
+        "val_column": "int_col"}}}
+    return df, cfg
+
+
+# (filename, title, fixture_callable)
+ENTRIES = [
+    ("datetime", "Datetime Displayers", datetime_fixture),
+    ("string", "String Displayer", string_fixture),
+    ("float", "Float Displayer", float_fixture),
+    ("link", "Link Displayer", link_fixture),
+    ("histogram", "Histogram Displayer", histogram_fixture),
+    ("chart", "Chart Displayer", chart_fixture),
+    ("image", "Image Displayer", image_fixture),
+    ("color-map-continuous", "Color Map (Continuous)", color_map_continuous_fixture),
+    ("color-map-explicit", "Color Map (Explicit Palette)", color_map_explicit_fixture),
+    ("color-from-column", "Color From Column", color_from_column_fixture),
+    ("error-highlight", "Error Highlighting", error_highlight_fixture),
+    ("tooltip", "Tooltip", tooltip_fixture),
+]
+
+
+def styled_html(df, title, column_config_overrides):
+    artifact = prepare_buckaroo_artifact(
+        df, column_config_overrides=column_config_overrides, embed_type="DFViewer")
+    return _HTML_TEMPLATE.format(title=title, artifact_json=artifact_to_json(artifact))
+
+
+def generate_embed(filename, title, df, column_config_overrides):
+    html = styled_html(df, title, column_config_overrides)
+    path = os.path.join(OUT_DIR, f"{filename}.html")
+    with open(path, "w") as f:
+        f.write(html)
+    print(f"  Generated {path}")
+
+
+def copy_static_assets():
+    import shutil
+
+    static_dir = os.path.join(os.path.dirname(__file__), "..", "buckaroo", "static")
+    for fname in ("static-embed.js", "static-embed.css"):
+        src = os.path.join(static_dir, fname)
+        dst = os.path.join(OUT_DIR, fname)
+        if os.path.exists(src):
+            shutil.copy2(src, dst)
+            print(f"  Copied {fname}")
+        else:
+            print(f"  WARNING: {src} not found — run full_build.sh first")
+
+
+if __name__ == "__main__":
+    print("Generating column-config styling static embeds...")
+    copy_static_assets()
+    for filename, title, fixture in ENTRIES:
+        df, cfg = fixture()
+        generate_embed(filename, title, df, cfg)
+    print(f"\nDone. Files in {OUT_DIR}")

--- a/scripts/generate_column_config_static_html.py
+++ b/scripts/generate_column_config_static_html.py
@@ -16,6 +16,7 @@ import numpy as np
 import pandas as pd
 
 from buckaroo.artifact import (prepare_buckaroo_artifact, artifact_to_json, _HTML_TEMPLATE)
+from buckaroo.styling_helpers import obj_, float_, pinned_histogram, inherit_
 
 
 OUT_DIR = os.path.join(os.path.dirname(__file__), "..", "docs", "extra-html", "styling")
@@ -210,31 +211,55 @@ def tooltip_fixture():
     return df, cfg
 
 
-# (filename, title, fixture_callable)
+# ---------------------------------------------------------------------------
+# Pinned-rows demo — the only example that overrides the default
+# ``pinned_rows=[]`` used by every other entry. Documents the
+# ``pinned_rows=`` argument by showing a non-default value alongside the
+# stats it pins (dtype, histogram, mean, std, min, max).
+# ---------------------------------------------------------------------------
+
+PINNED_ROWS_DEMO = [obj_("dtype"), pinned_histogram(), float_("mean", 2), float_("std", 2), inherit_("min"),
+    inherit_("max")]
+
+
+def pinned_rows_fixture():
+    rng = np.random.default_rng(0)
+    df = pd.DataFrame({"int_col": rng.integers(0, 100, 200), "float_col": rng.normal(50, 15, 200),
+        "str_col": rng.choice(["alpha", "beta", "gamma"], 200)})
+    # No column_config_overrides — this example is only about pinned_rows.
+    return df, {}
+
+
+# (filename, title, fixture_callable, pinned_rows_override)
+# pinned_rows_override defaults to [] so the rendered table has no
+# summary band — the article's whole point is showing only what the
+# column_config does, not the default dtype/histogram pair.
 ENTRIES = [
-    ("datetime", "Datetime Displayers", datetime_fixture),
-    ("string", "String Displayer", string_fixture),
-    ("float", "Float Displayer", float_fixture),
-    ("link", "Link Displayer", link_fixture),
-    ("histogram", "Histogram Displayer", histogram_fixture),
-    ("chart", "Chart Displayer", chart_fixture),
-    ("image", "Image Displayer", image_fixture),
-    ("color-map-continuous", "Color Map (Continuous)", color_map_continuous_fixture),
-    ("color-map-explicit", "Color Map (Explicit Palette)", color_map_explicit_fixture),
-    ("color-from-column", "Color From Column", color_from_column_fixture),
-    ("error-highlight", "Error Highlighting", error_highlight_fixture),
-    ("tooltip", "Tooltip", tooltip_fixture),
+    ("datetime", "Datetime Displayers", datetime_fixture, []),
+    ("string", "String Displayer", string_fixture, []),
+    ("float", "Float Displayer", float_fixture, []),
+    ("link", "Link Displayer", link_fixture, []),
+    ("histogram", "Histogram Displayer", histogram_fixture, []),
+    ("chart", "Chart Displayer", chart_fixture, []),
+    ("image", "Image Displayer", image_fixture, []),
+    ("color-map-continuous", "Color Map (Continuous)", color_map_continuous_fixture, []),
+    ("color-map-explicit", "Color Map (Explicit Palette)", color_map_explicit_fixture, []),
+    ("color-from-column", "Color From Column", color_from_column_fixture, []),
+    ("error-highlight", "Error Highlighting", error_highlight_fixture, []),
+    ("tooltip", "Tooltip", tooltip_fixture, []),
+    ("pinned-rows", "Pinned Summary Rows", pinned_rows_fixture, PINNED_ROWS_DEMO),
 ]
 
 
-def styled_html(df, title, column_config_overrides):
+def styled_html(df, title, column_config_overrides, pinned_rows):
     artifact = prepare_buckaroo_artifact(
-        df, column_config_overrides=column_config_overrides, embed_type="DFViewer")
+        df, column_config_overrides=column_config_overrides,
+        pinned_rows=pinned_rows, embed_type="DFViewer")
     return _HTML_TEMPLATE.format(title=title, artifact_json=artifact_to_json(artifact))
 
 
-def generate_embed(filename, title, df, column_config_overrides):
-    html = styled_html(df, title, column_config_overrides)
+def generate_embed(filename, title, df, column_config_overrides, pinned_rows):
+    html = styled_html(df, title, column_config_overrides, pinned_rows)
     path = os.path.join(OUT_DIR, f"{filename}.html")
     with open(path, "w") as f:
         f.write(html)
@@ -258,7 +283,7 @@ def copy_static_assets():
 if __name__ == "__main__":
     print("Generating column-config styling static embeds...")
     copy_static_assets()
-    for filename, title, fixture in ENTRIES:
+    for filename, title, fixture, pinned_rows in ENTRIES:
         df, cfg = fixture()
-        generate_embed(filename, title, df, cfg)
+        generate_embed(filename, title, df, cfg, pinned_rows)
     print(f"\nDone. Files in {OUT_DIR}")

--- a/tests/unit/serialization_utils_test.py
+++ b/tests/unit/serialization_utils_test.py
@@ -4,7 +4,7 @@ import pandas as pd
 from buckaroo.ddd_library import get_multiindex_with_names_index_df, get_multiindex_cols_df, get_multiindex_index_df
 from buckaroo.serialization_utils import (
     is_ser_dt_safe, is_dataframe_datetime_safe, check_and_fix_df, pd_to_obj,
-    to_parquet, DuplicateColumnsException)
+    to_parquet, DuplicateColumnsException, _json_encode_cell)
 
 
 
@@ -147,5 +147,19 @@ def test_serialize_naive_json():
 #         {'type': 'finite_number', 'loc': ('a',), 'msg': 'Input should be a finite number',
 #          'input': value
 #          }]
+
+
+def test_json_encode_cell_numpy_array_roundtrips():
+    # histogram_bins arrives as a numpy float array; without explicit
+    # ndarray handling _json_encode_cell falls back to default=str and
+    # emits a Python repr like "[ 2.857 6.571 ...]" that JSON.parse can't
+    # decode on the JS side. The encoded string must round-trip through
+    # json.loads to a list of floats.
+    import json
+    import numpy as np
+    bins = np.array([3.0, 7.5, 12.0, 16.5, 21.0])
+    encoded = _json_encode_cell(bins)
+    decoded = json.loads(encoded)
+    assert decoded == [3.0, 7.5, 12.0, 16.5, 21.0]
 
 


### PR DESCRIPTION
## Summary

New ReadTheDocs article mirroring the structure of [theme-customization](https://buckaroo-data.readthedocs.io/en/latest/articles/theme-customization.html), but covering the per-column `column_config_overrides` API instead of the global `theme` config. Each example is a live static embed (iframe → HTML page → `static-embed.js`).

Fixtures and examples are kept in sync with the Marimo styling gallery.

## What's in the article

- **Displayers:** datetime (default + Intl locales), string (max_length), float (fraction-digit control), linkify, histogram, chart (with custom color remap), Base64PNGImageDisplayer.
- **Color rules:** color_map (continuous `BLUE_TO_YELLOW` with `val_column` + explicit-palette variants), color_from_column, color_not_null (paired with tooltip + `merge_rule:"hidden"` for error highlighting).
- **Tooltip:** simple tooltip pulling from another column.
- **How styling is applied:** the three-layer merge (default → summary-stat-aware → overrides) and how it survives interaction in server mode.
- **Programmatic styling pointer:** links to the existing `Styling-Howto` / `Styling-Gallery-Pandas` / `Styling-Gallery-Polars` notebooks for the dynamic / summary-stat-driven pattern this static dict can't express.

## Build wiring

- `scripts/generate_column_config_static_html.py` mirrors `generate_theme_static_html.py`. Fixtures are inline so the script is self-contained — no `~/Downloads/*.py` dependency.
- `docs/.readthedocs.yaml` runs the generator alongside the existing theme/DDD generators. The existing `cp -r docs/extra-html/* …` step already picks up the new `styling/` subdirectory.

## Test plan

- [x] Local sphinx-build succeeds; 12 iframes rendered in `articles/column-config-styling.html`.
- [x] Article + every iframe target + `static-embed.{js,css}` serve over a local HTTP server (all 200).
- [x] Spot-checked generated artifact JSON: float fraction-digit configs, `color_not_null` + `tooltip_config` on `a` + `merge_rule:"hidden"` dropping `err_messages`.
- [ ] RTD build picks up the new generator step and renders the iframes on the published article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)