### PR TITLE
fix(server): move search_string to per-client state (#851)

### DIFF
--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -175,7 +175,12 @@ class LoadHandler(tornado.web.RequestHandler):
         return True
 
     def _push_state_to_clients(self, session, metadata: dict):
-        """Push updated state to all connected WebSocket clients."""
+        """Push updated state to all connected WebSocket clients.
+
+        Also resets each client's live ``search_string`` (#851): the
+        dataset just changed, so a term carried over from the previous
+        load would silently filter the new one.
+        """
         log.info("push_state path=%s ws_clients=%d", metadata.get("filename", "?"), len(session.ws_clients))
         if not session.ws_clients:
             return
@@ -183,6 +188,7 @@ class LoadHandler(tornado.web.RequestHandler):
         push_msg = json.dumps(build_state_message(session, metadata=metadata))
         for client in list(session.ws_clients):
             try:
+                client.search_string = ""
                 client.write_message(push_msg)
             except Exception:
                 session.ws_clients.discard(client)
@@ -242,11 +248,6 @@ class LoadHandler(tornado.web.RequestHandler):
         session.backend = "pandas"
         session.xorq_dataflow = None
         session.expr = None
-        # Reset the live-typed row-fetch filter so a search term carried
-        # over from a prior dataset on this session doesn't silently
-        # filter the new one (Codex P1 on #839). The client's fresh
-        # buckaroo_state has search_string="" — keep the server in sync.
-        session.search_string = ""
         session.prompt = prompt
         if component_config:
             session.component_config = component_config
@@ -388,9 +389,6 @@ class LoadExprHandler(tornado.web.RequestHandler):
         session.df = None
         session.dataflow = None
         session.ldf = None
-        # Reset the live-typed row-fetch filter so a prior term doesn't
-        # silently filter the freshly loaded expression (Codex P1 on #839).
-        session.search_string = ""
         session.metadata = metadata
         session.prompt = prompt
         if component_config:
@@ -422,6 +420,9 @@ class LoadExprHandler(tornado.web.RequestHandler):
             push_msg = json.dumps(build_state_message(session, metadata=metadata))
             for client in list(session.ws_clients):
                 try:
+                    # Reset per-client live search (#851): a term from
+                    # the prior expression would silently filter the new one.
+                    client.search_string = ""
                     client.write_message(push_msg)
                 except Exception:
                     session.ws_clients.discard(client)
@@ -567,6 +568,8 @@ class LoadCompareHandler(tornado.web.RequestHandler):
             push_msg = json.dumps(build_state_message(session))
             for client in list(session.ws_clients):
                 try:
+                    # Reset per-client live search (#851).
+                    client.search_string = ""
                     client.write_message(push_msg)
                 except Exception:
                     session.ws_clients.discard(client)

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -185,11 +185,15 @@ class LoadHandler(tornado.web.RequestHandler):
         if not session.ws_clients:
             return
 
-        push_msg = json.dumps(build_state_message(session, metadata=metadata))
         for client in list(session.ws_clients):
             try:
+                # Reset per-client live search first (dataset changed),
+                # then build the msg so the injected ``buckaroo_state``
+                # mirrors the post-reset value.
                 client.search_string = ""
-                client.write_message(push_msg)
+                msg = build_state_message(session, metadata=metadata,
+                    search_string=client.search_string)
+                client.write_message(json.dumps(msg))
             except Exception:
                 session.ws_clients.discard(client)
 
@@ -417,13 +421,14 @@ class LoadExprHandler(tornado.web.RequestHandler):
                         **component_config}
 
         if session.ws_clients:
-            push_msg = json.dumps(build_state_message(session, metadata=metadata))
             for client in list(session.ws_clients):
                 try:
                     # Reset per-client live search (#851): a term from
                     # the prior expression would silently filter the new one.
                     client.search_string = ""
-                    client.write_message(push_msg)
+                    msg = build_state_message(session, metadata=metadata,
+                        search_string=client.search_string)
+                    client.write_message(json.dumps(msg))
                 except Exception:
                     session.ws_clients.discard(client)
 
@@ -565,12 +570,13 @@ class LoadCompareHandler(tornado.web.RequestHandler):
 
         # Push to WebSocket clients
         if session.ws_clients:
-            push_msg = json.dumps(build_state_message(session))
             for client in list(session.ws_clients):
                 try:
                     # Reset per-client live search (#851).
                     client.search_string = ""
-                    client.write_message(push_msg)
+                    msg = build_state_message(session,
+                        search_string=client.search_string)
+                    client.write_message(json.dumps(msg))
                 except Exception:
                     session.ws_clients.discard(client)
 

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -33,11 +33,11 @@ class SessionState:
     xorq_dataflow: Any = None  # XorqServerDataflow when backend="xorq"
     expr: Any = None  # ibis/xorq expression when backend="xorq"
     buckaroo_state: dict = field(default_factory=dict)
-    # Live search term applied at row-fetch time (#838) — bypasses the
-    # dataflow stat pipeline that ``quick_command_args.search`` goes
-    # through, so per-keystroke filtering stays fast on parquet-backed
-    # exprs with ~10⁶ rows.
-    search_string: str = ""
+    # NOTE: ``search_string`` used to live here, but it's per-client typing
+    # state (not a session-wide property). Two clients sharing a session
+    # were clobbering each other's input via the rebroadcast path (#851).
+    # It now lives on ``DataStreamHandler`` instances; this comment is the
+    # tombstone so anyone reading state ordering doesn't expect it back.
     buckaroo_options: dict = field(default_factory=dict)
     command_config: dict = field(default_factory=dict)
     operation_results: dict = field(default_factory=dict)

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -58,12 +58,20 @@ mismatch. Lockstep with the buckaroo PyPI version is the documented expectation;
 this field is the runtime escape hatch."""
 
 
-def build_state_message(session: "SessionState", metadata: dict | None = None) -> dict:
+def build_state_message(session: "SessionState", metadata: dict | None = None,
+                         search_string: str = "") -> dict:
     """Build the full ``initial_state`` WebSocket payload from a session.
 
     Args:
         session: The session whose state to serialise.
         metadata: Override metadata to include; defaults to ``session.metadata``.
+        search_string: The *recipient client's* per-client live-typed
+            search term (#851). Injected into ``buckaroo_state`` so the
+            JS ``WebSocketModel`` — which replaces ``buckaroo_state``
+            wholesale on receipt — doesn't silently clear the recipient's
+            search box. The session itself never owns this value; callers
+            must pass the right value per recipient (typically
+            ``handler.search_string``).
 
     Returns:
         A dict ready to be JSON-serialised and sent to WebSocket clients.
@@ -73,7 +81,10 @@ def build_state_message(session: "SessionState", metadata: dict | None = None) -
         "prompt": session.prompt, "df_display_args": session.df_display_args, "df_data_dict": session.df_data_dict,
         "df_meta": session.df_meta, "mode": session.mode}
     if session.mode == "buckaroo":
-        msg["buckaroo_state"] = session.buckaroo_state
+        # Per-client search_string overlay (#851 Codex P1): the snapshot
+        # on the session is search-agnostic; we re-inject the recipient's
+        # value here so a missing key can't wipe it on the client.
+        msg["buckaroo_state"] = {**session.buckaroo_state, "search_string": search_string}
         msg["buckaroo_options"] = session.buckaroo_options
         msg["command_config"] = session.command_config
         msg["operation_results"] = session.operation_results

--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -1,3 +1,4 @@
+import copy
 import json
 import logging
 import os
@@ -20,16 +21,21 @@ log = logging.getLogger("buckaroo.server.websocket")
 
 _BUCKAROO_DEBUG = os.environ.get("BUCKAROO_DEBUG", "").lower() in ("1", "true")
 
-# Fields in buckaroo_state that drive dataflow changes; others are ignored.
-# search_string lives here too — it doesn't touch the dataflow itself but
-# the row-fetch dispatch reads ``session.search_string`` and applies a
-# literal-contains filter before paginating (#838).
-_DATAFLOW_FIELDS = ("post_processing", "cleaning_method", "quick_command_args", "search_string")
+# Fields in buckaroo_state that drive *dataflow* changes; mutations to
+# any of these rebuild the dataflow and rebroadcast to every client.
+# ``search_string`` is deliberately NOT here — it's per-client typing
+# state owned by the handler instance (#851).
+_DATAFLOW_FIELDS = ("post_processing", "cleaning_method", "quick_command_args")
 
 
 class DataStreamHandler(tornado.websocket.WebSocketHandler):
     def open(self, session_id):
         self.session_id = session_id
+        # Per-client live search term (#838, fix for #851/cross-client
+        # pollution). Used only by the row-fetch filter and the per-client
+        # highlight overlay below — never broadcast, never stored on the
+        # session.
+        self.search_string = ""
         sessions = self.application.settings["sessions"]
         sessions.add_ws_client(session_id, self)
 
@@ -67,8 +73,26 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             if not isinstance(new_state, dict):
                 raise ValueError(f"new_state must be a dict, got {type(new_state).__name__}")
 
+            # Decide up front whether the dataflow path will run, so we
+            # don't both (a) send a per-client overlay AND (b) broadcast
+            # an initial_state in the same turn. The broadcast already
+            # carries any highlight_phrase that ``quick_command_args.search``
+            # produced via cleaning_sd, so the overlay would be redundant
+            # (and tests/clients that read one message back would see two).
+            dataflow_changed = any(old_state.get(f) != new_state.get(f) for f in _DATAFLOW_FIELDS)
+
+            # Per-client live search (#838 / #851). Update self; if no
+            # dataflow change is coming, send a targeted highlight overlay
+            # to this client only. Never touches the session, never broadcasts.
+            new_search = new_state.get("search_string", "")
+            new_search = new_search if isinstance(new_search, str) else ""
+            if self.search_string != new_search:
+                self.search_string = new_search
+                if not dataflow_changed:
+                    self._send_highlight_overlay(session)
+
             # Skip if no effective change to the fields that drive the dataflow.
-            if all(old_state.get(f) == new_state.get(f) for f in _DATAFLOW_FIELDS):
+            if not dataflow_changed:
                 log.debug("buckaroo_state_change no-op session=%s — skipping rebroadcast", self.session_id)
                 return
 
@@ -79,12 +103,6 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
                 dataflow.cleaning_method = new_state.get("cleaning_method", "")
             if old_state.get("quick_command_args") != new_state.get("quick_command_args"):
                 dataflow.quick_command_args = new_state.get("quick_command_args", {})
-            # search_string is stored on the session — the row-fetch
-            # dispatch reads it instead of pushing it into the dataflow
-            # (#838). Coerce non-string to "" so a malformed payload can't
-            # crash the filter helpers downstream.
-            new_search = new_state.get("search_string", "")
-            session.search_string = new_search if isinstance(new_search, str) else ""
 
             # Re-extract state from the dataflow — same helper works for both
             # ServerDataflow and XorqServerDataflow (verified by probe).
@@ -92,7 +110,10 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             session.df_display_args = buckaroo_state["df_display_args"]
             session.df_data_dict = buckaroo_state["df_data_dict"]
             session.df_meta = buckaroo_state["df_meta"]
-            session.buckaroo_state = new_state
+            # Strip search_string before snapshotting onto the session — it
+            # belongs to this client only (#851), so a future client that
+            # connects shouldn't inherit it via build_state_message.
+            session.buckaroo_state = {k: v for k, v in new_state.items() if k != "search_string"}
             session.buckaroo_options = buckaroo_state["buckaroo_options"]
             session.command_config = buckaroo_state["command_config"]
 
@@ -121,6 +142,44 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
                 err["details"] = tb
             self.write_message(json.dumps(err))
 
+    def _send_highlight_overlay(self, session):
+        """Send this client an ``initial_state`` with highlight_phrase
+        injected into every string-column ``displayer_args`` so live-typed
+        matches highlight in the grid (#851).
+
+        Per-client because ``search_string`` is per-client — another
+        client's term must not bleed into this one's highlight, and a
+        broadcast initial_state would clobber every other input box. We
+        deep-copy ``session.df_display_args`` so the overlay never
+        mutates the shared session snapshot.
+
+        Empty term clears any prior highlight by sending the pristine
+        df_display_args back. Skipped when no display config is loaded
+        yet — the upcoming ``initial_state`` on first load will be
+        unhighlighted, which is correct (search starts empty).
+        """
+        if not session.df_display_args:
+            return
+        term = self.search_string
+        overlay = copy.deepcopy(session.df_display_args)
+        for dva in overlay.values():
+            dvc = (dva or {}).get("df_viewer_config") or {}
+            for col in dvc.get("column_config", []) or []:
+                disp = col.get("displayer_args")
+                if not isinstance(disp, dict) or disp.get("displayer") != "string":
+                    continue
+                if term:
+                    disp["highlight_phrase"] = [term]
+                else:
+                    disp.pop("highlight_phrase", None)
+
+        msg = build_state_message(session)
+        msg["df_display_args"] = overlay
+        try:
+            self.write_message(json.dumps(msg))
+        except Exception:
+            log.debug("highlight overlay write failed for session=%s", self.session_id)
+
     def _handle_infinite_request(self, payload_args):
         sessions = self.application.settings["sessions"]
         session = sessions.get(self.session_id)
@@ -131,12 +190,14 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             return
 
         def _dispatch(pa):
-            # search_string is the per-session live-typed filter (#838) —
-            # passed alongside payload_args rather than mixed into it so
-            # the WS-level row-fetch contract (start/end/sort) stays
-            # untouched and each backend can apply the filter in its
-            # native expression layer.
-            search = session.search_string or ""
+            # search_string is the per-CLIENT live-typed filter (#838 /
+            # #851) — read off self so two clients sharing the session
+            # don't fight over each other's input. Passed alongside
+            # payload_args rather than mixed into it so the WS-level
+            # row-fetch contract (start/end/sort) stays untouched and
+            # each backend can apply the filter in its native
+            # expression layer.
+            search = self.search_string or ""
             if session.mode == "lazy" and session.ldf is not None:
                 return handle_infinite_request_lazy(session.ldf, session.orig_to_rw,
                     session.rw_to_orig, session.metadata.get("rows", 0), pa)

--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -39,10 +39,11 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
         sessions = self.application.settings["sessions"]
         sessions.add_ws_client(session_id, self)
 
-        # Send initial state if session already has data loaded
+        # Send initial state if session already has data loaded.
+        # search_string="" — fresh connection, no per-client typing yet.
         session = sessions.get(session_id)
         if session and (session.df is not None or session.ldf is not None or session.xorq_dataflow is not None):
-            self.write_message(json.dumps(build_state_message(session)))
+            self.write_message(json.dumps(build_state_message(session, search_string=self.search_string)))
 
     def on_message(self, message):
         try:
@@ -127,11 +128,15 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
                             **session.component_config,
                         }
 
-            # Broadcast updated state to all connected clients
-            update_payload = json.dumps(build_state_message(session))
+            # Broadcast updated state to all connected clients. Each
+            # client gets its own search_string re-injected so a
+            # dataflow rebuild from one tab doesn't silently clear the
+            # search box on another (or on the typing client itself).
             for client in list(session.ws_clients):
                 try:
-                    client.write_message(update_payload)
+                    msg = build_state_message(session,
+                        search_string=getattr(client, "search_string", ""))
+                    client.write_message(json.dumps(msg))
                 except Exception:
                     session.ws_clients.discard(client)
         except Exception:
@@ -173,7 +178,11 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
                 else:
                     disp.pop("highlight_phrase", None)
 
-        msg = build_state_message(session)
+        # Pass self.search_string so the overlay's buckaroo_state
+        # round-trips the typed term back to this client (Codex P1 on
+        # #854 — without it the JS clears the search box on every
+        # keystroke).
+        msg = build_state_message(session, search_string=self.search_string)
         msg["df_display_args"] = overlay
         try:
             self.write_message(json.dumps(msg))

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -433,6 +433,97 @@ class TestWebSocket(tornado.testing.AsyncHTTPTestCase):
                 os.unlink(f.name)
 
     @tornado.testing.gen_test
+    async def test_search_string_echoed_in_overlay_buckaroo_state(self):
+        """Codex P1 on #854: when a client sends a search-only state change,
+        the server's overlay reply must carry that ``search_string`` inside
+        ``buckaroo_state``. Otherwise the JS ``WebSocketModel`` replaces
+        ``state.buckaroo_state`` wholesale with a copy missing the key,
+        React's local ``buckarooState.search_string`` resets to ``""`` and
+        the search box clears on every keystroke."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                sid = "ws-search-echo"
+                await _async_fetch(self.get_http_port(), "/load",
+                    method="POST",
+                    body=json.dumps({"session": sid, "path": f.name, "mode": "buckaroo"}))
+
+                ws = await tornado.websocket.websocket_connect(
+                    f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+                await ws.read_message()  # initial_state on connect
+
+                ws.write_message(json.dumps({
+                    "type": "buckaroo_state_change",
+                    "new_state": {
+                        "post_processing": "", "cleaning_method": "",
+                        "quick_command_args": {}, "df_display": "main",
+                        "show_commands": False, "sampled": False,
+                        "search_string": "Alice"}}))
+                msg = json.loads(await ws.read_message())
+                self.assertEqual(msg["type"], "initial_state")
+                self.assertEqual(msg["buckaroo_state"].get("search_string"), "Alice",
+                    "overlay reply must echo the client's search_string in buckaroo_state — "
+                    "missing key would clobber the React-local value on every keystroke")
+                ws.close()
+            finally:
+                os.unlink(f.name)
+
+    @tornado.testing.gen_test
+    async def test_search_string_per_client_in_dataflow_broadcast(self):
+        """Codex P1 on #854: when client A triggers a dataflow rebuild,
+        the broadcast ``initial_state`` must carry *A's* per-client
+        search_string back to A — and a separate client B sharing the
+        session must see *its own* search_string (here ``""``), not A's.
+        The session-level snapshot is search-agnostic; the per-client
+        value lives only on the handler."""
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                sid = "ws-search-broadcast"
+                await _async_fetch(self.get_http_port(), "/load",
+                    method="POST",
+                    body=json.dumps({"session": sid, "path": f.name, "mode": "buckaroo"}))
+
+                ws_a = await tornado.websocket.websocket_connect(
+                    f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+                await ws_a.read_message()
+                ws_b = await tornado.websocket.websocket_connect(
+                    f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+                await ws_b.read_message()
+
+                # A types a search — overlay-only, B unaffected.
+                ws_a.write_message(json.dumps({
+                    "type": "buckaroo_state_change",
+                    "new_state": {
+                        "post_processing": "", "cleaning_method": "",
+                        "quick_command_args": {}, "df_display": "main",
+                        "show_commands": False, "sampled": False,
+                        "search_string": "Alice"}}))
+                await ws_a.read_message()  # consume A's overlay
+
+                # Now A triggers a dataflow change. Server rebuilds and
+                # broadcasts initial_state to both. Each client's msg
+                # should carry their own search_string.
+                ws_a.write_message(json.dumps({
+                    "type": "buckaroo_state_change",
+                    "new_state": {
+                        "post_processing": "", "cleaning_method": "",
+                        "quick_command_args": {"sort": "name"},
+                        "df_display": "main",
+                        "show_commands": False, "sampled": False,
+                        "search_string": "Alice"}}))
+                msg_a = json.loads(await ws_a.read_message())
+                msg_b = json.loads(await ws_b.read_message())
+                self.assertEqual(msg_a["buckaroo_state"].get("search_string"), "Alice",
+                    "A's broadcast copy must preserve A's per-client search_string")
+                self.assertEqual(msg_b["buckaroo_state"].get("search_string"), "",
+                    "B's broadcast copy must carry B's empty search_string, not A's")
+                ws_a.close()
+                ws_b.close()
+            finally:
+                os.unlink(f.name)
+
+    @tornado.testing.gen_test
     async def test_ws_request_no_data_loaded(self):
         ws = await tornado.websocket.websocket_connect(
             f"ws://localhost:{self.get_http_port()}/ws/no-data-session")


### PR DESCRIPTION
## Summary
- `search_string` lived on `SessionState` and was rebroadcast to every WS client on any buckaroo_state change. Two clients sharing a session (iframe + notebook, two tabs) clobbered each other's search term on every keystroke.
- Moved to `DataStreamHandler` instance state. `_DATAFLOW_FIELDS` no longer includes it; per-client edits send a targeted *highlight overlay* (deep-copied `df_display_args` with `highlight_phrase` injected into string-column `displayer_args`) instead of broadcasting an `initial_state`. Live-typed highlight stays in sync with the per-client filter without polluting other clients.
- `/load`, `/load_expr`, and `/compare` push paths reset `client.search_string` on dataset change.

## Test plan
- [ ] `pytest tests/unit/server/` — existing search_string row-fetch tests still pass.
- [ ] Manual: open the same session in an iframe and a separate tab — typing in one box no longer changes the other's term or grid.

Closes #851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)