### PR TITLE
feat(server): /load accepts backend='polars' for buckaroo dataflow

### DIFF
--- a/buckaroo/server/data_loading_polars.py
+++ b/buckaroo/server/data_loading_polars.py
@@ -1,0 +1,135 @@
+"""Polars counterparts of the pandas-based loaders in ``data_loading``.
+
+Lives in its own module so polars stays an optional dependency — the
+server only imports this when ``/load`` is called with
+``backend: "polars"``. Mirrors the shape of ``data_loading``:
+
+* :func:`load_file_polars` reads parquet/csv/tsv/json eagerly into a
+  ``pl.DataFrame``.
+* :class:`PolarsServerDataflow` is the polars analogue of
+  ``ServerDataflow`` — same role in the pipeline, polars-flavored
+  analysis / autocleaning / stats / sampling classes (lifted from
+  ``PolarsBuckarooInfiniteWidget``).
+* :func:`handle_infinite_request_buckaroo_polars` is the polars
+  equivalent of ``handle_infinite_request_buckaroo`` — applies the
+  live ``search_string`` as a literal substring match on String
+  columns (mirrors ``search_df_str`` semantics from the pandas path
+  so the client-facing behaviour is identical).
+"""
+import os
+import traceback
+from io import BytesIO
+
+import polars as pl
+
+from buckaroo.dataflow.dataflow import CustomizableDataflow
+from buckaroo.dataflow.autocleaning import PandasAutocleaning
+from buckaroo.customizations.pl_autocleaning_conf import NoCleaningConfPl
+from buckaroo.pluggable_analysis_framework.df_stats_v2 import PlDfStatsV2
+from buckaroo.polars_buckaroo import (
+    PLSampling, local_analysis_klasses, prepare_df_for_serialization)
+from buckaroo.serialization_utils import pd_to_obj
+
+
+class PolarsServerSampling(PLSampling):
+    """Server-mode polars sampling. Inherits ``PLSampling``'s widget
+    defaults but caps pre-stats work at ``pre_limit`` so a multi-million-row
+    /load doesn't OOM the stats pipeline."""
+    pre_limit = 1_000_000
+    serialize_limit = -1  # infinite mode — no per-page sample cap
+
+
+class PolarsServerDataflow(CustomizableDataflow):
+    """Headless polars dataflow matching ``PolarsBuckarooInfiniteWidget``."""
+    analysis_klasses = local_analysis_klasses
+    autocleaning_klass = PandasAutocleaning
+    autoclean_conf = tuple([NoCleaningConfPl])
+    DFStatsClass = PlDfStatsV2
+    sampling_klass = PolarsServerSampling
+
+    def _df_to_obj(self, df):
+        # Matches PolarsBuckarooWidget._df_to_obj — pandas frames pass
+        # straight through, polars frames go via to_pandas for the JSON
+        # initial-state path. (The hot path is the parquet infinite handler
+        # below, not this; this is only the initial empty/seed payload.)
+        import pandas as pd
+        if isinstance(df, pd.DataFrame):
+            return pd_to_obj(self.sampling_klass.serialize_sample(df))
+        return pd_to_obj(self.sampling_klass.serialize_sample(df.to_pandas()))
+
+
+def load_file_polars(path: str) -> pl.DataFrame:
+    """Eager polars read. Extension dispatch mirrors :func:`load_file`."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".csv":
+        return pl.read_csv(path)
+    elif ext == ".tsv":
+        return pl.read_csv(path, separator="\t")
+    elif ext in (".parquet", ".parq"):
+        return pl.read_parquet(path)
+    elif ext == ".json":
+        return pl.read_ndjson(path)
+    else:
+        raise ValueError(f"Unsupported file format: {ext}")
+
+
+def get_metadata_polars(df: pl.DataFrame, path: str) -> dict:
+    columns = [{"name": str(c), "dtype": str(d)} for c, d in zip(df.columns, df.dtypes)]
+    return {"path": path, "rows": len(df), "columns": columns}
+
+
+def create_polars_dataflow(df, column_config_overrides=None, extra_grid_config=None, init_sd=None) -> PolarsServerDataflow:
+    return PolarsServerDataflow(df, column_config_overrides=column_config_overrides,
+        extra_grid_config=extra_grid_config, init_sd=init_sd, skip_main_serial=True)
+
+
+def handle_infinite_request_buckaroo_polars(
+    dataflow: PolarsServerDataflow, payload_args: dict, search_string: str = ""
+) -> tuple[dict, bytes]:
+    """Polars analogue of :func:`handle_infinite_request_buckaroo`.
+
+    ``search_string`` is the live-typed filter (#838) — applied as a
+    literal substring match across all polars ``String`` columns.
+    Literal (``literal=True``) so user typing isn't treated as regex;
+    this matches the pandas server path's ``search_df_str`` semantics.
+    """
+    from buckaroo.server.window import clamp_window
+
+    _unused, processed_df, merged_sd = dataflow.widget_args_tuple
+    if processed_df is None:
+        return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0}, b"")
+    try:
+        if search_string:
+            string_cols = [c for c, dt in zip(processed_df.columns, processed_df.dtypes)
+                if dt == pl.String]
+            if string_cols:
+                mask = pl.any_horizontal(
+                    pl.col(c).str.contains(search_string, literal=True)
+                    for c in string_cols)
+                filtered_df = processed_df.filter(mask)
+            else:
+                filtered_df = processed_df
+        else:
+            filtered_df = processed_df
+
+        start, end = clamp_window(
+            payload_args.get("start"), payload_args.get("end"), len(filtered_df))
+
+        sort = payload_args.get("sort")
+        if sort:
+            ascending = payload_args.get("sort_direction") == "asc"
+            converted_sort_column = merged_sd[sort]["orig_col_name"]
+            sorted_df = filtered_df.with_row_index().sort(
+                converted_sort_column, descending=not ascending)
+            slice_df = sorted_df[start:end]
+        else:
+            slice_df = filtered_df.with_row_index()[start:end]
+
+        out = BytesIO()
+        prepare_df_for_serialization(slice_df).write_parquet(out, compression="uncompressed")
+        parquet_bytes = out.getvalue()
+        msg = {"type": "infinite_resp", "key": payload_args, "data": [], "length": len(filtered_df)}
+        return msg, parquet_bytes
+    except Exception:
+        return ({"type": "infinite_resp", "key": payload_args, "data": [], "length": 0,
+            "error_info": traceback.format_exc()}, b"")

--- a/buckaroo/server/data_loading_polars.py
+++ b/buckaroo/server/data_loading_polars.py
@@ -59,7 +59,13 @@ class PolarsServerDataflow(CustomizableDataflow):
 
 
 def load_file_polars(path: str) -> pl.DataFrame:
-    """Eager polars read. Extension dispatch mirrors :func:`load_file`."""
+    """Eager polars read. Extension dispatch mirrors :func:`load_file`.
+
+    ``.json`` uses ``pl.read_json`` (standard JSON array of records) to
+    match ``pd.read_json``'s default ``lines=False`` — same file must
+    load under either backend. Newline-delimited JSON is reachable via
+    the explicit ``.ndjson`` extension.
+    """
     ext = os.path.splitext(path)[1].lower()
     if ext == ".csv":
         return pl.read_csv(path)
@@ -68,6 +74,8 @@ def load_file_polars(path: str) -> pl.DataFrame:
     elif ext in (".parquet", ".parq"):
         return pl.read_parquet(path)
     elif ext == ".json":
+        return pl.read_json(path)
+    elif ext == ".ndjson":
         return pl.read_ndjson(path)
     else:
         raise ValueError(f"Unsupported file format: {ext}")
@@ -108,7 +116,12 @@ def handle_infinite_request_buckaroo_polars(
                     for c in string_cols)
                 filtered_df = processed_df.filter(mask)
             else:
-                filtered_df = processed_df
+                # No string columns to search → no matches. ``search_df_str``
+                # starts from an all-False mask and only ORs over string/object
+                # columns, so a non-empty search on a numeric-only frame
+                # produces an empty result. Matching that here keeps the UI
+                # honest: a search term should never silently appear unfiltered.
+                filtered_df = processed_df.clear()
         else:
             filtered_df = processed_df
 

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -135,9 +135,9 @@ class LoadHandler(tornado.web.RequestHandler):
         return body
 
     def _validate_request(self, body: dict) -> tuple:
-        """Validate and extract session_id, path, mode, prompt, no_browser, and component_config from request.
+        """Validate and extract session_id, path, mode, prompt, no_browser, component_config, backend from request.
 
-        Returns (session_id, path, mode, prompt, no_browser, component_config) or a tuple of Nones on error.
+        Returns (session_id, path, mode, prompt, no_browser, component_config, backend) or a tuple of Nones on error.
 
         ``session`` is optional — when omitted the server mints a UUID and
         returns it in the response. Lets Tauri/Electron-style hosts call /load
@@ -149,7 +149,7 @@ class LoadHandler(tornado.web.RequestHandler):
         if not path:
             self.set_status(400)
             self.write({"error": "Missing 'path'"})
-            return None, None, None, None, None, None
+            return None, None, None, None, None, None, None
 
         if not session_id:
             session_id = uuid.uuid4().hex
@@ -158,7 +158,12 @@ class LoadHandler(tornado.web.RequestHandler):
         prompt = body.get("prompt", "")
         no_browser = bool(body.get("no_browser", False))
         component_config = body.get("component_config")
-        return session_id, path, mode, prompt, no_browser, component_config
+        # ``backend`` is mode="buckaroo"-only: "pandas" (default) builds a
+        # ServerDataflow against pandas; "polars" builds a PolarsServerDataflow.
+        # Validated/branched in ``post`` — silently passed through here so a
+        # bad value surfaces as a 400 from the loader, not a TypeError.
+        backend = str(body.get("backend", "pandas")).lower()
+        return session_id, path, mode, prompt, no_browser, component_config, backend
 
     def _load_lazy_polars(self, session, path: str, ldf, metadata: dict):
         """Set up lazy polars session state."""
@@ -195,6 +200,38 @@ class LoadHandler(tornado.web.RequestHandler):
         port = self.application.settings["port"]
         return find_or_create_session_window(session_id, port, reload_if_found=True)
 
+    def _load_polars_with_error_handling(self, path: str):
+        """Eager polars load for ``backend='polars'``. Errors share the
+        same shape as the pandas loader so the response surface is
+        identical from the client's POV."""
+        try:
+            from buckaroo.server.data_loading_polars import load_file_polars, get_metadata_polars
+            df = load_file_polars(path)
+            metadata = get_metadata_polars(df, path)
+            return df, metadata
+        except FileNotFoundError:
+            self.set_status(404)
+            self.write({"error_code": "file_not_found", "message": f"File not found: {path}"})
+            return None, None
+        except ImportError:
+            self.set_status(400)
+            self.write({"error_code": "missing_dependency",
+                "message": "backend='polars' requires polars to be installed"})
+            return None, None
+        except ValueError as e:
+            self.set_status(400)
+            self.write({"error_code": "invalid_file", "message": str(e)})
+            return None, None
+        except Exception:
+            tb = traceback.format_exc()
+            log.error("polars load error path=%s: %s", path, tb)
+            resp: dict = {"error_code": "load_error", "message": "Failed to load file"}
+            if _BUCKAROO_DEBUG:
+                resp["details"] = tb
+            self.set_status(500)
+            self.write(resp)
+            return None, None
+
     def _load_file_with_error_handling(self, path: str, is_lazy: bool):
         """Load file and handle errors. Returns (file_obj, metadata) or (None, None)."""
         try:
@@ -229,17 +266,30 @@ class LoadHandler(tornado.web.RequestHandler):
         if body is None:
             return
 
-        session_id, path, mode, prompt, no_browser, component_config = self._validate_request(body)
+        session_id, path, mode, prompt, no_browser, component_config, backend = self._validate_request(body)
         if session_id is None:
+            return
+
+        # ``backend`` only affects mode="buckaroo". Reject early so a
+        # mismatched lazy/viewer request doesn't silently look fine.
+        if backend not in ("pandas", "polars"):
+            self.set_status(400)
+            self.write({"error_code": "invalid_backend",
+                "message": f"backend must be 'pandas' or 'polars', got {backend!r}"})
+            return
+        if backend == "polars" and mode != "buckaroo":
+            self.set_status(400)
+            self.write({"error_code": "invalid_backend",
+                "message": "backend='polars' is only valid with mode='buckaroo'"})
             return
 
         sessions = self.application.settings["sessions"]
         session = sessions.get_or_create(session_id, path)
         session.mode = mode
-        # Loading via /load is always pandas — clear any xorq state left
+        # Loading via /load is pandas or polars — clear any xorq state left
         # by a prior /load_expr on the same session so WS dispatch routes
-        # to the new pandas dataflow rather than a stale xorq one.
-        session.backend = "pandas"
+        # to the new dataflow rather than a stale xorq one.
+        session.backend = backend
         session.xorq_dataflow = None
         session.expr = None
         # Reset the live-typed row-fetch filter so a search term carried
@@ -252,7 +302,10 @@ class LoadHandler(tornado.web.RequestHandler):
             session.component_config = component_config
 
         # Load data in appropriate mode
-        file_obj, metadata = self._load_file_with_error_handling(path, is_lazy=(mode == "lazy"))
+        if backend == "polars" and mode == "buckaroo":
+            file_obj, metadata = self._load_polars_with_error_handling(path)
+        else:
+            file_obj, metadata = self._load_file_with_error_handling(path, is_lazy=(mode == "lazy"))
         if file_obj is None:
             return
 
@@ -262,7 +315,11 @@ class LoadHandler(tornado.web.RequestHandler):
             session.df = file_obj
             session.metadata = metadata
             if mode == "buckaroo":
-                dataflow = create_dataflow(file_obj)
+                if backend == "polars":
+                    from buckaroo.server.data_loading_polars import create_polars_dataflow
+                    dataflow = create_polars_dataflow(file_obj)
+                else:
+                    dataflow = create_dataflow(file_obj)
                 session.dataflow = dataflow
                 buckaroo_state = get_buckaroo_display_state(dataflow)
                 session.df_display_args = buckaroo_state["df_display_args"]

--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -142,6 +142,9 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
                     session.rw_to_orig, session.metadata.get("rows", 0), pa)
             if session.mode == "buckaroo" and session.backend == "xorq" and session.xorq_dataflow:
                 return _handle_infinite_request_xorq(session.xorq_dataflow, pa, search_string=search)
+            if session.mode == "buckaroo" and session.backend == "polars" and session.dataflow:
+                from buckaroo.server.data_loading_polars import handle_infinite_request_buckaroo_polars
+                return handle_infinite_request_buckaroo_polars(session.dataflow, pa, search_string=search)
             if session.mode == "buckaroo" and session.dataflow:
                 return handle_infinite_request_buckaroo(session.dataflow, pa, search_string=search)
             return handle_infinite_request(session.df, pa)

--- a/tests/unit/server/test_data_loading_polars.py
+++ b/tests/unit/server/test_data_loading_polars.py
@@ -1,0 +1,95 @@
+"""Unit tests for ``buckaroo.server.data_loading_polars``.
+
+Covers behaviour added in PR #855 (``backend='polars'`` for ``/load``)
+and pins parity with the pandas path on two edge cases flagged in code
+review:
+
+* Search across a frame with no string columns returns 0 rows (matches
+  ``search_df_str`` semantics so the UI doesn't appear unfiltered).
+* ``.json`` files are read as standard JSON arrays (matches
+  ``pd.read_json`` default ``lines=False`` so the same file loads under
+  either backend).
+"""
+import json
+import os
+import tempfile
+
+import polars as pl
+import pytest
+
+from buckaroo.server.data_loading_polars import (
+    create_polars_dataflow,
+    handle_infinite_request_buckaroo_polars,
+    load_file_polars,
+)
+
+
+def _payload(start=0, end=100):
+    return {"start": start, "end": end}
+
+
+def test_search_with_no_string_columns_returns_empty():
+    """P1 (#855 codex): non-empty search on a numeric-only frame must
+    return 0 rows. The pandas path's ``search_df_str`` OR-accumulates
+    matches over string/object columns starting from an all-False mask,
+    so a frame with no such columns produces an empty result. The polars
+    handler must match — otherwise users see the full frame and assume
+    search is broken."""
+    df = pl.DataFrame({"x": [1, 2, 3], "y": [4.0, 5.0, 6.0]})
+    dataflow = create_polars_dataflow(df)
+    msg, _parquet = handle_infinite_request_buckaroo_polars(
+        dataflow, _payload(), search_string="anything")
+    assert msg["length"] == 0, (
+        f"search on numeric-only frame should return 0 rows "
+        f"(matching pandas search_df_str), got length={msg['length']}")
+
+
+def test_search_with_string_columns_still_works():
+    """Sanity check the fix doesn't break the happy path: a literal
+    substring match on a frame with string columns should still filter
+    to matching rows."""
+    df = pl.DataFrame({"name": ["alice", "bob", "carol"], "x": [1, 2, 3]})
+    dataflow = create_polars_dataflow(df)
+    msg, _parquet = handle_infinite_request_buckaroo_polars(
+        dataflow, _payload(), search_string="ali")
+    assert msg["length"] == 1, f"expected 1 row matching 'ali', got {msg['length']}"
+
+
+def test_load_file_polars_json_array():
+    """P2 (#855 codex): ``.json`` must read a standard JSON array of
+    records — matching ``pd.read_json`` default ``lines=False``. The
+    initial implementation used ``pl.read_ndjson`` which only accepts
+    newline-delimited JSON, so a file that loads fine under
+    ``backend='pandas'`` would 500 under ``backend='polars'``."""
+    records = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}, {"a": 3, "b": "z"}]
+    with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as f:
+        json.dump(records, f)
+        path = f.name
+    try:
+        df = load_file_polars(path)
+        assert df.shape == (3, 2), f"expected (3, 2), got {df.shape}"
+        assert sorted(df.columns) == ["a", "b"]
+    finally:
+        os.unlink(path)
+
+
+def test_load_file_polars_ndjson_still_works():
+    """Newline-delimited JSON should still load — via the ``.ndjson``
+    extension. Keeps support for the format the original implementation
+    handled, just behind a distinct extension so ``.json`` can mean
+    standard JSON (matching pandas)."""
+    records = [{"a": 1, "b": "x"}, {"a": 2, "b": "y"}]
+    with tempfile.NamedTemporaryFile("w", suffix=".ndjson", delete=False) as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+        path = f.name
+    try:
+        df = load_file_polars(path)
+        assert df.shape == (2, 2)
+    finally:
+        os.unlink(path)
+
+
+def test_load_file_polars_unsupported_extension():
+    with pytest.raises(ValueError, match="Unsupported file format"):
+        load_file_polars("/tmp/foo.xyz")

--- a/tests/unit/server/test_data_loading_polars.py
+++ b/tests/unit/server/test_data_loading_polars.py
@@ -17,11 +17,7 @@ import tempfile
 import polars as pl
 import pytest
 
-from buckaroo.server.data_loading_polars import (
-    create_polars_dataflow,
-    handle_infinite_request_buckaroo_polars,
-    load_file_polars,
-)
+from buckaroo.server.data_loading_polars import (create_polars_dataflow, handle_infinite_request_buckaroo_polars, load_file_polars)
 
 
 def _payload(start=0, end=100):


### PR DESCRIPTION
## Summary
- `/load` was hardcoded to pandas (`load_file` → `create_dataflow`); the polars buckaroo dataflow was only reachable via the notebook widget. Demos that embed via the standalone server (iframe / `BuckarooServerView`) couldn't exercise it.
- Adds `backend: 'polars'` to the POST body (default `'pandas'`, polars validated as `mode='buckaroo'`-only). New module `data_loading_polars.py` with `PolarsServerDataflow` (config lifted from `PolarsBuckarooInfiniteWidget`), eager polars file loader, and `handle_infinite_request_buckaroo_polars` (literal-substring `str.contains` across String columns to match pandas `search_df_str` semantics).
- WS dispatch routes `session.backend == 'polars'` to the new handler; pandas / xorq branches untouched. Polars stays optional — `data_loading_polars` is lazy-imported.

Usage:
```python
POST /load { "session": "demo", "path": "data.parquet", "mode": "buckaroo", "backend": "polars" }
```

## Test plan
- [ ] `pytest tests/unit/server/` — existing pandas-backend `/load` tests still pass (92 passed locally).
- [ ] Manual: POST /load with backend=polars, then open the session — grid renders, sorting and search work end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)