### PR TITLE
fix(js): export parquetRead/parquetMetadata from static-embed.js

### DIFF
--- a/packages/js/static-embed.tsx
+++ b/packages/js/static-embed.tsx
@@ -3,6 +3,11 @@ import * as ReactDOM from "react-dom/client";
 import { BuckarooStaticTable, resolveDFDataAsync, preResolveDFDataDict } from "buckaroo-js-core";
 import "../buckaroo-js-core/dist/style.css";
 
+// Named exports so callers can import parquetRead from static-embed.js directly
+// and feed raw ArrayBuffer parquet (e.g. from fetch()) without base64 encoding.
+export { parquetRead, parquetMetadata } from "hyparquet";
+export { resolveDFDataAsync, preResolveDFDataDict } from "buckaroo-js-core";
+
 async function main() {
     const dataEl = document.getElementById("buckaroo-data");
     if (!dataEl?.textContent) {

--- a/packages/js/static-embed.tsx
+++ b/packages/js/static-embed.tsx
@@ -5,20 +5,14 @@ import "../buckaroo-js-core/dist/style.css";
 
 // Named exports so callers can import parquetRead from static-embed.js directly
 // and feed raw ArrayBuffer parquet (e.g. from fetch()) without base64 encoding.
-export { parquetRead, parquetMetadata } from "hyparquet";
-export { resolveDFDataAsync, preResolveDFDataDict } from "buckaroo-js-core";
+// Re-exported via buckaroo-js-core (which re-exports from hyparquet) to keep a
+// single source of truth for the parquet decoder.
+export { parquetRead, parquetMetadata, resolveDFDataAsync, preResolveDFDataDict } from "buckaroo-js-core";
 
-async function main() {
-    const dataEl = document.getElementById("buckaroo-data");
-    if (!dataEl?.textContent) {
-        throw new Error("No #buckaroo-data script block found");
-    }
-    const artifact = JSON.parse(dataEl.textContent);
-
-    const rootEl = document.getElementById("root");
-    if (!rootEl) throw new Error("No #root element found");
-
-    // Pre-resolve parquet_b64 payloads before React render
+// Resolve any parquet_b64 payloads in the artifact and render it into rootEl.
+// Exported so callers that fetch raw parquet (via the exported parquetRead)
+// can build an artifact at runtime and trigger the same render main() does.
+export async function renderArtifact(rootEl: HTMLElement, artifact: any) {
     const [dfData, summaryStatsData] = await Promise.all([
         resolveDFDataAsync(artifact.df_data),
         resolveDFDataAsync(artifact.summary_stats_data),
@@ -31,11 +25,9 @@ async function main() {
         summary_stats_data: summaryStatsData,
     };
 
-    // For Buckaroo mode, pre-resolve all parquet_b64 values in df_data_dict
     if (artifact.embed_type === "Buckaroo" && artifact.df_data_dict) {
         resolved.df_display_args = artifact.df_display_args;
         resolved.df_data_dict = await preResolveDFDataDict(artifact.df_data_dict);
-        // Ensure "main" key has the already-resolved data
         resolved.df_data_dict["main"] = dfData;
         resolved.df_meta = artifact.df_meta;
         resolved.buckaroo_options = artifact.buckaroo_options;
@@ -48,6 +40,16 @@ async function main() {
             <BuckarooStaticTable artifact={resolved} />
         </div>
     );
+}
+
+async function main() {
+    const dataEl = document.getElementById("buckaroo-data");
+    // When the bundle is imported purely as a library (for parquetRead / renderArtifact),
+    // there is no #buckaroo-data; silently skip auto-init instead of erroring.
+    if (!dataEl?.textContent) return;
+    const rootEl = document.getElementById("root");
+    if (!rootEl) throw new Error("No #root element found");
+    await renderArtifact(rootEl, JSON.parse(dataEl.textContent));
 }
 
 main().catch((e) => {


### PR DESCRIPTION
Closes #857.

## Summary

- Adds named exports `parquetRead`, `parquetMetadata`, `resolveDFDataAsync`, `preResolveDFDataDict`, and `renderArtifact` to `packages/js/static-embed.tsx`
- All parquet exports route through `buckaroo-js-core` so the parquet decoder has a single source of truth
- `main()` silently skips when there is no `#buckaroo-data`, so the bundle can be imported purely as a library without a spurious "No #buckaroo-data script block found" console error
- esbuild already outputs ESM (`--format=esm`) — no build-config changes
- Existing `<script src="static-embed.js">` pages continue to work unchanged

## What this enables

Pages served over HTTP can fetch raw parquet + an artifact-metadata JSON separately, decode the parquet client-side without base64 inflation, and render Buckaroo:

```js
import { parquetRead, renderArtifact } from './static-embed.js';

const [artifact, buf] = await Promise.all([
    fetch('/artifact.json').then(r => r.json()),       // df_viewer_config, summary_stats_data, etc.
    fetch('/data.parquet').then(r => r.arrayBuffer()), // raw bytes, no base64
]);

const rows = await new Promise((resolve, reject) =>
    parquetRead({ file: buf, rowFormat: 'object', onComplete: resolve, onError: reject })
);

// Remap header names → internal col_names (a, b, c…), coerce BigInt → Number, then:
artifact.df_data = rows;
await renderArtifact(document.getElementById('root'), artifact);
```

This skips the ~33% base64 overhead and lets the parquet file be cached and served separately from the HTML.

## Notes for callers

- `parquetRead` returns `INT64` columns as `BigInt`; coerce to `Number` before splicing into `df_data` if your column was a plain int.
- Buckaroo internally renames columns to `a, b, c…`; the original names live on `df_viewer_config.column_config[i].header_name`. Use that to remap decoded row keys to `col_name`.

## Test plan

- [x] `pnpm run build:static` produces a bundle that exports `parquetRead`, `parquetMetadata`, `resolveDFDataAsync`, `preResolveDFDataDict`, `renderArtifact` — verified
- [x] Manually verified end-to-end with a fetched parquet + artifact JSON rendering full Buckaroo (with summary stats / histograms)
- [ ] Existing static-embed Playwright tests pass (`pnpm test:static-embed`) — 7 failures reproduce on the un-edited PR branch and appear pre-existing; needs separate investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)