### PR TITLE
feat(server): /load_expr accepts cache_storage_path for stat cache prewarm

### DIFF
--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -113,6 +113,11 @@ class XorqStatPipeline:
                 "xorq is required for XorqStatPipeline. "
                 "Install with: pip install buckaroo[xorq]")
 
+        if backend is not None and cache_storage is not None:
+            raise ValueError(
+                "backend and cache_storage are mutually exclusive: "
+                "pass one or the other, not both")
+
         self.all_stat_funcs = _normalize_inputs(stat_funcs)
         self._original_inputs = list(stat_funcs)
         self.backend = backend

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -106,7 +106,8 @@ class XorqStatPipeline:
     EXTERNAL_KEYS = frozenset(
         {"orig_col_name", "rewritten_col_name", "dtype", "length", "min", "max"})
 
-    def __init__(self, stat_funcs: list, backend: Any = None, unit_test: bool = True):
+    def __init__(self, stat_funcs: list, backend: Any = None, unit_test: bool = True,
+                 cache_storage=None):
         if not HAS_XORQ:
             raise ImportError(
                 "xorq is required for XorqStatPipeline. "
@@ -115,6 +116,7 @@ class XorqStatPipeline:
         self.all_stat_funcs = _normalize_inputs(stat_funcs)
         self._original_inputs = list(stat_funcs)
         self.backend = backend
+        self.cache_storage = cache_storage
 
         # Validate the full DAG up front (raises DAGConfigError on misconfig).
         self.ordered_stat_funcs = build_typed_dag(
@@ -139,6 +141,8 @@ class XorqStatPipeline:
     def _execute(self, query):
         if self.backend is not None:
             return self.backend.execute(query)
+        if self.cache_storage is not None:
+            return query.cache(cache=self.cache_storage).execute()
         return query.execute()
 
     def _maybe_materialize(self, table):
@@ -198,7 +202,9 @@ class XorqStatPipeline:
         passed in — the user's backend is for their queries, not ours.
         """
         saved_backend = self.backend
+        saved_cache = self.cache_storage
         self.backend = None
+        self.cache_storage = None
         try:
             table = xo.memtable(PERVERSE_DF)
             _, errors = self.process_table(table)
@@ -209,6 +215,7 @@ class XorqStatPipeline:
             return False, []
         finally:
             self.backend = saved_backend
+            self.cache_storage = saved_cache
 
     def process_table(self, table) -> Tuple[SDType, List[StatError]]:
         materialized, cleanup = self._maybe_materialize(table)
@@ -403,13 +410,15 @@ class XorqDfStatsV2:
         # (issue #709). DAG validation still runs as part of __init__.
         XorqStatPipeline(objs, unit_test=False)
 
-    def __init__(self, table, col_analysis_objs, operating_df_name=None, debug=False):
+    def __init__(self, table, col_analysis_objs, operating_df_name=None, debug=False,
+                 cache_storage=None):
         self.table = table
         # Skip the unit_test PERVERSE_DF run on each widget construction —
         # it doubles the SQL query count (issue #709). The DAG-validation
         # cost is already paid by verify_analysis_objects on first set up
         # and by the test suite. Mirrors PlDfStatsV2.
-        self.ap = XorqStatPipeline(col_analysis_objs, unit_test=False)
+        self.ap = XorqStatPipeline(col_analysis_objs, unit_test=False,
+            cache_storage=cache_storage)
         self.operating_df_name = operating_df_name
         self.debug = debug
         self.sdf, self.errs = self.ap.process_table_v1_compat(self.table)

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -421,6 +421,7 @@ class LoadExprHandler(tornado.web.RequestHandler):
         component_config = body.get("component_config")
 
         project_root = body.get("project_root")
+        cache_storage_path = body.get("cache_storage_path")
 
         try:
             expr = xorq_loading.load_expr_build_dir(build_dir)
@@ -429,7 +430,8 @@ class LoadExprHandler(tornado.web.RequestHandler):
                 + xorq_loading.load_project_post_processing_klasses(project_root)
                 if project_root else [])
             xorq_dataflow = xorq_loading.XorqServerDataflow(
-                expr, skip_main_serial=True, extra_klasses=extra_klasses)
+                expr, skip_main_serial=True, extra_klasses=extra_klasses,
+                cache_storage_path=cache_storage_path)
             metadata = xorq_loading.get_xorq_metadata(xorq_dataflow, build_dir)
         except FileNotFoundError:
             self.set_status(404)

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -23,6 +23,20 @@ from buckaroo.xorq_buckaroo import (
 log = logging.getLogger(__name__)
 
 
+def _make_cache_storage(cache_storage_path):
+    """Build a ``ParquetSnapshotCache`` from a filesystem path string.
+
+    Returns ``None`` when ``cache_storage_path`` is falsy so callers can
+    check with a simple ``if self.cache_storage``.
+    """
+    if not cache_storage_path:
+        return None
+    from xorq.caching import ParquetSnapshotCache, ParquetStorage, SnapshotStrategy  # noqa: PLC0415
+    from xorq.api import connect  # noqa: PLC0415
+    storage = ParquetStorage(source=connect(), base_path=Path(cache_storage_path))
+    return ParquetSnapshotCache(strategy=SnapshotStrategy(), storage=storage)
+
+
 class XorqServerDataflow(XorqDataflow):
     """Headless XorqDataflow with infinite sampling.
 
@@ -46,12 +60,13 @@ class XorqServerDataflow(XorqDataflow):
     DFStatsClass = XorqDfStatsV2
     analysis_klasses = _XORQ_ANALYSIS_KLASSES
 
-    def __init__(self, expr, *args, extra_klasses=None, **kwargs):
+    def __init__(self, expr, *args, extra_klasses=None, cache_storage_path=None, **kwargs):
         if extra_klasses:
             # Per-instance override — class-level _XORQ_ANALYSIS_KLASSES is
             # left untouched so other sessions / direct widget usage don't
             # inherit one project's stats.
             self.analysis_klasses = list(_XORQ_ANALYSIS_KLASSES) + list(extra_klasses)
+        self.cache_storage = _make_cache_storage(cache_storage_path)
         super().__init__(expr, *args, **kwargs)
 
 

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -32,8 +32,7 @@ def _make_cache_storage(cache_storage_path):
     if not cache_storage_path:
         return None
     from xorq.caching import ParquetSnapshotCache, ParquetStorage, SnapshotStrategy  # noqa: PLC0415
-    from xorq.api import connect  # noqa: PLC0415
-    storage = ParquetStorage(source=connect(), base_path=Path(cache_storage_path))
+    storage = ParquetStorage(base_path=Path(cache_storage_path))
     return ParquetSnapshotCache(strategy=SnapshotStrategy(), storage=storage)
 
 

--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -166,7 +166,12 @@ class XorqDataflow(CustomizableDataflow):
                     'orig_col_name': orig_col,
                     'rewritten_col_name': rewritten_col}
             return empty, {}
-        sdf, errs = super()._get_summary_sd(processed_df)
+        cache_storage = getattr(self, 'cache_storage', None)
+        stats = self.DFStatsClass(
+            processed_df, self.analysis_klasses, self.df_name,
+            debug=self.debug, cache_storage=cache_storage)
+        sdf = stats.sdf
+        errs = stats.errs if stats.errs else {}
         rewritten = {}
         for orig_col, rewritten_col in old_col_new_col(processed_df):
             col_meta = dict(sdf.get(orig_col, {}))

--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -171,7 +171,12 @@ class XorqDataflow(CustomizableDataflow):
             processed_df, self.analysis_klasses, self.df_name,
             debug=self.debug, cache_storage=cache_storage)
         sdf = stats.sdf
-        errs = stats.errs if stats.errs else {}
+        if stats.errs:
+            if self.debug:
+                raise Exception("Error executing analysis")
+            errs = stats.errs
+        else:
+            errs = {}
         rewritten = {}
         for orig_col, rewritten_col in old_col_new_col(processed_df):
             col_meta = dict(sdf.get(orig_col, {}))

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -373,3 +373,27 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
         finally:
             shutil.rmtree(builds_root, ignore_errors=True)
             os.unlink(csv_path)
+
+    @tornado.testing.gen_test
+    async def test_cache_storage_path_accepted(self):
+        """POST /load_expr with cache_storage_path must succeed and write cache
+        files to the specified directory on stat execution."""
+        builds_root = tempfile.mkdtemp()
+        cache_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            resp = await _post(self.get_http_port(), "/load_expr",
+                {"session": "lx-cache", "build_dir": build_path,
+                 "cache_storage_path": cache_root})
+            self.assertEqual(resp.code, 200)
+            body = json.loads(resp.body)
+            self.assertEqual(body["rows"], 10)
+            # At least one cache file must have been written.
+            cache_files = []
+            for root, _dirs, files in os.walk(cache_root):
+                cache_files.extend(files)
+            self.assertGreater(len(cache_files), 0,
+                f"expected cache files under {cache_root}, found none")
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+            shutil.rmtree(cache_root, ignore_errors=True)


### PR DESCRIPTION
Closes #864.

## Summary

- `POST /load_expr` now accepts an optional `cache_storage_path` field
- When set, `XorqServerDataflow` constructs a `ParquetSnapshotCache` pointing at that directory and stores it as `self.cache_storage`
- `XorqDataflow._get_summary_sd` reads `self.cache_storage` (via `getattr` with a `None` default, so the widget path is unaffected) and passes it to `XorqDfStatsV2`
- `XorqDfStatsV2.__init__` passes it through to `XorqStatPipeline`
- `XorqStatPipeline._execute` wraps every stat query with `.cache(cache=self.cache_storage).execute()` when the storage is set; the batch aggregate and all per-column histogram queries are covered by this single hook
- `unit_test()` saves and restores `cache_storage` alongside `backend` so PERVERSE_DF smoke tests never write to the caller's cache path
- Behaviour is identical to today when `cache_storage_path` is omitted

## Test plan

- [ ] `tests/unit/server/test_load_expr.py::TestLoadExpr::test_cache_storage_path_accepted` — new test: POSTs `/load_expr` with `cache_storage_path`, asserts `rows=10` and that at least one parquet file was written under the cache dir
- [ ] Full `test_load_expr.py` suite (9 tests) passes locally
- [ ] Full Python unit suite (1052 tests) passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)