### PR TITLE
feat(server): POST /reload_expr/<session_id> — refresh klasses on live xorq session

### DIFF
--- a/buckaroo/server/app.py
+++ b/buckaroo/server/app.py
@@ -3,7 +3,7 @@ import time
 
 import tornado.web
 
-from buckaroo.server.handlers import HealthHandler, DiagnosticsHandler, LoadHandler, LoadExprHandler, LoadCompareHandler, SessionPageHandler
+from buckaroo.server.handlers import HealthHandler, DiagnosticsHandler, LoadHandler, LoadExprHandler, LoadCompareHandler, ReloadExprHandler, SessionPageHandler
 from buckaroo.server.websocket_handler import DataStreamHandler
 from buckaroo.server.session import SessionManager
 
@@ -30,6 +30,7 @@ def make_app(sessions: SessionManager | None = None, port: int = 8888, open_brow
             (r"/diagnostics", DiagnosticsHandler),
             (r"/load", LoadHandler),
             (r"/load_expr", LoadExprHandler),
+            (r"/reload_expr/([^/]+)", ReloadExprHandler),
             (r"/load_compare", LoadCompareHandler),
             (r"/s/([^/]+)", SessionPageHandler),
             (r"/ws/([^/]+)", DataStreamHandler),

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -452,6 +452,8 @@ class LoadExprHandler(tornado.web.RequestHandler):
         session.mode = "buckaroo"
         session.backend = "xorq"
         session.expr = expr
+        session.build_dir = build_dir
+        session.project_root = project_root
         session.xorq_dataflow = xorq_dataflow
         # Clear pandas-side state left by a prior /load on the same
         # session so WS dispatch can no longer reach a stale dataflow.
@@ -657,6 +659,95 @@ class LoadCompareHandler(tornado.web.RequestHandler):
 
         self.write({"session": session_id, "server_pid": os.getpid(), "browser_action": browser_action,
             "rows": len(merged_df), "columns": [str(c) for c in merged_df.columns], "eqs": eqs})
+
+
+class ReloadExprHandler(tornado.web.RequestHandler):
+    """POST /reload_expr/<session_id> — refresh post-processing and stat
+    klasses on a live xorq session without restarting the server.
+
+    Re-scans ``<project_root>/stats/`` and ``<project_root>/post_processing/``
+    for the session's stored project root, rebuilds the ``XorqServerDataflow``
+    with the fresh klass list, and broadcasts the updated ``command_config``
+    and ``buckaroo_options`` to all open WebSocket clients. The expression
+    and its cached stats are reused — no re-execute against the data backend.
+
+    Returns 404 when the session does not exist, 400 when it is not a xorq
+    session or has no project_root recorded, 501 when xorq is not installed."""
+
+    async def post(self, session_id):
+        sessions = self.application.settings["sessions"]
+        session = sessions.get(session_id)
+        if session is None:
+            self.set_status(404)
+            self.write({"error_code": "session_not_found",
+                "message": f"Session not found: {session_id}"})
+            return
+
+        if session.backend != "xorq" or session.xorq_dataflow is None:
+            self.set_status(400)
+            self.write({"error_code": "not_xorq_session",
+                "message": "Session is not a xorq session"})
+            return
+
+        if not session.project_root:
+            self.set_status(400)
+            self.write({"error_code": "no_project_root",
+                "message": "Session has no project_root — pass project_root to /load_expr first"})
+            return
+
+        try:
+            from buckaroo.server import xorq_loading
+        except ImportError:
+            self.set_status(501)
+            self.write({"error_code": "xorq_not_installed",
+                "message": "xorq is not installed on this server. "
+                "Install with `pip install buckaroo[xorq]`."})
+            return
+
+        try:
+            extra_klasses = (
+                xorq_loading.load_project_stat_klasses(session.project_root)
+                + xorq_loading.load_project_post_processing_klasses(session.project_root))
+            xorq_dataflow = xorq_loading.XorqServerDataflow(
+                session.expr, skip_main_serial=True, extra_klasses=extra_klasses)
+        except Exception:
+            tb = traceback.format_exc()
+            log.error("reload_expr error session=%s: %s", session_id, tb)
+            resp: dict = {"error_code": "reload_expr_error",
+                "message": "Failed to reload xorq klasses"}
+            if _BUCKAROO_DEBUG:
+                resp["details"] = tb
+            self.set_status(500)
+            self.write(resp)
+            return
+
+        session.xorq_dataflow = xorq_dataflow
+        session.df_display_args = xorq_dataflow.df_display_args
+        session.df_data_dict = xorq_dataflow.df_data_dict
+        session.df_meta = xorq_dataflow.df_meta
+        session.buckaroo_options = xorq_dataflow.buckaroo_options
+        session.command_config = xorq_dataflow.command_config
+
+        if session.component_config and session.df_display_args:
+            for key in session.df_display_args:
+                dvc = session.df_display_args[key].get("df_viewer_config")
+                if dvc is not None:
+                    dvc["component_config"] = {
+                        **dvc.get("component_config", {}),
+                        **session.component_config}
+
+        for client in list(session.ws_clients):
+            try:
+                msg = build_state_message(session,
+                    search_string=getattr(client, "search_string", ""))
+                client.write_message(json.dumps(msg))
+            except Exception:
+                session.ws_clients.discard(client)
+
+        klass_count = len(extra_klasses)
+        log.info("reload_expr session=%s project_root=%s klasses=%d",
+            session_id, session.project_root, klass_count)
+        self.write({"session": session_id, "klasses_loaded": klass_count})
 
 
 def _render_engine_bar(datasets: list) -> tuple:

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -721,12 +721,26 @@ class ReloadExprHandler(tornado.web.RequestHandler):
             self.write(resp)
             return
 
+        # Replay the session's active buckaroo state onto the new dataflow so
+        # a user who had selected a post-processing method or set
+        # cleaning_method / quick_command_args before the reload doesn't
+        # silently get unfiltered results while the UI still shows their
+        # previous selection.
+        bs = session.buckaroo_state
+        if bs.get("post_processing"):
+            xorq_dataflow.post_processing_method = bs["post_processing"]
+        if bs.get("cleaning_method"):
+            xorq_dataflow.cleaning_method = bs["cleaning_method"]
+        if bs.get("quick_command_args"):
+            xorq_dataflow.quick_command_args = bs["quick_command_args"]
+
+        refreshed = get_buckaroo_display_state(xorq_dataflow)
         session.xorq_dataflow = xorq_dataflow
-        session.df_display_args = xorq_dataflow.df_display_args
-        session.df_data_dict = xorq_dataflow.df_data_dict
-        session.df_meta = xorq_dataflow.df_meta
-        session.buckaroo_options = xorq_dataflow.buckaroo_options
-        session.command_config = xorq_dataflow.command_config
+        session.df_display_args = refreshed["df_display_args"]
+        session.df_data_dict = refreshed["df_data_dict"]
+        session.df_meta = refreshed["df_meta"]
+        session.buckaroo_options = refreshed["buckaroo_options"]
+        session.command_config = refreshed["command_config"]
 
         if session.component_config and session.df_display_args:
             for key in session.df_display_args:

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -32,6 +32,8 @@ class SessionState:
     dataflow: Any = None  # ServerDataflow when backend="pandas"
     xorq_dataflow: Any = None  # XorqServerDataflow when backend="xorq"
     expr: Any = None  # ibis/xorq expression when backend="xorq"
+    build_dir: Optional[str] = None  # xorq build dir, stored for /reload_expr
+    project_root: Optional[str] = None  # project root for klass discovery
     buckaroo_state: dict = field(default_factory=dict)
     # NOTE: ``search_string`` used to live here, but it's per-client typing
     # state (not a session-wide property). Two clients sharing a session

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -372,4 +372,116 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             ws.close()
         finally:
             shutil.rmtree(builds_root, ignore_errors=True)
+
+
+class TestReloadExpr(tornado.testing.AsyncHTTPTestCase):
+    def get_app(self):
+        return make_app()
+
+    def test_reload_expr_session_not_found(self):
+        resp = self.fetch(
+            "/reload_expr/no-such-session", method="POST", body="",
+            headers={"Content-Type": "application/json"})
+        self.assertEqual(resp.code, 404)
+        body = json.loads(resp.body)
+        self.assertEqual(body["error_code"], "session_not_found")
+
+    @tornado.testing.gen_test
+    async def test_reload_expr_not_xorq_session(self):
+        """/reload_expr on a pandas session must return 400."""
+        csv_fd, csv_path = tempfile.mkstemp(suffix=".csv")
+        os.close(csv_fd)
+        try:
+            import pandas as pd
+            pd.DataFrame({"x": [1, 2]}).to_csv(csv_path, index=False)
+            await _post(self.get_http_port(), "/load",
+                {"session": "re-pandas", "path": csv_path, "mode": "buckaroo"})
+            resp = await _post(self.get_http_port(), "/reload_expr/re-pandas", {})
+            self.assertEqual(resp.code, 400)
+            body = json.loads(resp.body)
+            self.assertEqual(body["error_code"], "not_xorq_session")
+        finally:
             os.unlink(csv_path)
+
+    @tornado.testing.gen_test
+    async def test_reload_expr_no_project_root(self):
+        """Session loaded via /load_expr without project_root must return 400."""
+        builds_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": "re-no-pr", "build_dir": build_path})
+            resp = await _post(self.get_http_port(), "/reload_expr/re-no-pr", {})
+            self.assertEqual(resp.code, 400)
+            body = json.loads(resp.body)
+            self.assertEqual(body["error_code"], "no_project_root")
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
+    async def test_reload_expr_broadcasts_updated_options(self):
+        """Adding a post_processing file to project_root and calling
+        /reload_expr must surface the new method in buckaroo_options
+        broadcast to WS clients — without re-executing the expression."""
+        builds_root = tempfile.mkdtemp()
+        project_root = tempfile.mkdtemp()
+        pp_dir = os.path.join(project_root, "post_processing")
+        os.makedirs(pp_dir)
+        try:
+            build_path = _build_expr_dir(builds_root)
+            sid = "re-broadcast"
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": sid, "build_dir": build_path,
+                 "project_root": project_root})
+
+            ws = await tornado.websocket.websocket_connect(
+                f"ws://localhost:{self.get_http_port()}/ws/{sid}")
+            init_msg = json.loads(await ws.read_message())
+            initial_options = init_msg.get("buckaroo_options", {})
+            initial_pp = initial_options.get("post_processing", [])
+
+            # Write a minimal post-processing file into the project.
+            pp_file = os.path.join(pp_dir, "double_idx.py")
+            with open(pp_file, "w") as f:
+                f.write("def process(expr):\n    return expr\n")
+
+            reload_resp = await _post(
+                self.get_http_port(), f"/reload_expr/{sid}", {})
+            self.assertEqual(reload_resp.code, 200)
+            body = json.loads(reload_resp.body)
+            self.assertEqual(body["session"], sid)
+            self.assertGreaterEqual(body["klasses_loaded"], 1)
+
+            # The WS client must receive an updated initial_state carrying
+            # the new post-processing method in buckaroo_options.
+            updated_msg = json.loads(await ws.read_message())
+            self.assertEqual(updated_msg["type"], "initial_state")
+            updated_options = updated_msg.get("buckaroo_options", {})
+            updated_pp = updated_options.get("post_processing", [])
+            self.assertGreater(len(updated_pp), len(initial_pp),
+                f"expected new pp klass in options; before={initial_pp} after={updated_pp}")
+
+            ws.close()
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+            shutil.rmtree(project_root, ignore_errors=True)
+
+    @tornado.testing.gen_test
+    async def test_reload_expr_returns_200_with_zero_klasses(self):
+        """Empty project_root is valid — reload returns 200 with klasses_loaded=0."""
+        builds_root = tempfile.mkdtemp()
+        project_root = tempfile.mkdtemp()
+        try:
+            build_path = _build_expr_dir(builds_root)
+            sid = "re-empty-pr"
+            await _post(self.get_http_port(), "/load_expr",
+                {"session": sid, "build_dir": build_path,
+                 "project_root": project_root})
+
+            resp = await _post(self.get_http_port(), f"/reload_expr/{sid}", {})
+            self.assertEqual(resp.code, 200)
+            body = json.loads(resp.body)
+            self.assertEqual(body["klasses_loaded"], 0)
+        finally:
+            shutil.rmtree(builds_root, ignore_errors=True)
+            shutil.rmtree(project_root, ignore_errors=True)

--- a/tests/unit/server/test_load_expr.py
+++ b/tests/unit/server/test_load_expr.py
@@ -374,35 +374,6 @@ class TestLoadExpr(tornado.testing.AsyncHTTPTestCase):
             shutil.rmtree(builds_root, ignore_errors=True)
 
 
-class TestReloadExpr(tornado.testing.AsyncHTTPTestCase):
-    def get_app(self):
-        return make_app()
-
-    def test_reload_expr_session_not_found(self):
-        resp = self.fetch(
-            "/reload_expr/no-such-session", method="POST", body="",
-            headers={"Content-Type": "application/json"})
-        self.assertEqual(resp.code, 404)
-        body = json.loads(resp.body)
-        self.assertEqual(body["error_code"], "session_not_found")
-
-    @tornado.testing.gen_test
-    async def test_reload_expr_not_xorq_session(self):
-        """/reload_expr on a pandas session must return 400."""
-        csv_fd, csv_path = tempfile.mkstemp(suffix=".csv")
-        os.close(csv_fd)
-        try:
-            import pandas as pd
-            pd.DataFrame({"x": [1, 2]}).to_csv(csv_path, index=False)
-            await _post(self.get_http_port(), "/load",
-                {"session": "re-pandas", "path": csv_path, "mode": "buckaroo"})
-            resp = await _post(self.get_http_port(), "/reload_expr/re-pandas", {})
-            self.assertEqual(resp.code, 400)
-            body = json.loads(resp.body)
-            self.assertEqual(body["error_code"], "not_xorq_session")
-        finally:
-            os.unlink(csv_path)
-
     @tornado.testing.gen_test
     async def test_cache_storage_path_accepted(self):
         """POST /load_expr with cache_storage_path must succeed and write cache


### PR DESCRIPTION
Closes #869.

## Summary

- `POST /reload_expr/<session_id>` re-scans `<project_root>/stats/` and `<project_root>/post_processing/`, rebuilds `XorqServerDataflow` with fresh `extra_klasses`, and broadcasts `initial_state` to all open WS clients. The ibis expression is reused — no re-execution against the data backend.
- `SessionState` gains two new fields: `build_dir` and `project_root`, stored by `LoadExprHandler.post` so the reload endpoint can act without a second call from the client.
- Error surface: 404 on unknown session, 400 on non-xorq session or missing `project_root`, 501 when xorq is not installed.

## Test plan

- `TestReloadExpr::test_reload_expr_session_not_found` — 404 on unknown session
- `TestReloadExpr::test_reload_expr_not_xorq_session` — 400 on pandas session
- `TestReloadExpr::test_reload_expr_no_project_root` — 400 when no project_root stored
- `TestReloadExpr::test_reload_expr_broadcasts_updated_options` — writes a new `post_processing/*.py` file, calls `/reload_expr`, asserts WS client receives `initial_state` with the new method in `buckaroo_options.post_processing`
- `TestReloadExpr::test_reload_expr_returns_200_with_zero_klasses` — empty project root returns 200 with `klasses_loaded=0`

All 13 tests in `test_load_expr.py` pass (8 existing + 5 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)