### PR TITLE
ci: merge npm release into PyPI release workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,11 +1,11 @@
 name: Release npm
 
-# Standalone workflow that publishes packages/buckaroo-js-core to npm.
-# Kept separate from Release (PyPI) so we can iterate on it without
-# touching the wheel/PyPI pipeline. To keep buckaroo-js-core in lockstep
-# with the Python package, run this with `version` set to the same
-# semver as the matching Python release (e.g. the git tag created by
-# the Release workflow).
+# Emergency standalone workflow for re-publishing buckaroo-js-core to npm.
+# The normal path is the release-npm job in release.yml, which runs
+# automatically after the PyPI release and inherits the version from it.
+# Use this workflow only when you need to re-publish a specific version
+# without triggering a full PyPI release (e.g. after a Trusted Publisher
+# config fix or a transient npm outage).
 #
 # Auth: npm Trusted Publishing via OIDC (no NPM_TOKEN secret). Register
 # this repo + workflow as a Trusted Publisher in the npm UI:
@@ -63,7 +63,7 @@ jobs:
       - name: Upgrade npm to a Trusted-Publishing-capable version
         # Trusted Publishing requires npm >= 11.5.1. The global npm dir
         # on github-hosted runners is root-owned, so sudo is needed.
-        run: sudo npm install -g npm@latest
+        run: sudo npm install -g npm@11.5.1
 
       - name: OIDC diagnostics (compare against npm Trusted Publisher config)
         # Prints the values npm checks against the Trusted Publisher

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 20
     environment: pypi
+    outputs:
+      version: ${{ steps.versions.outputs.new }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -183,3 +185,83 @@ jobs:
           name: changelog-${{ steps.versions.outputs.new }}
           path: /tmp/changelog_entry.md
           if-no-files-found: ignore
+
+  release-npm:
+    name: Publish buckaroo-js-core to npm
+    needs: release
+    # GitHub-hosted runner required: npm Trusted Publishing OIDC is only
+    # supported on github-hosted runners (Depot's depot-ubuntu-latest is
+    # treated as self-hosted and won't receive npm OIDC credentials).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.10.0
+
+      - name: Setup Node.js with npm registry
+        uses: actions/setup-node@v6
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: 'packages/pnpm-lock.yaml'
+
+      - name: Install pnpm dependencies
+        working-directory: packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        # Trusted Publishing requires npm >= 11.5.1. The global npm dir
+        # on github-hosted runners is root-owned, so sudo is needed.
+        run: sudo npm install -g npm@latest
+
+      - name: OIDC diagnostics (compare against npm Trusted Publisher config)
+        # NOTE: the npm Trusted Publisher on npmjs.com must be updated to
+        # point to "release.yml" (not "release-npm.yml") now that this job
+        # lives here. See https://www.npmjs.com/package/buckaroo-js-core/access
+        run: |
+          echo "npm version:              $(npm --version)"
+          echo "GITHUB_REPOSITORY:        ${GITHUB_REPOSITORY}"
+          echo "GITHUB_WORKFLOW_REF:      ${GITHUB_WORKFLOW_REF}"
+          echo "GITHUB_REF:               ${GITHUB_REF}"
+          echo "GITHUB_REF_NAME:          ${GITHUB_REF_NAME}"
+          echo "GITHUB_JOB:               ${GITHUB_JOB}"
+          echo "Job environment (yaml):   npm"
+          echo
+          echo "On npmjs.com the Trusted Publisher must match:"
+          echo "  Owner:        $(echo "${GITHUB_REPOSITORY}" | cut -d/ -f1)"
+          echo "  Repository:   $(echo "${GITHUB_REPOSITORY}" | cut -d/ -f2)"
+          echo "  Workflow:     $(basename "${GITHUB_WORKFLOW_REF%@*}")"
+          echo "  Environment:  npm  (or leave blank if no environment configured)"
+
+      - name: Set buckaroo-js-core version to ${{ needs.release.outputs.version }}
+        working-directory: packages/buckaroo-js-core
+        run: npm version "${{ needs.release.outputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Build buckaroo-js-core
+        working-directory: packages/buckaroo-js-core
+        run: pnpm run build
+
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION="${{ needs.release.outputs.version }}"
+          if npm view "buckaroo-js-core@${VERSION}" version >/dev/null 2>&1; then
+            echo "buckaroo-js-core@${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (Trusted Publishing + provenance)
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/buckaroo-js-core
+        run: npm publish --access public --provenance --loglevel=verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,6 +189,7 @@ jobs:
   release-npm:
     name: Publish buckaroo-js-core to npm
     needs: release
+    if: needs.release.result == 'success'
     # GitHub-hosted runner required: npm Trusted Publishing OIDC is only
     # supported on github-hosted runners (Depot's depot-ubuntu-latest is
     # treated as self-hosted and won't receive npm OIDC credentials).
@@ -221,7 +222,7 @@ jobs:
       - name: Upgrade npm to a Trusted-Publishing-capable version
         # Trusted Publishing requires npm >= 11.5.1. The global npm dir
         # on github-hosted runners is root-owned, so sudo is needed.
-        run: sudo npm install -g npm@latest
+        run: sudo npm install -g npm@11.5.1
 
       - name: OIDC diagnostics (compare against npm Trusted Publisher config)
         # NOTE: the npm Trusted Publisher on npmjs.com must be updated to


### PR DESCRIPTION
## Summary

- Adds a `release-npm` job to `release.yml` that runs automatically after the `release` (PyPI) job completes
- Version flows from the PyPI job via `jobs.release.outputs.version` — no manual coordination needed
- The npm job inherits the same idempotency check (skips if that version is already on npm)
- `release-npm.yml` is kept for emergency standalone re-publishes

## One manual step required

The npm Trusted Publisher on npmjs.com must be updated:

- Go to https://www.npmjs.com/package/buckaroo-js-core/access
- Change the registered workflow from `release-npm.yml` → `release.yml`
- Environment stays `npm`

The OIDC diagnostics step prints the exact values npm checks, so if auth fails it's easy to compare against the registered config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)