### PR TITLE
feat(compare): stats_diff/head_diff/key_diff for pandas, polars, and xorq backends

### DIFF
--- a/buckaroo/buckaroo_widget.py
+++ b/buckaroo/buckaroo_widget.py
@@ -126,7 +126,7 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
         column_config_overrides:Union[Literal[None], OverrideColumnConfig]=None,
         pinned_rows:Union[Literal[None], PinnedRowConfig]=None, extra_grid_config=None,
         component_config:Union[Literal[None], ComponentConfig]=None,
-        init_sd=None, skip_main_serial=False, record_transcript=False):
+        init_sd=None, skip_stat_columns=None, skip_main_serial=False, record_transcript=False):
         """
         BuckarooWidget was originally designed to extend CustomizableDataFlow
 
@@ -157,6 +157,7 @@ class BuckarooWidgetBase(anywidget.AnyWidget):
             debug=debug,column_config_overrides=column_config_overrides,
             pinned_rows=pinned_rows, extra_grid_config=extra_grid_config,
             component_config=component_config, init_sd=init_sd,
+            skip_stat_columns=skip_stat_columns,
             skip_main_serial=skip_main_serial)
 
         bidirectional_wire(self, self.dataflow, "df_data_dict")
@@ -390,9 +391,10 @@ class BuckarooInfiniteWidget(BuckarooWidget):
         column_config_overrides:Union[Literal[None], OverrideColumnConfig]=None,
         pinned_rows:Union[Literal[None], PinnedRowConfig]=None, extra_grid_config=None,
         component_config:Union[Literal[None], ComponentConfig]=None,
-        init_sd=None, record_transcript=False):
+        init_sd=None, skip_stat_columns=None, record_transcript=False):
         super().__init__(orig_df, debug, column_config_overrides, pinned_rows,
             extra_grid_config, component_config, init_sd,
+            skip_stat_columns=skip_stat_columns,
             skip_main_serial=True, record_transcript=record_transcript)
 
         def widget_tuple_args_bridge(change_unused):
@@ -466,9 +468,10 @@ class DFViewerInfinite(BuckarooInfiniteWidget):
         column_config_overrides:Union[Literal[None], OverrideColumnConfig]=None,
         pinned_rows:Union[Literal[None], PinnedRowConfig]=None, extra_grid_config=None,
         component_config:Union[Literal[None], ComponentConfig]=None,
-        init_sd=None):
+        init_sd=None, skip_stat_columns=None):
         super().__init__(orig_df, debug, column_config_overrides, pinned_rows,
-            extra_grid_config, component_config, init_sd)
+            extra_grid_config, component_config, init_sd,
+            skip_stat_columns=skip_stat_columns)
         self.df_id = str(id(orig_df))
 
 

--- a/buckaroo/compare.py
+++ b/buckaroo/compare.py
@@ -205,14 +205,47 @@ def key_diff_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> dict | None:
 # ---------------------------------------------------------------------------
 
 
-def _column_summaries_xorq(path: Path) -> dict[str, dict]:
+def _as_expr(src):
+    """Accept either a parquet path/str or an already-built xorq expression.
+
+    Lets every xorq diff helper take ``expr1``/``expr2`` directly — so a diff
+    composes the two entry expressions (each carrying its own ``.cache()``
+    node) rather than reaching for a materialised ``result.parquet``.
+    """
+    import xorq.api as xo
+
+    if isinstance(src, (str, Path)):
+        return xo.deferred_read_parquet(str(src))
+    return src
+
+
+def _align_backends(a, b):
+    """Land two expressions on one backend, but only if they differ.
+
+    Two independently-loaded entry expressions can be bound to different
+    backends, which an outer join rejects; ``into_backend`` unifies them.  When
+    both already share a backend (e.g. both read parquet on the default xorq
+    backend) we skip it — into_backend would force an eager transport.
+    """
+    try:
+        con_a = a._find_backend(use_default=True)
+    except Exception:
+        con_a = None
+    try:
+        con_b = b._find_backend(use_default=True)
+    except Exception:
+        con_b = None
+    if con_a is not None and con_b is not None and con_a is not con_b:
+        b = b.into_backend(con_a)
+    return a, b
+
+
+def _column_summaries_xorq(src) -> dict[str, dict]:
     """One ibis aggregate expression covering every column, executed once.
 
     Nothing larger than the single scalar summary row is materialised.
     """
-    import xorq.api as xo
-
-    expr = xo.deferred_read_parquet(str(path))
+    expr = _as_expr(src)
     schema = expr.schema()
 
     agg: list = [expr.count().name("__total__")]
@@ -239,95 +272,210 @@ def _column_summaries_xorq(path: Path) -> dict[str, dict]:
     return result
 
 
-def _infer_keys_xorq(a_path: Path, b_path: Path) -> list[str]:
-    """Infer key columns by querying both parquets via DuckDB."""
-    import duckdb
-    import xorq.api as xo
-
-    a_schema = xo.deferred_read_parquet(str(a_path)).schema()
-    b_schema = xo.deferred_read_parquet(str(b_path)).schema()
-    shared = [c for c in a_schema if c in b_schema and not a_schema[c].is_numeric()]
-    if not shared:
-        return []
-    con = duckdb.connect()
-    row = con.execute(
-        "SELECT " + ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in shared)
-        + f" FROM '{a_path}'").fetchone()
-    total = con.execute(f"SELECT COUNT(*) FROM '{a_path}'").fetchone()[0]
-    threshold = max(20, int(total * 0.5))
-    return [c for c, v in zip(shared, row) if v <= threshold]
+def _max_group_xorq(expr, combo: list[str]) -> int:
+    """Largest number of rows sharing a single value of ``combo`` (one agg)."""
+    grp = expr.group_by(list(combo)).agg(__cnt__=expr.count())
+    return int(grp["__cnt__"].max().execute())
 
 
-def head_diff_xorq(a_path: Path, b_path: Path, n: int = 10) -> dict:
-    """LIMIT-N query on each parquet — no full table scan (xorq backend)."""
-    import duckdb
-    import xorq.api as xo
+def _rank_pk_xorq(src, threshold: float = 1.0, max_width: int = 4, max_group: int | None = None,
+        columns: list[str] | None = None) -> dict | None:
+    """Best join-key candidate for a parquet file or expression (xorq backend).
 
-    a_df = xo.deferred_read_parquet(str(a_path)).limit(n).execute()
-    b_df = xo.deferred_read_parquet(str(b_path)).limit(n).execute()
-    con = duckdb.connect()
-    a_total = con.execute(f"SELECT COUNT(*) FROM '{a_path}'").fetchone()[0]
-    b_total = con.execute(f"SELECT COUNT(*) FROM '{b_path}'").fetchone()[0]
+    Searches single columns (most-unique first), then composites of width
+    2..``max_width`` (shortest first), and returns the first candidate whose
+    *uniqueness* — distinct key tuples / row count — is ``>= threshold``::
+
+        {"keys": [...], "uniqueness": float, "max_group": int | None, "n": int}
+
+    Returns ``None`` if nothing reaches ``threshold``.
+
+    All work is pushed to xorq as aggregate expressions — ``count``,
+    ``nunique``, a distinct-row ``count`` per composite candidate, and (when
+    ``max_group`` is set) one ``group_by``/``max``.  Nothing larger than a
+    one-row summary is materialised, so this is safe on files far larger than
+    memory.  It does not touch DuckDB directly; whatever backend xorq is
+    configured with executes the expressions.
+
+    Parameters
+    ----------
+    threshold
+        Minimum distinct/rows to accept.  ``1.0`` means an exact primary key;
+        a value below 1.0 accepts an *approximate* key and tolerates up to
+        ``(1 - threshold)`` of the rows being duplicate-keyed (real-world data
+        often has no clean PK).
+    max_width
+        Largest composite key to consider.
+    max_group
+        Reject any candidate whose largest duplicate group exceeds this.  A
+        high-uniqueness key can still explode an outer join if one value (a
+        null, a sentinel) covers many rows; the global ratio does not bound
+        that, the biggest group does.  ``None`` skips the check.
+    columns
+        Restrict candidate columns to this subset (e.g. columns shared by both
+        sides of a diff).  ``None`` considers every column.
+    """
+    from itertools import combinations
+
+    expr = _as_expr(src)
+    cols = list(expr.schema())
+    if columns is not None:
+        cols = [c for c in cols if c in columns]
+    if not cols:
+        return None
+
+    aggs = [expr.count().name("__n__")] + [expr[c].nunique().name(c) for c in cols]
+    row = expr.aggregate(aggs).execute().iloc[0]
+    n = int(row["__n__"])
+    if n == 0:
+        return None
+    distinct = {c: int(row[c]) for c in cols}
+    need = threshold * n
+
+    def _accept(combo: tuple[str, ...], d: int) -> dict | None:
+        if d < need:
+            return None
+        mg = _max_group_xorq(expr, list(combo))
+        if max_group is not None and mg > max_group:
+            return None
+        return {"keys": list(combo), "uniqueness": d / n, "max_group": mg, "n": n}
+
+    # Single columns, most-unique first — a passing single beats any composite.
+    for c in sorted(cols, key=lambda c: distinct[c], reverse=True):
+        result = _accept((c,), distinct[c])
+        if result is not None:
+            return result
+
+    # Composite keys, shortest first.  Prune with a cheap cardinality-product
+    # upper bound before paying for the distinct-tuple count.
+    usable = [c for c in cols if distinct[c] > 1]
+    for width in range(2, max_width + 1):
+        for combo in combinations(usable, width):
+            bound = 1
+            for c in combo:
+                bound *= distinct[c]
+                if bound >= need:
+                    break
+            if bound < need:
+                continue
+            d = int(expr.select(*combo).distinct().count().execute())
+            result = _accept(combo, d)
+            if result is not None:
+                return result
+    return None
+
+
+def _detect_pk_xorq(src, threshold: float = 1.0, max_width: int = 4, max_group: int | None = None,
+        columns: list[str] | None = None) -> list[str] | None:
+    """Detected (approximate) primary key for a parquet file or expr, or ``None``.
+
+    Thin wrapper over :func:`_rank_pk_xorq` returning just the key columns.
+    See that function for the meaning of ``threshold`` / ``max_group``.
+    """
+    result = _rank_pk_xorq(
+        src, threshold=threshold, max_width=max_width,
+        max_group=max_group, columns=columns)
+    return list(result["keys"]) if result else None
+
+
+def _shared_columns_xorq(a, b) -> list[str]:
+    """Columns present in both schemas, in ``a``'s order (path or expr)."""
+    a_schema = _as_expr(a).schema()
+    b_schema = _as_expr(b).schema()
+    return [c for c in a_schema if c in b_schema]
+
+
+def head_diff_xorq(a, b, n: int = 10) -> dict:
+    """First N rows of each side + totals, all as xorq expressions."""
+    a_expr = _as_expr(a)
+    b_expr = _as_expr(b)
+    a_df = a_expr.limit(n).execute()
+    b_df = b_expr.limit(n).execute()
+    a_total = int(a_expr.count().execute())
+    b_total = int(b_expr.count().execute())
     return {"before": a_df.to_html(classes="data-table", index=False, border=0),
         "after": b_df.to_html(classes="data-table", index=False, border=0), "n": n, "a_total": a_total,
         "b_total": b_total}
 
 
-def stats_diff_xorq(a_path: Path, b_path: Path) -> list[dict]:
-    """Per-column stats computed directly on parquet files (xorq backend).
+def stats_diff_xorq(a, b) -> list[dict]:
+    """Per-column stats for each side (path or expr).
 
-    Each side is one aggregate query — no DataFrame materialisation.
+    Each side is one aggregate expression — no DataFrame materialisation.
     """
-    import xorq.api as xo
-
-    a_schema = xo.deferred_read_parquet(str(a_path)).schema()
-    b_schema = xo.deferred_read_parquet(str(b_path)).schema()
-    cols = list(dict.fromkeys(list(a_schema) + list(b_schema)))
-    a_s = _column_summaries_xorq(a_path)
-    b_s = _column_summaries_xorq(b_path)
+    a_expr = _as_expr(a)
+    b_expr = _as_expr(b)
+    cols = list(dict.fromkeys(list(a_expr.schema()) + list(b_expr.schema())))
+    a_s = _column_summaries_xorq(a_expr)
+    b_s = _column_summaries_xorq(b_expr)
     return [{"name": col, "before": a_s.get(col), "after": b_s.get(col)} for col in cols]
 
 
-def key_diff_xorq(a_path: Path, b_path: Path) -> dict | None:
-    """Outer-join on inferred keys using DuckDB SQL (xorq backend)."""
-    import duckdb
+def key_diff_xorq(a, b, keys: list[str] | None = None, threshold: float = 0.98, max_width: int = 4,
+        max_group: int | None = 10_000) -> dict | None:
+    """Outer-join two sides on a detected (approximate) key (xorq backend).
 
-    keys = _infer_keys_xorq(a_path, b_path)
+    ``a`` / ``b`` are parquet paths *or* xorq expressions — the diff composes
+    ``expr1`` ⋈ ``expr2`` and lets each side resolve its own cache, never
+    reaching for a materialised parquet.  The join key is inferred with
+    :func:`_detect_pk_xorq` over the shared columns — preferring a true primary
+    key, tolerating an approximate one down to ``threshold`` so real data
+    without a clean key still aligns.  ``max_group`` rejects a key whose
+    largest duplicate group would risk a many-to-many blowup.  Returns
+    ``None`` when no usable key is found.
+
+    Pure ibis: the outer join, the membership counts and the 50-row preview
+    are all expressions; nothing larger than the preview is materialised.
+    """
+    import xorq.vendor.ibis as ibis
+
+    a_expr = _as_expr(a)
+    b_expr = _as_expr(b)
+    # A caller that already knows the key (e.g. resolved + cached from lineage)
+    # passes it in to skip the per-column uniqueness scan entirely.
+    if not keys:
+        shared = _shared_columns_xorq(a_expr, b_expr)
+        keys = _detect_pk_xorq(
+            a_expr, threshold=threshold, max_width=max_width,
+            max_group=max_group, columns=shared)
+        if not keys:
+            keys = _detect_pk_xorq(
+                b_expr, threshold=threshold, max_width=max_width,
+                max_group=max_group, columns=shared)
     if not keys:
         return None
 
-    con = duckdb.connect()
-    con.execute(f"CREATE VIEW a AS SELECT * FROM '{a_path}'")
-    con.execute(f"CREATE VIEW b AS SELECT * FROM '{b_path}'")
-
-    a_cols = [r[0] for r in con.execute("DESCRIBE a").fetchall()]
-    b_cols = [r[0] for r in con.execute("DESCRIBE b").fetchall()]
-    a_non_keys = [c for c in a_cols if c not in keys]
-    b_non_keys = [c for c in b_cols if c not in keys]
-
-    key_sel = ", ".join(f'COALESCE(a."{k}", b."{k}") AS "{k}"' for k in keys)
-    a_sel = ", ".join(f'a."{c}" AS "{c}_before"' for c in a_non_keys)
-    b_sel = ", ".join(f'b."{c}" AS "{c}_after"' for c in b_non_keys)
-    on_clause = " AND ".join(f'a."{k}" = b."{k}"' for k in keys)
-    select_parts = [p for p in [key_sel, a_sel, b_sel] if p]
-    sql_join = f"SELECT {', '.join(select_parts)} FROM a FULL OUTER JOIN b ON {on_clause}"
+    a_non_keys = [c for c in a_expr.schema() if c not in keys]
+    b_non_keys = [c for c in b_expr.schema() if c not in keys]
 
     try:
-        con.execute(f"CREATE VIEW merged AS {sql_join}")
+        # The two sides may be bound to different backends (each entry
+        # expression is loaded independently); land them on one backend so the
+        # outer join is single-engine (no-op when they already share one).
+        a_expr, b_expr = _align_backends(a_expr, b_expr)
+        # Label each side's non-key columns so they don't collide on the join.
+        a_ren = a_expr.rename({f"{c}_before": c for c in a_non_keys})
+        b_ren = b_expr.rename({f"{c}_after": c for c in b_non_keys})
+        joined = a_ren.outer_join(b_ren, [a_ren[k] == b_ren[k] for k in keys])
+
+        sel = [ibis.coalesce(a_ren[k], b_ren[k]).name(k) for k in keys]
+        sel += [joined[f"{c}_before"] for c in a_non_keys]
+        sel += [joined[f"{c}_after"] for c in b_non_keys]
+        merged = joined.select(*sel)
+
         if a_non_keys and b_non_keys:
-            counts = con.execute(f"""
-                SELECT
-                    SUM(CASE WHEN "{a_non_keys[0]}_before" IS NULL THEN 1 ELSE 0 END) AS only_after,
-                    SUM(CASE WHEN "{b_non_keys[0]}_after"  IS NULL THEN 1 ELSE 0 END) AS only_before,
-                    COUNT(*) AS total
-                FROM merged
-            """).fetchone()
-            only_after, only_before, total = int(counts[0]), int(counts[1]), int(counts[2])
-            both = total - only_before - only_after
+            # a-side null → row only in b ("only_after"); b-side null → only in a.
+            a_probe = f"{a_non_keys[0]}_before"
+            b_probe = f"{b_non_keys[0]}_after"
+            counts = merged.aggregate(only_after=merged[a_probe].isnull().sum().cast("int64"),
+                only_before=merged[b_probe].isnull().sum().cast("int64"), total=merged.count()).execute().iloc[0]
+            only_after = int(counts["only_after"])
+            only_before = int(counts["only_before"])
+            both = int(counts["total"]) - only_before - only_after
         else:
             only_before = only_after = 0
-            both = con.execute("SELECT COUNT(*) FROM merged").fetchone()[0]
-        preview = con.execute("SELECT * FROM merged LIMIT 50").df()
+            both = int(merged.count().execute())
+        preview = merged.limit(50).execute()
     except Exception:
         return None
 

--- a/buckaroo/compare.py
+++ b/buckaroo/compare.py
@@ -11,6 +11,20 @@ summary statistics and outer-join diffs across three backends:
   xorq    — one ibis aggregate expression per parquet file; nothing
             larger than a scalar summary row is materialised.
 
+All three backends share one key-detection algorithm (``_rank_pk_*`` /
+``_detect_pk_*``): rank candidates by uniqueness, single columns first then
+small composites, accept the first that clears ``threshold`` with a bounded
+largest-duplicate-group (``max_group``).  ``key_diff*`` joins on the detected
+key and **stops** (returns ``None``) when no simple primary key exists, rather
+than joining on a low-cardinality column and exploding into a many-to-many
+product.  ``probe_diff`` exposes that decision as a cheap pre-flight check.
+
+The three backends agree on real data.  They can differ only in two corners,
+both of which make poor primary keys anyway: a float column that mixes a
+genuine NaN with nulls (pandas cannot tell NaN from null, polars/xorq can), and
+a key whose value is itself null (engines disagree on whether null == null
+joins).
+
 Polars functions require ``buckaroo[polars]``.
 Xorq functions require ``buckaroo[xorq]``.
 """
@@ -37,6 +51,21 @@ def _safe_float(v) -> float | None:
         return None if math.isnan(f) else f
     except (TypeError, ValueError):
         return None
+
+
+def _require_keys_in_both(keys: list[str], a_cols, b_cols) -> None:
+    """Raise if any explicitly-supplied key is missing from either side.
+
+    Auto-detected keys come from the shared columns and always pass; this
+    guards the explicit ``keys=`` path so a typo surfaces as a clear error
+    rather than being swallowed into a ``None`` ("no usable key") result.
+    Note that explicit keys still skip the uniqueness / ``max_group`` guard —
+    the caller is trusted to pass a real key.
+    """
+    a_set, b_set = set(a_cols), set(b_cols)
+    missing = [k for k in keys if k not in a_set or k not in b_set]
+    if missing:
+        raise ValueError(f"key_diff keys not present in both inputs: {missing}")
 
 
 # ---------------------------------------------------------------------------
@@ -70,16 +99,76 @@ def _column_summaries_pd(df: pd.DataFrame) -> dict[str, dict]:
     return result
 
 
-def _infer_keys(a: pd.DataFrame, b: pd.DataFrame) -> list[str]:
-    """Heuristic: shared non-numeric low-cardinality columns are likely keys."""
-    shared_non_numeric = [
-        c for c in a.columns
-        if c in b.columns and not pd.api.types.is_numeric_dtype(a[c])
-    ]
-    if not shared_non_numeric:
-        return []
-    counts = a[shared_non_numeric].nunique(dropna=False)
-    return [c for c in shared_non_numeric if counts[c] <= max(20, int(len(a) * 0.5))]
+def _max_group_pd(df: pd.DataFrame, combo: list[str]) -> int:
+    """Largest number of rows sharing a single value of ``combo``."""
+    return int(df.groupby(list(combo), dropna=False).size().max())
+
+
+def _rank_pk_pd(df: pd.DataFrame, threshold: float = 1.0, max_width: int = 4, max_group: int | None = None,
+        columns: list[str] | None = None) -> dict | None:
+    """Best join-key candidate for a DataFrame (pandas port of :func:`_rank_pk_xorq`).
+
+    Same search and acceptance rule as the xorq/polars backends: single columns
+    most-unique-first, then composites of width 2..``max_width`` (shortest
+    first); the first candidate whose uniqueness (distinct/rows) is
+    ``>= threshold`` and whose largest duplicate group is ``<= max_group`` wins.
+    Returns ``None`` if nothing qualifies.  See :func:`_rank_pk_xorq` for the
+    meaning of ``threshold`` / ``max_group``.
+    """
+    from itertools import combinations
+
+    cols = list(df.columns)
+    if columns is not None:
+        cols = [c for c in cols if c in columns]
+    if not cols:
+        return None
+    n = len(df)
+    if n == 0:
+        return None
+    distinct = {c: int(df[c].nunique(dropna=True)) for c in cols}
+    need = threshold * n
+
+    def _accept(combo: tuple[str, ...], d: int) -> dict | None:
+        if d < need:
+            return None
+        mg = _max_group_pd(df, list(combo))
+        if max_group is not None and mg > max_group:
+            return None
+        return {"keys": list(combo), "uniqueness": d / n, "max_group": mg, "n": n}
+
+    # Single columns, most-unique first — a passing single beats any composite.
+    for c in sorted(cols, key=lambda c: distinct[c], reverse=True):
+        result = _accept((c,), distinct[c])
+        if result is not None:
+            return result
+
+    # Composite keys, shortest first.  Prune with a cheap cardinality-product
+    # upper bound before paying for the distinct-tuple count.
+    usable = [c for c in cols if distinct[c] > 1]
+    for width in range(2, max_width + 1):
+        for combo in combinations(usable, width):
+            bound = 1
+            for c in combo:
+                bound *= distinct[c]
+                if bound >= need:
+                    break
+            if bound < need:
+                continue
+            d = int(len(df.drop_duplicates(subset=list(combo))))
+            result = _accept(combo, d)
+            if result is not None:
+                return result
+    return None
+
+
+def _detect_pk_pd(df: pd.DataFrame, threshold: float = 1.0, max_width: int = 4, max_group: int | None = None,
+        columns: list[str] | None = None) -> list[str] | None:
+    """Detected (approximate) primary key for a DataFrame, or ``None``.
+
+    Thin wrapper over :func:`_rank_pk_pd` returning just the key columns.
+    """
+    result = _rank_pk_pd(df, threshold=threshold, max_width=max_width, max_group=max_group, columns=columns)
+    return list(result["keys"]) if result else None
 
 
 def head_diff(a: pd.DataFrame, b: pd.DataFrame, n: int = 10) -> dict:
@@ -97,20 +186,34 @@ def stats_diff(a: pd.DataFrame, b: pd.DataFrame) -> list[dict]:
     return [{"name": col, "before": a_s.get(col), "after": b_s.get(col)} for col in cols]
 
 
-def key_diff(a: pd.DataFrame, b: pd.DataFrame) -> dict | None:
-    """Outer-join on inferred keys; show per-key value changes (pandas backend)."""
-    keys = _infer_keys(a, b)
+def key_diff(a: pd.DataFrame, b: pd.DataFrame, keys: list[str] | None = None, threshold: float = 0.98,
+        max_width: int = 4, max_group: int | None = 10_000) -> dict | None:
+    """Outer-join two frames on a detected primary key (pandas backend).
+
+    The key is found with :func:`_detect_pk_pd` over the shared columns
+    (uniqueness ``>= threshold``, largest duplicate group ``<= max_group``) —
+    the same algorithm as the polars and xorq backends.  When no such key
+    exists the diff is **stopped**: it returns ``None`` rather than joining on a
+    low-cardinality column and exploding into a many-to-many product.
+    Membership counts come from the merge indicator, so a genuine null in a
+    data column is never mistaken for a non-matching row.
+    """
+    if not keys:
+        shared = [c for c in a.columns if c in b.columns]
+        keys = (_detect_pk_pd(a, threshold=threshold, max_width=max_width, max_group=max_group, columns=shared)
+            or _detect_pk_pd(b, threshold=threshold, max_width=max_width, max_group=max_group, columns=shared))
     if not keys:
         return None
+    _require_keys_in_both(keys, a.columns, b.columns)
     try:
         merged = a.merge(b, on=keys, how="outer", suffixes=("_before", "_after"), indicator=True)
     except Exception:
         return None
-    only_left = int((merged["_merge"] == "left_only").sum())
-    only_right = int((merged["_merge"] == "right_only").sum())
+    only_before = int((merged["_merge"] == "left_only").sum())
+    only_after = int((merged["_merge"] == "right_only").sum())
     both = int((merged["_merge"] == "both").sum())
     merged = merged.drop(columns=["_merge"])
-    return {"keys": keys, "only_before": only_left, "only_after": only_right, "matched": both,
+    return {"keys": keys, "only_before": only_before, "only_after": only_after, "matched": both,
         "table_html": merged.head(50).to_html(classes="data-table", index=False, border=0)}
 
 
@@ -125,7 +228,9 @@ def _column_summaries_polars(df: "pl.DataFrame") -> dict[str, dict]:
 
     n = len(df)
     nulls = df.select(pl.all().null_count()).row(0, named=True)
-    distincts = df.select(pl.all().n_unique()).row(0, named=True)
+    # drop_nulls before n_unique so 'distinct' excludes null, matching the
+    # pandas (nunique dropna=True) and xorq (ibis nunique) backends.
+    distincts = df.select(pl.all().drop_nulls().n_unique()).row(0, named=True)
 
     num_cols = [c for c in df.columns if df.schema[c].is_numeric()]
     if num_cols:
@@ -147,14 +252,103 @@ def _column_summaries_polars(df: "pl.DataFrame") -> dict[str, dict]:
     return result
 
 
-def _infer_keys_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> list[str]:
+def _as_lazy_pl(src):
+    """Accept a parquet path/str, a LazyFrame, or a DataFrame -> LazyFrame.
+
+    Mirrors :func:`_as_expr`: lets the polars key helpers take a path and push
+    the uniqueness aggregates down through a lazy scan, so PK detection on a
+    file far larger than memory never materialises more than a summary row.
+    """
     import polars as pl
 
-    shared = [c for c in a.columns if c in b.columns and not a.schema[c].is_numeric()]
-    if not shared:
-        return []
-    counts = a.select(pl.col(shared).n_unique()).row(0, named=True)
-    return [c for c in shared if counts[c] <= max(20, int(len(a) * 0.5))]
+    if isinstance(src, (str, Path)):
+        return pl.scan_parquet(src)
+    if isinstance(src, pl.LazyFrame):
+        return src
+    return src.lazy()
+
+
+def _max_group_pl(lf, combo: list[str]) -> int:
+    """Largest number of rows sharing a single value of ``combo`` (one agg)."""
+    import polars as pl
+
+    mx = lf.group_by(list(combo)).agg(pl.len().alias("__cnt__")).select(pl.col("__cnt__").max()).collect()[0, 0]
+    return int(mx) if mx is not None else 0
+
+
+def _rank_pk_polars(src, threshold: float = 1.0, max_width: int = 4, max_group: int | None = None,
+        columns: list[str] | None = None) -> dict | None:
+    """Best join-key candidate for a DataFrame / LazyFrame / parquet path (polars).
+
+    Polars port of :func:`_rank_pk_xorq` — identical search (single columns
+    most-unique-first, then composites of width 2..``max_width``) and the same
+    uniqueness ``>= threshold`` / ``max_group`` acceptance rule.  Aggregates run
+    on a lazy scan, so nothing larger than a summary row is materialised.  See
+    :func:`_rank_pk_xorq` for the meaning of ``threshold`` / ``max_group``.
+    """
+    from itertools import combinations
+
+    import polars as pl
+
+    lf = _as_lazy_pl(src)
+    cols = list(lf.collect_schema().names())
+    if columns is not None:
+        cols = [c for c in cols if c in columns]
+    if not cols:
+        return None
+
+    # distinct excludes nulls (drop_nulls) to match ibis/pandas nunique semantics.
+    summary = lf.select(
+        [pl.len().alias("__n__")] + [pl.col(c).drop_nulls().n_unique().alias(c) for c in cols]).collect()
+    row = summary.row(0, named=True)
+    n = int(row["__n__"])
+    if n == 0:
+        return None
+    distinct = {c: int(row[c]) for c in cols}
+    need = threshold * n
+
+    def _accept(combo: tuple[str, ...], d: int) -> dict | None:
+        if d < need:
+            return None
+        mg = _max_group_pl(lf, list(combo))
+        if max_group is not None and mg > max_group:
+            return None
+        return {"keys": list(combo), "uniqueness": d / n, "max_group": mg, "n": n}
+
+    for c in sorted(cols, key=lambda c: distinct[c], reverse=True):
+        result = _accept((c,), distinct[c])
+        if result is not None:
+            return result
+
+    usable = [c for c in cols if distinct[c] > 1]
+    for width in range(2, max_width + 1):
+        for combo in combinations(usable, width):
+            bound = 1
+            for c in combo:
+                bound *= distinct[c]
+                if bound >= need:
+                    break
+            if bound < need:
+                continue
+            d = int(lf.select(list(combo)).unique().select(pl.len()).collect()[0, 0])
+            result = _accept(combo, d)
+            if result is not None:
+                return result
+    return None
+
+
+def _detect_pk_polars(src, threshold: float = 1.0, max_width: int = 4, max_group: int | None = None,
+        columns: list[str] | None = None) -> list[str] | None:
+    """Detected (approximate) primary key for a polars frame/path, or ``None``."""
+    result = _rank_pk_polars(src, threshold=threshold, max_width=max_width, max_group=max_group, columns=columns)
+    return list(result["keys"]) if result else None
+
+
+def _shared_columns_polars(a, b) -> list[str]:
+    """Columns present in both schemas, in ``a``'s order (frame/path)."""
+    a_cols = _as_lazy_pl(a).collect_schema().names()
+    b_cols = set(_as_lazy_pl(b).collect_schema().names())
+    return [c for c in a_cols if c in b_cols]
 
 
 def head_diff_polars(a_path: Path, b_path: Path, n: int = 10) -> dict:
@@ -178,26 +372,47 @@ def stats_diff_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> list[dict]:
     return [{"name": col, "before": a_s.get(col), "after": b_s.get(col)} for col in cols]
 
 
-def key_diff_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> dict | None:
-    """Outer join on inferred keys (polars backend)."""
-    keys = _infer_keys_polars(a, b)
+def key_diff_polars(a, b, keys: list[str] | None = None, threshold: float = 0.98, max_width: int = 4,
+        max_group: int | None = 10_000) -> dict | None:
+    """Outer-join two sides on a detected primary key (polars backend).
+
+    Same algorithm as :func:`key_diff_xorq`: the key is found with
+    :func:`_detect_pk_polars` over the shared columns.  When no key reaches
+    ``threshold`` (within ``max_width`` / ``max_group``) the diff is
+    **stopped** — it returns ``None`` rather than joining on a low-cardinality
+    column and exploding into a many-to-many product.  ``a`` / ``b`` accept a
+    parquet path, a LazyFrame, or a DataFrame.
+    """
+    import polars as pl
+
+    la = _as_lazy_pl(a)
+    lb = _as_lazy_pl(b)
+    if not keys:
+        shared = _shared_columns_polars(la, lb)
+        keys = (_detect_pk_polars(la, threshold=threshold, max_width=max_width, max_group=max_group, columns=shared)
+            or _detect_pk_polars(lb, threshold=threshold, max_width=max_width, max_group=max_group, columns=shared))
     if not keys:
         return None
+
+    a_cols = list(la.collect_schema().names())
+    b_cols = list(lb.collect_schema().names())
+    _require_keys_in_both(keys, a_cols, b_cols)
+    a_non = [c for c in a_cols if c not in keys]
+    b_non = [c for c in b_cols if c not in keys]
     try:
-        merged = a.join(b, on=keys, how="full", suffix="_after", coalesce=True)
+        # Marker columns give a null-safe membership count: a genuine null in a
+        # data column must not be mistaken for a non-matching row.
+        am = la.rename({c: f"{c}_before" for c in a_non}).with_columns(__a__=pl.lit(True))
+        bm = lb.rename({c: f"{c}_after" for c in b_non}).with_columns(__b__=pl.lit(True))
+        merged = am.join(bm, on=keys, how="full", coalesce=True).collect()
     except Exception:
         return None
-    a_only_col = next((c for c in a.columns if c not in keys), None)
-    b_col_after = f"{a_only_col}_after" if a_only_col else None
-    if a_only_col and b_col_after in merged.columns:
-        only_before = int(merged[b_col_after].is_null().sum())
-        only_after = int(merged[a_only_col].is_null().sum())
-        both = len(merged) - only_before - only_after
-    else:
-        only_before = only_after = 0
-        both = len(merged)
+    only_after = int(merged["__a__"].is_null().sum())   # a-side absent -> row only in b
+    only_before = int(merged["__b__"].is_null().sum())  # b-side absent -> row only in a
+    both = len(merged) - only_before - only_after
+    preview = merged.drop("__a__", "__b__").head(50)
     return {"keys": keys, "only_before": only_before, "only_after": only_after, "matched": both,
-        "table_html": merged.head(50).to_pandas().to_html(classes="data-table", index=False, border=0)}
+        "table_html": preview.to_pandas().to_html(classes="data-table", index=False, border=0)}
 
 
 # ---------------------------------------------------------------------------
@@ -444,6 +659,7 @@ def key_diff_xorq(a, b, keys: list[str] | None = None, threshold: float = 0.98, 
                 max_group=max_group, columns=shared)
     if not keys:
         return None
+    _require_keys_in_both(keys, list(a_expr.schema()), list(b_expr.schema()))
 
     a_non_keys = [c for c in a_expr.schema() if c not in keys]
     b_non_keys = [c for c in b_expr.schema() if c not in keys]
@@ -454,8 +670,10 @@ def key_diff_xorq(a, b, keys: list[str] | None = None, threshold: float = 0.98, 
         # outer join is single-engine (no-op when they already share one).
         a_expr, b_expr = _align_backends(a_expr, b_expr)
         # Label each side's non-key columns so they don't collide on the join.
-        a_ren = a_expr.rename({f"{c}_before": c for c in a_non_keys})
-        b_ren = b_expr.rename({f"{c}_after": c for c in b_non_keys})
+        # Marker columns give a null-safe membership count: a genuine null in a
+        # data column must not be mistaken for a non-matching row.
+        a_ren = a_expr.rename({f"{c}_before": c for c in a_non_keys}).mutate(__a__=ibis.literal(True))
+        b_ren = b_expr.rename({f"{c}_after": c for c in b_non_keys}).mutate(__b__=ibis.literal(True))
         joined = a_ren.outer_join(b_ren, [a_ren[k] == b_ren[k] for k in keys])
 
         sel = [ibis.coalesce(a_ren[k], b_ren[k]).name(k) for k in keys]
@@ -463,24 +681,106 @@ def key_diff_xorq(a, b, keys: list[str] | None = None, threshold: float = 0.98, 
         sel += [joined[f"{c}_after"] for c in b_non_keys]
         merged = joined.select(*sel)
 
-        if a_non_keys and b_non_keys:
-            # a-side null → row only in b ("only_after"); b-side null → only in a.
-            a_probe = f"{a_non_keys[0]}_before"
-            b_probe = f"{b_non_keys[0]}_after"
-            counts = merged.aggregate(only_after=merged[a_probe].isnull().sum().cast("int64"),
-                only_before=merged[b_probe].isnull().sum().cast("int64"), total=merged.count()).execute().iloc[0]
-            only_after = int(counts["only_after"])
-            only_before = int(counts["only_before"])
-            both = int(counts["total"]) - only_before - only_after
-        else:
-            only_before = only_after = 0
-            both = int(merged.count().execute())
+        # a-side marker null → row only in b ("only_after"); b-side null → only in a.
+        counts = joined.aggregate(only_after=joined["__a__"].isnull().sum().cast("int64"),
+            only_before=joined["__b__"].isnull().sum().cast("int64"), total=joined.count()).execute().iloc[0]
+        only_after = int(counts["only_after"])
+        only_before = int(counts["only_before"])
+        both = int(counts["total"]) - only_before - only_after
         preview = merged.limit(50).execute()
     except Exception:
         return None
 
     return {"keys": keys, "only_before": only_before, "only_after": only_after, "matched": both,
         "table_html": preview.to_html(classes="data-table", index=False, border=0)}
+
+
+# ---------------------------------------------------------------------------
+# fast probe — decide whether a key diff is worth running at all
+# ---------------------------------------------------------------------------
+
+
+def probe_diff(a, b, threshold: float = 0.98, max_width: int = 4, max_group: int | None = 10_000) -> dict:
+    """Cheap pre-flight for a key diff: is there a simple primary key to join on?
+
+    Runs the same uniqueness-ranked key search the diffs use, over the columns
+    shared by ``a`` and ``b``, and returns a verdict the caller checks BEFORE
+    paying for a full compare::
+
+        {"can_diff": bool, "keys": list[str] | None, "reason": str}
+
+    When ``can_diff`` is ``False`` the diff should be **stopped**: no column (or
+    small composite) is unique enough to join on, so the only available join
+    would be a many-to-many cartesian product.  The cost is one uniqueness pass
+    per side, which a lazy/parquet backend pushes down — so this is safe to run
+    on a large file before deciding whether to materialise the diff.
+
+    The backend is chosen from the input type: pandas DataFrames use the pandas
+    detector, polars frames the polars detector, and parquet paths / xorq
+    expressions the xorq detector (when xorq is installed, else a polars scan).
+    """
+    keys = _detect_pk_either(a, b, threshold=threshold, max_width=max_width, max_group=max_group)
+    if keys:
+        return {"can_diff": True, "keys": keys,
+            "reason": f"primary key {keys} reaches uniqueness >= {threshold}"}
+    return {"can_diff": False, "keys": None,
+        "reason": (f"no key with uniqueness >= {threshold} in the shared columns "
+            "(within max_width/max_group) — diff stopped to avoid a many-to-many join")}
+
+
+def _detect_pk_either(a, b, *, threshold: float, max_width: int, max_group: int | None) -> list[str] | None:
+    """Detect a PK on ``a`` (then ``b``) using the backend implied by the input type.
+
+    ``a`` and ``b`` must be the same backend family; a mismatch (e.g. a pandas
+    frame against a polars frame or a path) raises ``ValueError`` rather than
+    crashing inside a backend with an opaque error.
+    """
+    if isinstance(a, pd.DataFrame) and isinstance(b, pd.DataFrame):
+        shared = [c for c in a.columns if c in b.columns]
+        detect = _detect_pk_pd
+    elif _is_polars(a) and _is_polars(b):
+        shared = _shared_columns_polars(a, b)
+        detect = _detect_pk_polars
+    elif isinstance(a, (str, Path)) and isinstance(b, (str, Path)):
+        # parquet paths: xorq when available, else a polars lazy scan
+        if _has_xorq():
+            shared = _shared_columns_xorq(a, b)
+            detect = _detect_pk_xorq
+        else:
+            shared = _shared_columns_polars(a, b)
+            detect = _detect_pk_polars
+    elif _has_xorq() and _is_xorq_expr(a) and _is_xorq_expr(b):
+        shared = _shared_columns_xorq(a, b)
+        detect = _detect_pk_xorq
+    else:
+        raise ValueError(
+            "probe_diff needs both sides on the same backend: two pandas DataFrames, two polars "
+            f"frames, two parquet paths, or two xorq expressions; got {type(a).__name__} and "
+            f"{type(b).__name__}")
+    return (detect(a, threshold=threshold, max_width=max_width, max_group=max_group, columns=shared)
+        or detect(b, threshold=threshold, max_width=max_width, max_group=max_group, columns=shared))
+
+
+def _is_xorq_expr(x) -> bool:
+    # ibis/xorq expressions expose schema() as a method; polars frames expose
+    # .schema as a (non-callable) property and pandas frames have neither.
+    return not isinstance(x, (str, Path)) and callable(getattr(x, "schema", None))
+
+
+def _is_polars(src) -> bool:
+    try:
+        import polars as pl
+    except ImportError:
+        return False
+    return isinstance(src, (pl.DataFrame, pl.LazyFrame))
+
+
+def _has_xorq() -> bool:
+    try:
+        import xorq.api  # noqa: F401
+    except ImportError:
+        return False
+    return True
 
 
 # ---------------------------------------------------------------------------

--- a/buckaroo/compare.py
+++ b/buckaroo/compare.py
@@ -1,4 +1,344 @@
+"""DataFrame comparison utilities.
+
+``col_join_dfs`` — join two DataFrames and produce a Buckaroo-styled
+merged frame with per-column diff statistics (existing API).
+
+``stats_diff*`` / ``head_diff*`` / ``key_diff*`` — compute per-column
+summary statistics and outer-join diffs across three backends:
+
+  pandas  — default; vectorised over all columns in three batch passes.
+  polars  — three .select() calls; head_diff reads only N rows lazily.
+  xorq    — one ibis aggregate expression per parquet file; nothing
+            larger than a scalar summary row is materialised.
+
+Polars functions require ``buckaroo[polars]``.
+Xorq functions require ``buckaroo[xorq]``.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pandas as pd
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+# ---------------------------------------------------------------------------
+# shared utility
+# ---------------------------------------------------------------------------
+
+
+def _safe_float(v) -> float | None:
+    try:
+        f = float(v)
+        return None if math.isnan(f) else f
+    except (TypeError, ValueError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# pandas backend
+# ---------------------------------------------------------------------------
+
+
+def _column_summaries_pd(df: pd.DataFrame) -> dict[str, dict]:
+    """Three vectorised passes instead of per-column loops.
+
+    Old approach called mean/min/max/sum individually for each column
+    (N_cols * 4 scans).  This version does one isnull pass, one nunique
+    pass, and one numeric agg across all numeric columns at once.
+    """
+    n = len(df)
+    null_counts = df.isnull().sum()
+    distinct_counts = df.nunique(dropna=True)
+
+    numeric_cols = df.select_dtypes(include="number").columns.tolist()
+    num_agg = df[numeric_cols].agg(["mean", "min", "max", "sum"]) if numeric_cols else pd.DataFrame()
+
+    result: dict[str, dict] = {}
+    for col in df.columns:
+        num = None
+        if col in num_agg.columns:
+            col_agg = num_agg[col]
+            num = {"mean": _safe_float(col_agg["mean"]), "min": _safe_float(col_agg["min"]),
+                "max": _safe_float(col_agg["max"]), "sum": _safe_float(col_agg["sum"])}
+        result[col] = {"count": n, "nulls": int(null_counts[col]), "distinct": int(distinct_counts[col]),
+            "numeric": num}
+    return result
+
+
+def _infer_keys(a: pd.DataFrame, b: pd.DataFrame) -> list[str]:
+    """Heuristic: shared non-numeric low-cardinality columns are likely keys."""
+    shared_non_numeric = [
+        c for c in a.columns
+        if c in b.columns and not pd.api.types.is_numeric_dtype(a[c])
+    ]
+    if not shared_non_numeric:
+        return []
+    counts = a[shared_non_numeric].nunique(dropna=False)
+    return [c for c in shared_non_numeric if counts[c] <= max(20, int(len(a) * 0.5))]
+
+
+def head_diff(a: pd.DataFrame, b: pd.DataFrame, n: int = 10) -> dict:
+    """Side-by-side first-N rows as HTML tables (pandas backend)."""
+    return {"before": a.head(n).to_html(classes="data-table", index=False, border=0),
+        "after": b.head(n).to_html(classes="data-table", index=False, border=0), "n": n, "a_total": len(a),
+        "b_total": len(b)}
+
+
+def stats_diff(a: pd.DataFrame, b: pd.DataFrame) -> list[dict]:
+    """Per-column count / nulls / distinct / numeric summary (pandas backend)."""
+    cols = list(dict.fromkeys(list(a.columns) + list(b.columns)))
+    a_s = _column_summaries_pd(a)
+    b_s = _column_summaries_pd(b)
+    return [{"name": col, "before": a_s.get(col), "after": b_s.get(col)} for col in cols]
+
+
+def key_diff(a: pd.DataFrame, b: pd.DataFrame) -> dict | None:
+    """Outer-join on inferred keys; show per-key value changes (pandas backend)."""
+    keys = _infer_keys(a, b)
+    if not keys:
+        return None
+    try:
+        merged = a.merge(b, on=keys, how="outer", suffixes=("_before", "_after"), indicator=True)
+    except Exception:
+        return None
+    only_left = int((merged["_merge"] == "left_only").sum())
+    only_right = int((merged["_merge"] == "right_only").sum())
+    both = int((merged["_merge"] == "both").sum())
+    merged = merged.drop(columns=["_merge"])
+    return {"keys": keys, "only_before": only_left, "only_after": only_right, "matched": both,
+        "table_html": merged.head(50).to_html(classes="data-table", index=False, border=0)}
+
+
+# ---------------------------------------------------------------------------
+# polars backend  (requires buckaroo[polars])
+# ---------------------------------------------------------------------------
+
+
+def _column_summaries_polars(df: "pl.DataFrame") -> dict[str, dict]:
+    """Three .select() calls — null counts, distinct counts, numeric aggs."""
+    import polars as pl
+
+    n = len(df)
+    nulls = df.select(pl.all().null_count()).row(0, named=True)
+    distincts = df.select(pl.all().n_unique()).row(0, named=True)
+
+    num_cols = [c for c in df.columns if df.schema[c].is_numeric()]
+    if num_cols:
+        num_row = df.select(
+            [pl.col(c).mean().alias(f"{c}__mean") for c in num_cols]
+            + [pl.col(c).min().alias(f"{c}__min") for c in num_cols]
+            + [pl.col(c).max().alias(f"{c}__max") for c in num_cols]
+            + [pl.col(c).sum().alias(f"{c}__sum") for c in num_cols]).row(0, named=True)
+    else:
+        num_row = {}
+
+    result: dict[str, dict] = {}
+    for col in df.columns:
+        num = None
+        if col in num_cols:
+            num = {"mean": _safe_float(num_row.get(f"{col}__mean")), "min": _safe_float(num_row.get(f"{col}__min")),
+                "max": _safe_float(num_row.get(f"{col}__max")), "sum": _safe_float(num_row.get(f"{col}__sum"))}
+        result[col] = {"count": n, "nulls": nulls[col], "distinct": distincts[col], "numeric": num}
+    return result
+
+
+def _infer_keys_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> list[str]:
+    import polars as pl
+
+    shared = [c for c in a.columns if c in b.columns and not a.schema[c].is_numeric()]
+    if not shared:
+        return []
+    counts = a.select(pl.col(shared).n_unique()).row(0, named=True)
+    return [c for c in shared if counts[c] <= max(20, int(len(a) * 0.5))]
+
+
+def head_diff_polars(a_path: Path, b_path: Path, n: int = 10) -> dict:
+    """Read only N rows from each parquet via lazy scan (polars backend)."""
+    import polars as pl
+
+    a_df = pl.scan_parquet(a_path).head(n).collect()
+    b_df = pl.scan_parquet(b_path).head(n).collect()
+    a_total = pl.scan_parquet(a_path).select(pl.len()).collect()[0, 0]
+    b_total = pl.scan_parquet(b_path).select(pl.len()).collect()[0, 0]
+    return {"before": a_df.to_pandas().to_html(classes="data-table", index=False, border=0),
+        "after": b_df.to_pandas().to_html(classes="data-table", index=False, border=0), "n": n, "a_total": a_total,
+        "b_total": b_total}
+
+
+def stats_diff_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> list[dict]:
+    """Per-column stats (polars backend)."""
+    cols = list(dict.fromkeys(list(a.columns) + list(b.columns)))
+    a_s = _column_summaries_polars(a)
+    b_s = _column_summaries_polars(b)
+    return [{"name": col, "before": a_s.get(col), "after": b_s.get(col)} for col in cols]
+
+
+def key_diff_polars(a: "pl.DataFrame", b: "pl.DataFrame") -> dict | None:
+    """Outer join on inferred keys (polars backend)."""
+    keys = _infer_keys_polars(a, b)
+    if not keys:
+        return None
+    try:
+        merged = a.join(b, on=keys, how="full", suffix="_after", coalesce=True)
+    except Exception:
+        return None
+    a_only_col = next((c for c in a.columns if c not in keys), None)
+    b_col_after = f"{a_only_col}_after" if a_only_col else None
+    if a_only_col and b_col_after in merged.columns:
+        only_before = int(merged[b_col_after].is_null().sum())
+        only_after = int(merged[a_only_col].is_null().sum())
+        both = len(merged) - only_before - only_after
+    else:
+        only_before = only_after = 0
+        both = len(merged)
+    return {"keys": keys, "only_before": only_before, "only_after": only_after, "matched": both,
+        "table_html": merged.head(50).to_pandas().to_html(classes="data-table", index=False, border=0)}
+
+
+# ---------------------------------------------------------------------------
+# xorq backend  (requires buckaroo[xorq])
+# ---------------------------------------------------------------------------
+
+
+def _column_summaries_xorq(path: Path) -> dict[str, dict]:
+    """One ibis aggregate expression covering every column, executed once.
+
+    Nothing larger than the single scalar summary row is materialised.
+    """
+    import xorq.api as xo
+    import xorq.vendor.ibis as ibis
+
+    expr = xo.deferred_read_parquet(str(path))
+    schema = expr.schema()
+
+    agg: list = [expr.count().name("__total__")]
+    for col_name, dtype in schema.items():
+        agg.append(expr[col_name].isnull().sum().cast("int64").name(f"{col_name}__nulls"))
+        agg.append(expr[col_name].nunique().name(f"{col_name}__distinct"))
+        if dtype.is_numeric():
+            agg.append(expr[col_name].mean().name(f"{col_name}__mean"))
+            agg.append(expr[col_name].min().cast("float64").name(f"{col_name}__min"))
+            agg.append(expr[col_name].max().cast("float64").name(f"{col_name}__max"))
+            agg.append(expr[col_name].sum().cast("float64").name(f"{col_name}__sum"))
+
+    row = expr.aggregate(agg).execute().iloc[0]
+    total = int(row["__total__"])
+
+    result: dict[str, dict] = {}
+    for col_name, dtype in schema.items():
+        num = None
+        if dtype.is_numeric():
+            num = {"mean": _safe_float(row[f"{col_name}__mean"]), "min": _safe_float(row[f"{col_name}__min"]),
+                "max": _safe_float(row[f"{col_name}__max"]), "sum": _safe_float(row[f"{col_name}__sum"])}
+        result[col_name] = {"count": total, "nulls": int(row[f"{col_name}__nulls"]),
+            "distinct": int(row[f"{col_name}__distinct"]), "numeric": num}
+    return result
+
+
+def _infer_keys_xorq(a_path: Path, b_path: Path) -> list[str]:
+    """Infer key columns by querying both parquets via DuckDB."""
+    import duckdb
+    import xorq.api as xo
+
+    a_schema = xo.deferred_read_parquet(str(a_path)).schema()
+    b_schema = xo.deferred_read_parquet(str(b_path)).schema()
+    shared = [c for c in a_schema if c in b_schema and not a_schema[c].is_numeric()]
+    if not shared:
+        return []
+    con = duckdb.connect()
+    row = con.execute(
+        "SELECT " + ", ".join(f'COUNT(DISTINCT "{c}") AS "{c}"' for c in shared)
+        + f" FROM '{a_path}'").fetchone()
+    total = con.execute(f"SELECT COUNT(*) FROM '{a_path}'").fetchone()[0]
+    threshold = max(20, int(total * 0.5))
+    return [c for c, v in zip(shared, row) if v <= threshold]
+
+
+def head_diff_xorq(a_path: Path, b_path: Path, n: int = 10) -> dict:
+    """LIMIT-N query on each parquet — no full table scan (xorq backend)."""
+    import duckdb
+    import xorq.api as xo
+
+    a_df = xo.deferred_read_parquet(str(a_path)).limit(n).execute()
+    b_df = xo.deferred_read_parquet(str(b_path)).limit(n).execute()
+    con = duckdb.connect()
+    a_total = con.execute(f"SELECT COUNT(*) FROM '{a_path}'").fetchone()[0]
+    b_total = con.execute(f"SELECT COUNT(*) FROM '{b_path}'").fetchone()[0]
+    return {"before": a_df.to_html(classes="data-table", index=False, border=0),
+        "after": b_df.to_html(classes="data-table", index=False, border=0), "n": n, "a_total": a_total,
+        "b_total": b_total}
+
+
+def stats_diff_xorq(a_path: Path, b_path: Path) -> list[dict]:
+    """Per-column stats computed directly on parquet files (xorq backend).
+
+    Each side is one aggregate query — no DataFrame materialisation.
+    """
+    import xorq.api as xo
+
+    a_schema = xo.deferred_read_parquet(str(a_path)).schema()
+    b_schema = xo.deferred_read_parquet(str(b_path)).schema()
+    cols = list(dict.fromkeys(list(a_schema) + list(b_schema)))
+    a_s = _column_summaries_xorq(a_path)
+    b_s = _column_summaries_xorq(b_path)
+    return [{"name": col, "before": a_s.get(col), "after": b_s.get(col)} for col in cols]
+
+
+def key_diff_xorq(a_path: Path, b_path: Path) -> dict | None:
+    """Outer-join on inferred keys using DuckDB SQL (xorq backend)."""
+    import duckdb
+
+    keys = _infer_keys_xorq(a_path, b_path)
+    if not keys:
+        return None
+
+    con = duckdb.connect()
+    con.execute(f"CREATE VIEW a AS SELECT * FROM '{a_path}'")
+    con.execute(f"CREATE VIEW b AS SELECT * FROM '{b_path}'")
+
+    a_cols = [r[0] for r in con.execute("DESCRIBE a").fetchall()]
+    b_cols = [r[0] for r in con.execute("DESCRIBE b").fetchall()]
+    a_non_keys = [c for c in a_cols if c not in keys]
+    b_non_keys = [c for c in b_cols if c not in keys]
+
+    key_sel = ", ".join(f'COALESCE(a."{k}", b."{k}") AS "{k}"' for k in keys)
+    a_sel = ", ".join(f'a."{c}" AS "{c}_before"' for c in a_non_keys)
+    b_sel = ", ".join(f'b."{c}" AS "{c}_after"' for c in b_non_keys)
+    on_clause = " AND ".join(f'a."{k}" = b."{k}"' for k in keys)
+    select_parts = [p for p in [key_sel, a_sel, b_sel] if p]
+    sql_join = f"SELECT {', '.join(select_parts)} FROM a FULL OUTER JOIN b ON {on_clause}"
+
+    try:
+        con.execute(f"CREATE VIEW merged AS {sql_join}")
+        if a_non_keys and b_non_keys:
+            counts = con.execute(f"""
+                SELECT
+                    SUM(CASE WHEN "{a_non_keys[0]}_before" IS NULL THEN 1 ELSE 0 END) AS only_after,
+                    SUM(CASE WHEN "{b_non_keys[0]}_after"  IS NULL THEN 1 ELSE 0 END) AS only_before,
+                    COUNT(*) AS total
+                FROM merged
+            """).fetchone()
+            only_after, only_before, total = int(counts[0]), int(counts[1]), int(counts[2])
+            both = total - only_before - only_after
+        else:
+            only_before = only_after = 0
+            both = con.execute("SELECT COUNT(*) FROM merged").fetchone()[0]
+        preview = con.execute("SELECT * FROM merged LIMIT 50").df()
+    except Exception:
+        return None
+
+    return {"keys": keys, "only_before": only_before, "only_after": only_after, "matched": both,
+        "table_html": preview.to_html(classes="data-table", index=False, border=0)}
+
+
+# ---------------------------------------------------------------------------
+# existing join-diff API (unchanged)
+# ---------------------------------------------------------------------------
 
 
 def col_join_dfs(df1, df2, join_columns, how):

--- a/buckaroo/compare.py
+++ b/buckaroo/compare.py
@@ -211,7 +211,6 @@ def _column_summaries_xorq(path: Path) -> dict[str, dict]:
     Nothing larger than the single scalar summary row is materialised.
     """
     import xorq.api as xo
-    import xorq.vendor.ibis as ibis
 
     expr = xo.deferred_read_parquet(str(path))
     schema = expr.schema()

--- a/buckaroo/dataflow/dataflow.py
+++ b/buckaroo/dataflow/dataflow.py
@@ -314,11 +314,16 @@ class CustomizableDataflow(DataFlow):
     def __init__(self, orig_df, debug=False,
                  column_config_overrides:Union[Literal[None], OverrideColumnConfig]=None,
                  pinned_rows:Union[Literal[None], PinnedRowConfig]=None, extra_grid_config=None,
-                 component_config:Union[Literal[None], ComponentConfig]=None, init_sd=None, skip_main_serial=False):
+                 component_config:Union[Literal[None], ComponentConfig]=None, init_sd=None, skip_main_serial=False,
+                 skip_stat_columns=None):
         if init_sd is None:
             self.init_sd = {}
         else:
             self.init_sd = init_sd
+        # Columns whose summary stats are supplied (via init_sd) and must NOT
+        # be recomputed. Explicit opt-in: a column merely *mentioned* in
+        # init_sd (e.g. a display hint) is still computed unless named here.
+        self.skip_stat_columns = set(skip_stat_columns or ())
         self.skip_main_serial = skip_main_serial
         if column_config_overrides is None:
             column_config_overrides = {}
@@ -626,7 +631,8 @@ class CustomizableDataflow(DataFlow):
         stats = self.DFStatsClass(
             processed_df,
             self.analysis_klasses,
-            self.df_name, debug=self.debug)
+            self.df_name, debug=self.debug,
+            skip_columns=getattr(self, 'skip_stat_columns', None))
         sdf = stats.sdf
         if stats.errs:
             if self.debug:

--- a/buckaroo/pluggable_analysis_framework/analysis_management.py
+++ b/buckaroo/pluggable_analysis_framework/analysis_management.py
@@ -286,7 +286,13 @@ class DfStats(object):
         kls.ap_class(col_analysis_objs)
 
     def __init__(self, df_stats_df:pd.DataFrame, col_analysis_objs:AObjs,
-        operating_df_name:str=None, debug:bool=False) -> None:
+        operating_df_name:str=None, debug:bool=False, skip_columns=None) -> None:
+        # ``skip_columns`` is accepted for signature parity with the v2 / xorq
+        # stats classes — CustomizableDataflow._get_summary_sd passes it to
+        # every DFStatsClass. The legacy v1 AnalysisPipeline has no
+        # column-skipping hook, so it is ignored here: every column is still
+        # computed and any externally-supplied stats (from ``init_sd``) override
+        # them downstream.
         self.df = self.get_operating_df(df_stats_df, force_full_eval=False)
         self.col_order = self.df.columns
         self.ap = self.ap_class(col_analysis_objs)

--- a/buckaroo/pluggable_analysis_framework/df_stats_v2.py
+++ b/buckaroo/pluggable_analysis_framework/df_stats_v2.py
@@ -40,7 +40,7 @@ class DfStatsV2:
         cls.ap_class(col_analysis_objs)
 
     def __init__(self, df_stats_df: pd.DataFrame, col_analysis_objs: AObjs, operating_df_name: str = None,
-            debug: bool = False) -> None:
+            debug: bool = False, skip_columns=None) -> None:
         self.df = self.get_operating_df(df_stats_df, force_full_eval=False)
         self.col_order = self.df.columns
         self.ap = self.ap_class(col_analysis_objs)
@@ -48,7 +48,7 @@ class DfStatsV2:
         self.debug = debug
 
         # Process using v1-compatible output format
-        self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, self.debug)
+        self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, self.debug, skip_columns=skip_columns)
         self.stat_errors = []
 
         if self.errs:
@@ -94,10 +94,10 @@ class PlDfStatsV2:
             return df.sample(n=min(50_000, rows), seed=42)
         return df
 
-    def __init__(self, df, col_analysis_objs, operating_df_name=None, debug=False):
+    def __init__(self, df, col_analysis_objs, operating_df_name=None, debug=False, skip_columns=None):
         self.df = self.get_operating_df(df)
         self.ap = StatPipeline(col_analysis_objs, unit_test=False)
-        self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, debug)
+        self.sdf, self.errs = self.ap.process_df_v1_compat(self.df, debug, skip_columns=skip_columns)
         self.stat_errors = []
         if self.errs:
             output_full_reproduce(self.errs, self.sdf, operating_df_name)

--- a/buckaroo/pluggable_analysis_framework/stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/stat_pipeline.py
@@ -270,8 +270,14 @@ class StatPipeline:
 
         return resolve_accumulator(accumulator, column_name, col_key_to_func)
 
-    def process_df(self, df: pd.DataFrame, debug: bool = False) -> Tuple[SDType, List[StatError]]:
+    def process_df(self, df: pd.DataFrame, debug: bool = False,
+                   skip_columns=None) -> Tuple[SDType, List[StatError]]:
         """Process all columns of a DataFrame.
+
+        ``skip_columns`` names columns whose summary stats are supplied
+        externally (e.g. via ``init_sd`` — reused from a source dataframe in a
+        diff). They still appear in the output with structural metadata, but no
+        stat functions run for them, so the column is never scanned.
 
         Returns:
             (summary_dict, all_errors) where summary_dict is SDType-compatible
@@ -283,10 +289,16 @@ class StatPipeline:
         if self.record_timings:
             self.timings = []
 
+        skip = set(skip_columns or ())
         summary: SDType = {}
         all_errors: List[StatError] = []
 
         for orig_col_name, rewritten_col_name in old_col_new_col(df):
+            if orig_col_name in skip or rewritten_col_name in skip:
+                # Provided externally — keep the column, skip computation.
+                summary[rewritten_col_name] = {
+                    'orig_col_name': orig_col_name, 'rewritten_col_name': rewritten_col_name}
+                continue
             ser = df[orig_col_name]
             col_dtype = ser.dtype
 
@@ -299,7 +311,8 @@ class StatPipeline:
 
         return summary, all_errors
 
-    def process_df_v1_compat(self, df: pd.DataFrame, debug: bool = False) -> Tuple[SDType, ErrDict]:
+    def process_df_v1_compat(self, df: pd.DataFrame, debug: bool = False,
+                             skip_columns=None) -> Tuple[SDType, ErrDict]:
         """Process DataFrame with v1-compatible error format.
 
         Returns (SDType, ErrDict) matching the v1 AnalysisPipeline interface.
@@ -307,7 +320,7 @@ class StatPipeline:
         that mixes ColAnalysis subclasses into the input list — DataFlow,
         autocleaning, server.data_loading, polars_buckaroo).
         """
-        summary, errors = self.process_df(df, debug=debug)
+        summary, errors = self.process_df(df, debug=debug, skip_columns=skip_columns)
 
         # Convert StatError list to v1 ErrDict format
         errs: ErrDict = {}

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -222,10 +222,10 @@ class XorqStatPipeline:
             self.backend = saved_backend
             self.cache_storage = saved_cache
 
-    def process_table(self, table) -> Tuple[SDType, List[StatError]]:
+    def process_table(self, table, skip_columns=None) -> Tuple[SDType, List[StatError]]:
         materialized, cleanup = self._maybe_materialize(table)
         try:
-            return self._process_table_impl(materialized)
+            return self._process_table_impl(materialized, skip_columns=skip_columns)
         finally:
             if cleanup is not None:
                 backend, name = cleanup
@@ -234,9 +234,13 @@ class XorqStatPipeline:
                 except Exception:
                     pass
 
-    def _process_table_impl(self, table) -> Tuple[SDType, List[StatError]]:
+    def _process_table_impl(self, table, skip_columns=None) -> Tuple[SDType, List[StatError]]:
         schema = table.schema()
         columns = list(table.columns)
+        # Columns whose stats are supplied externally (via init_sd) keep their
+        # structural metadata (name/dtype/length) but get no stat expressions
+        # built — so the column's data is never scanned.
+        skip = set(skip_columns or ())
 
         # Pre-populate every column accumulator with the externally-provided
         # keys. ``length`` is filled in by the batch query below. ``min`` /
@@ -259,6 +263,8 @@ class XorqStatPipeline:
                 continue
             xorq_col_param = next(r.name for r in sf.requires if r.type is XorqColumn)
             for col in columns:
+                if col in skip:
+                    continue
                 col_dtype = schema[col]
                 if sf.column_filter is not None and not sf.column_filter(col_dtype):
                     continue
@@ -317,7 +323,7 @@ class XorqStatPipeline:
             col_dtype = schema[col]
             col_funcs = build_column_dag(self.all_stat_funcs, col_dtype, external_keys=self.EXTERNAL_KEYS)
 
-            for sf in col_funcs:
+            for sf in col_funcs if col not in skip else []:
                 # Skip stats whose results are already in the accumulator
                 # (typically the batch-phase stats).
                 if sf.provides and all(sk.name in col_accum for sk in sf.provides):
@@ -375,14 +381,14 @@ class XorqStatPipeline:
 
         return True, []
 
-    def process_table_v1_compat(self, table) -> Tuple[SDType, ErrDict]:
+    def process_table_v1_compat(self, table, skip_columns=None) -> Tuple[SDType, ErrDict]:
         """Run process_table and convert errors to v1 ErrDict shape.
 
         Used by XorqDfStatsV2 / DataFlow consumers expecting the same
         ``{(col, stat): (Exception, kls)}`` shape that AnalysisPipeline
         produced.
         """
-        summary, errors = self.process_table(table)
+        summary, errors = self.process_table(table, skip_columns=skip_columns)
         errs: ErrDict = {}
         for se in errors:
             kls = _find_v1_class(se.stat_func, self._original_inputs) if se.stat_func else None
@@ -416,7 +422,7 @@ class XorqDfStatsV2:
         XorqStatPipeline(objs, unit_test=False)
 
     def __init__(self, table, col_analysis_objs, operating_df_name=None, debug=False,
-                 cache_storage=None):
+                 cache_storage=None, skip_columns=None):
         self.table = table
         # Skip the unit_test PERVERSE_DF run on each widget construction —
         # it doubles the SQL query count (issue #709). The DAG-validation
@@ -426,7 +432,7 @@ class XorqDfStatsV2:
             cache_storage=cache_storage)
         self.operating_df_name = operating_df_name
         self.debug = debug
-        self.sdf, self.errs = self.ap.process_table_v1_compat(self.table)
+        self.sdf, self.errs = self.ap.process_table_v1_compat(self.table, skip_columns=skip_columns)
         self.stat_errors = []
         if self.errs:
             output_full_reproduce(self.errs, self.sdf, operating_df_name)

--- a/buckaroo/polars_buckaroo.py
+++ b/buckaroo/polars_buckaroo.py
@@ -189,9 +189,10 @@ class PolarsDFViewerInfinite(PolarsBuckarooInfiniteWidget):
         column_config_overrides=None,
         pinned_rows=None, extra_grid_config=None,
         component_config=None,
-        init_sd=None, record_transcript=False):
+        init_sd=None, skip_stat_columns=None, record_transcript=False):
         super().__init__(orig_df, debug, column_config_overrides, pinned_rows,
-            extra_grid_config, component_config, init_sd, record_transcript=record_transcript)
+            extra_grid_config, component_config, init_sd,
+            skip_stat_columns=skip_stat_columns, record_transcript=record_transcript)
         self.df_id = str(id(orig_df))
 
 

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -422,6 +422,9 @@ class LoadExprHandler(tornado.web.RequestHandler):
         column_config_overrides = body.get("column_config_overrides")
         extra_grid_config = body.get("extra_grid_config")
         init_sd = body.get("init_sd")
+        # Columns whose summary stats are supplied via init_sd and must not be
+        # recomputed (e.g. a diff reusing each source column's stats).
+        skip_stat_columns = body.get("skip_stat_columns")
 
         project_root = body.get("project_root")
         cache_storage_path = body.get("cache_storage_path")
@@ -436,7 +439,8 @@ class LoadExprHandler(tornado.web.RequestHandler):
                 expr, skip_main_serial=True, extra_klasses=extra_klasses,
                 cache_storage_path=cache_storage_path,
                 column_config_overrides=column_config_overrides,
-                extra_grid_config=extra_grid_config, init_sd=init_sd)
+                extra_grid_config=extra_grid_config, init_sd=init_sd,
+                skip_stat_columns=skip_stat_columns)
             metadata = xorq_loading.get_xorq_metadata(xorq_dataflow, build_dir)
         except FileNotFoundError:
             self.set_status(404)

--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -169,7 +169,8 @@ class XorqDataflow(CustomizableDataflow):
         cache_storage = getattr(self, 'cache_storage', None)
         stats = self.DFStatsClass(
             processed_df, self.analysis_klasses, self.df_name,
-            debug=self.debug, cache_storage=cache_storage)
+            debug=self.debug, cache_storage=cache_storage,
+            skip_columns=getattr(self, 'skip_stat_columns', None))
         sdf = stats.sdf
         if stats.errs:
             if self.debug:

--- a/tests/unit/compare_perf_test.py
+++ b/tests/unit/compare_perf_test.py
@@ -1,30 +1,38 @@
-"""Performance / big-O regression tests for buckaroo.compare.
+"""Deterministic scaling-regression guards for buckaroo.compare.
 
-These guard the scaling claims the three diff backends make, not absolute
-speed. Each test measures an operation at two row counts and asserts on the
-*ratio* between them, which is largely machine-independent (both sizes scale
-by the same hardware factor), so the thresholds hold on a fast laptop and a
-slow CI runner alike. The whole module is sized to run in well under 10s.
+These replace the old wall-clock timing tests. Instead of measuring elapsed
+time and asserting on a ratio (machine-dependent, flaky on a loaded CI runner),
+each test asserts on *work done* and *results* — counts that are identical on a
+fast laptop and a slow runner:
 
-What the ratios encode:
-  - stats_diff*  is O(rows): a 10x row increase should cost ~10x, not ~100x.
-  - head_diff*   is lazy on the polars/xorq (parquet) backends: a 100x row
-                 increase should barely move the clock, because only the
-                 N-row preview (+ a metadata count) is read.
-  - key_diff* (all backends) detect a real unique key, so each stays ~linear
-                 and matches every row exactly once (matched == n). The
-                 deterministic matched count guards against the cartesian
-                 blowup the old low-cardinality key heuristic produced.
+  - head_diff*  on the parquet (polars / xorq) backends is lazy: it never
+                materialises more than the N-row preview, regardless of file
+                size. Guarded by spying on the materialisation boundary
+                (``LazyFrame.collect`` / ``Expr.execute``) and asserting no
+                call pulls more than N rows — plus, for polars, that no eager
+                full read (``pl.read_parquet``) happens at all.
+  - stats_diff* batches every column into a fixed number of backend passes
+                rather than one scan per column. Guarded by counting the
+                backend op (pandas ``DataFrame.agg`` / polars ``DataFrame.select``
+                / xorq ``Expr.execute``) on a narrow vs a wide frame and
+                asserting the count does not grow with the column count.
+  - key_diff*   detects the real unique key (not a low-cardinality column), so
+                every row matches exactly once (``matched == n``). The matched
+                count is the deterministic guard against the cartesian blowup
+                the old low-cardinality key heuristic produced.
 
-Run `pytest -s tests/unit/compare_perf_test.py` to see the timing table.
+The module is small and fast (no million-row fixtures) — the regressions show
+up at a few thousand rows just as clearly as at a million, because the spies
+measure rows materialised, not rows on disk.
 """
-import time
-
 import numpy as np
 import pandas as pd
 import pytest
 
-from buckaroo.compare import (head_diff, head_diff_polars, head_diff_xorq, key_diff, key_diff_polars, key_diff_xorq, stats_diff, stats_diff_polars, stats_diff_xorq)
+from buckaroo.compare import (
+    head_diff, head_diff_polars, head_diff_xorq,
+    key_diff, key_diff_polars, key_diff_xorq,
+    stats_diff, stats_diff_polars, stats_diff_xorq)
 
 # polars is a hard test dependency in this repo; xorq is gated to python < 3.14.
 # Gate per-backend (not at module level) so the pandas tests still run when an
@@ -45,20 +53,22 @@ needs_polars = pytest.mark.skipif(not HAS_POLARS, reason="requires buckaroo[pola
 needs_xorq = pytest.mark.skipif(not HAS_XORQ, reason="requires buckaroo[xorq] (python < 3.14)")
 
 
-# --- row counts -------------------------------------------------------------
-# Linear ops compare SMALL -> BIG (10x). Lazy ops compare TINY -> BIG (100x)
-# so a "reads the whole frame" regression shows up as ~100x, not ~1x.
-TINY = 10_000
-SMALL = 100_000
-BIG = 1_000_000
+# --- sizes ------------------------------------------------------------------
+N_PREVIEW = 10        # head_diff preview rows
+LAZY_ROWS = 2_000     # rows in the parquet used for the laziness spies (>> preview)
+KEY_N = 2_000         # rows for the no-blowup key tests (a cartesian blowup -> ~n^2/10)
+BATCH_ROWS = 500      # rows for the batching tests (column count is what varies)
+NCOLS_NARROW = 4
+NCOLS_WIDE = 40
 
 
 def _gen(n, seed=0):
     """Mixed-dtype frame: a unique int key, a low-cardinality column, nulls, a bool.
 
-    'id' is unique (a real join key). 'cat' has 10 distinct values, which is
-    exactly the kind of column the pandas/polars key heuristic wrongly treats
-    as a join key. Kept allocation-light so generating 1M rows is cheap.
+    'id' is ``arange(n)`` — identical for every seed, so two frames built with
+    different seeds share the same key set (every row matches) while their other
+    columns differ. 'cat' has 10 distinct values: exactly the low-cardinality
+    column the old key heuristic wrongly treated as a join key.
     """
     rng = np.random.default_rng(seed)
     df = pd.DataFrame({
@@ -71,171 +81,204 @@ def _gen(n, seed=0):
     return df
 
 
-def _best_of(fn, n=3):
-    """Warmup once, then return the min of n timed runs (steady-state cost)."""
-    fn()
-    return min(_timed(fn) for _ in range(n))
+def _gen_wide(ncols, nrows, seed=0):
+    """All-numeric frame of ``ncols`` columns — exercises the numeric-agg batch."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({f"c{i}": rng.standard_normal(nrows) for i in range(ncols)})
 
 
-def _timed(fn):
-    t0 = time.perf_counter()
-    fn()
-    return time.perf_counter() - t0
+def _count_calls(cls, method, fn):
+    """Run ``fn`` and return how many times ``cls.method`` was invoked.
 
-
-def _report(op, small_n, small_t, big_n, big_t):
-    ratio = big_t / max(small_t, 1e-9)
-    print(
-        f"\n[compare-perf] {op:<28} "
-        f"{small_n:>9,}={small_t * 1e3:7.1f}ms  "
-        f"{big_n:>9,}={big_t * 1e3:7.1f}ms  "
-        f"ratio={ratio:5.1f}x (rows x{big_n // small_n})")
-    return ratio
-
-
-@pytest.fixture(scope="session")
-def data(tmp_path_factory):
-    """Generate each row-size once: an in-memory frame plus a parquet file.
-
-    Tests pass the frame/path as BOTH sides of a diff — identical before/after
-    is a fine perf proxy (the per-side work is unchanged) and makes
-    key_diff_xorq match every row exactly once.
+    Deterministic stand-in for "how much work scales with the input": a backend
+    op called once per side is constant in column count; one called per column
+    is not.
     """
-    d = tmp_path_factory.mktemp("compare_perf")
-    frames, paths = {}, {}
-    for n in (TINY, SMALL, BIG):
-        df = _gen(n)
-        frames[n] = df
-        p = d / f"{n}.parquet"
-        df.to_parquet(p)
-        paths[n] = p
-    return {"frames": frames, "paths": paths}
+    orig = getattr(cls, method)
+    n = 0
+
+    def wrapped(self, *args, **kwargs):
+        nonlocal n
+        n += 1
+        return orig(self, *args, **kwargs)
+
+    setattr(cls, method, wrapped)
+    try:
+        fn()
+    finally:
+        setattr(cls, method, orig)
+    return n
+
+
+def _materialised_rows(cls, method, fn):
+    """Run ``fn`` and return the row count of every result ``cls.method`` produced.
+
+    A scalar result (e.g. a ``count()``) counts as 1 row. The max over all calls
+    is the largest frame the operation ever pulled into memory.
+    """
+    orig = getattr(cls, method)
+    sizes = []
+
+    def wrapped(self, *args, **kwargs):
+        out = orig(self, *args, **kwargs)
+        sizes.append(len(out) if hasattr(out, "__len__") else 1)
+        return out
+
+    setattr(cls, method, wrapped)
+    try:
+        fn()
+    finally:
+        setattr(cls, method, orig)
+    return sizes
+
+
+def _xorq_expr_base():
+    """The vendored-ibis ``Expr`` base class (the owner of ``.execute``).
+
+    Found via the MRO of a real expression so the test does not hard-code the
+    vendored module path, which has moved between xorq versions.
+    """
+    import xorq.api as xo
+
+    expr = xo.literal(1)
+    return next(c for c in type(expr).__mro__ if c.__name__ == "Expr")
+
+
+@pytest.fixture(scope="module")
+def lazy_parquet(tmp_path_factory):
+    """A single parquet file of LAZY_ROWS rows, used by the laziness spies."""
+    p = tmp_path_factory.mktemp("compare_lazy") / "t.parquet"
+    _gen(LAZY_ROWS).to_parquet(p)
+    return p
+
+
+@pytest.fixture(scope="module")
+def batch(tmp_path_factory):
+    """A narrow and a wide frame (same row count) + their parquet files."""
+    d = tmp_path_factory.mktemp("compare_batch")
+    narrow = _gen_wide(NCOLS_NARROW, BATCH_ROWS)
+    wide = _gen_wide(NCOLS_WIDE, BATCH_ROWS)
+    narrow_p = d / "narrow.parquet"
+    wide_p = d / "wide.parquet"
+    narrow.to_parquet(narrow_p)
+    wide.to_parquet(wide_p)
+    return {"narrow_df": narrow, "wide_df": wide, "narrow_p": narrow_p, "wide_p": wide_p}
 
 
 # ===========================================================================
-# stats_diff: O(rows). A 10x row jump should cost ~10x, never ~100x.
-# A correct linear backend lands near 10x; the ceiling still trips on an
-# accidental O(n^2) regression (~100x).
+# head_diff: lazy on the parquet backends — never materialise more than N rows.
 # ===========================================================================
-
-_LINEAR_MAX = 25.0
-
-
-def test_stats_diff_linear_pandas(data):
-    s, b = data["frames"][SMALL], data["frames"][BIG]
-    small_t = _best_of(lambda: stats_diff(s, s), n=3)
-    big_t = _best_of(lambda: stats_diff(b, b), n=2)
-    ratio = _report("stats_diff (pandas)", SMALL, small_t, BIG, big_t)
-    assert ratio < _LINEAR_MAX, f"stats_diff scaling {ratio:.1f}x for 10x rows — superlinear?"
 
 
 @needs_polars
-def test_stats_diff_linear_polars(data):
-    s = pl.from_pandas(data["frames"][SMALL])
-    b = pl.from_pandas(data["frames"][BIG])
-    small_t = _best_of(lambda: stats_diff_polars(s, s), n=3)
-    big_t = _best_of(lambda: stats_diff_polars(b, b), n=2)
-    ratio = _report("stats_diff (polars)", SMALL, small_t, BIG, big_t)
-    assert ratio < _LINEAR_MAX, f"stats_diff_polars scaling {ratio:.1f}x for 10x rows — superlinear?"
+def test_head_diff_polars_reads_only_preview(lazy_parquet, monkeypatch):
+    eager = {"n": 0}
+    orig_read = pl.read_parquet
+
+    def spy_read(*args, **kwargs):
+        eager["n"] += 1
+        return orig_read(*args, **kwargs)
+
+    monkeypatch.setattr(pl, "read_parquet", spy_read)
+    sizes = _materialised_rows(
+        pl.LazyFrame, "collect",
+        lambda: _assert_head_total(head_diff_polars(lazy_parquet, lazy_parquet, n=N_PREVIEW)))
+
+    assert sizes, "expected at least one LazyFrame.collect()"
+    assert max(sizes) <= N_PREVIEW, (
+        f"head_diff_polars materialised {max(sizes)} rows (> {N_PREVIEW}); a lazy scan should "
+        "read only the N-row preview plus a scalar count, not the whole frame.")
+    assert eager["n"] == 0, (
+        f"head_diff_polars called pl.read_parquet {eager['n']}x — that eagerly reads the whole "
+        "file; the preview must come from a lazy scan_parquet().head(n).")
 
 
 @needs_xorq
-def test_stats_diff_linear_xorq(data):
-    s, b = data["paths"][SMALL], data["paths"][BIG]
-    small_t = _best_of(lambda: stats_diff_xorq(s, s), n=3)
-    big_t = _best_of(lambda: stats_diff_xorq(b, b), n=1)
-    ratio = _report("stats_diff (xorq)", SMALL, small_t, BIG, big_t)
-    assert ratio < _LINEAR_MAX, f"stats_diff_xorq scaling {ratio:.1f}x for 10x rows — superlinear?"
+def test_head_diff_xorq_reads_only_preview(lazy_parquet):
+    expr_base = _xorq_expr_base()
+    sizes = _materialised_rows(
+        expr_base, "execute",
+        lambda: _assert_head_total(head_diff_xorq(lazy_parquet, lazy_parquet, n=N_PREVIEW)))
+
+    assert sizes, "expected at least one Expr.execute()"
+    assert max(sizes) <= N_PREVIEW, (
+        f"head_diff_xorq materialised {max(sizes)} rows (> {N_PREVIEW}); limit(n) + count() "
+        "should never pull the whole file into memory.")
+
+
+def _assert_head_total(res):
+    """The preview is only meaningful if the totals are right (the count ran)."""
+    assert res["a_total"] == LAZY_ROWS and res["b_total"] == LAZY_ROWS
+    assert res["n"] == N_PREVIEW
+    return res
+
+
+def test_head_diff_pandas_totals():
+    # pandas head_diff is in-memory (the frame is already materialised), so there
+    # is no laziness to prove — just that it reports the right totals + preview.
+    df = _gen(500)
+    res = head_diff(df, df, n=N_PREVIEW)
+    assert res["a_total"] == 500 and res["b_total"] == 500 and res["n"] == N_PREVIEW
+    assert "<table" in res["before"] and "<table" in res["after"]
 
 
 # ===========================================================================
-# head_diff: must NOT read the whole frame on the lazy (parquet) backends.
-# 100x more rows should stay near-flat; a non-lazy regression scales ~100x.
-# ===========================================================================
-
-_LAZY_MAX = 15.0
-
-
-@needs_polars
-def test_head_diff_lazy_polars(data):
-    t, b = data["paths"][TINY], data["paths"][BIG]
-    small_t = _best_of(lambda: head_diff_polars(t, t), n=3)
-    big_t = _best_of(lambda: head_diff_polars(b, b), n=3)
-    ratio = _report("head_diff (polars,lazy)", TINY, small_t, BIG, big_t)
-    assert ratio < _LAZY_MAX, (
-        f"head_diff_polars is {ratio:.1f}x slower for 100x rows — lazy scan should keep this "
-        "near-flat; it may be reading the full frame instead of N rows + metadata.")
-
-
-@needs_xorq
-def test_head_diff_lazy_xorq(data):
-    t, b = data["paths"][TINY], data["paths"][BIG]
-    small_t = _best_of(lambda: head_diff_xorq(t, t), n=3)
-    big_t = _best_of(lambda: head_diff_xorq(b, b), n=3)
-    ratio = _report("head_diff (xorq,lazy)", TINY, small_t, BIG, big_t)
-    assert ratio < _LAZY_MAX, (
-        f"head_diff_xorq is {ratio:.1f}x slower for 100x rows — limit(n)+count should keep this "
-        "near-flat; it may be materialising the full frame.")
-
-
-def test_head_diff_pandas_independent_of_rows(data):
-    # pandas head_diff is on an in-memory frame; it only renders head(10) + len(),
-    # so it is O(1) in row count.
-    s, b = data["frames"][SMALL], data["frames"][BIG]
-    small_t = _best_of(lambda: head_diff(s, s), n=3)
-    big_t = _best_of(lambda: head_diff(b, b), n=3)
-    ratio = _report("head_diff (pandas)", SMALL, small_t, BIG, big_t)
-    assert ratio < _LAZY_MAX, f"head_diff (pandas) scales with rows ({ratio:.1f}x) — should be ~O(1)."
-
-
-# ===========================================================================
-# key_diff: xorq picks a real unique key -> stays linear and matches 1:1.
+# stats_diff: batched over all columns — work is constant in the column count,
+# not one scan per column.
 # ===========================================================================
 
 
-@needs_xorq
-def test_key_diff_xorq_linear_with_unique_key(data):
-    t, s = data["paths"][TINY], data["paths"][SMALL]
-    big_res = key_diff_xorq(s, s)
-    # It must detect the unique 'id', not the low-card 'cat', so every row
-    # matches exactly once: matched == n, no cartesian blowup.
-    assert big_res is not None and big_res["matched"] == SMALL, (
-        f"key_diff_xorq matched={big_res and big_res['matched']} (expected {SMALL}); "
-        f"detected keys={big_res and big_res['keys']} — should be a unique key.")
-    small_t = _best_of(lambda: key_diff_xorq(t, t), n=2)
-    big_t = _best_of(lambda: key_diff_xorq(s, s), n=2)
-    ratio = _report("key_diff (xorq,unique)", TINY, small_t, SMALL, big_t)
-    assert ratio < _LINEAR_MAX, (
-        f"key_diff_xorq is {ratio:.1f}x for 10x rows — should be ~linear on a unique key.")
+@pytest.mark.parametrize("backend", ["pandas", "polars", "xorq"])
+def test_stats_diff_work_constant_in_column_count(backend, batch):
+    if backend == "pandas":
+        cls, method, run = pd.DataFrame, "agg", stats_diff
+        narrow, wide = batch["narrow_df"], batch["wide_df"]
+    elif backend == "polars":
+        pytest.importorskip("polars")
+        cls, method, run = pl.DataFrame, "select", stats_diff_polars
+        narrow, wide = pl.from_pandas(batch["narrow_df"]), pl.from_pandas(batch["wide_df"])
+    else:
+        pytest.importorskip("xorq")
+        cls, method, run = _xorq_expr_base(), "execute", stats_diff_xorq
+        narrow, wide = batch["narrow_p"], batch["wide_p"]
+
+    n_narrow = _count_calls(cls, method, lambda: run(narrow, narrow))
+    n_wide = _count_calls(cls, method, lambda: run(wide, wide))
+
+    assert n_narrow > 0, f"{backend}: expected stats_diff to call {method}() at least once"
+    assert n_narrow == n_wide, (
+        f"{backend} stats_diff issued {n_narrow} {method}() call(s) on {NCOLS_NARROW} columns "
+        f"but {n_wide} on {NCOLS_WIDE} — the work scales with column count; expected a fixed "
+        "number of batched passes regardless of width.")
 
 
 # ===========================================================================
-# key_diff must NOT cartesian-blow-up (pandas / polars). The detector picks the
-# unique 'id', so matched == n (one row per input row). The earlier low-
-# cardinality heuristic picked 'cat' (10 distinct) and produced ~n^2/k matched
-# rows; the deterministic matched count is the regression guard.
+# key_diff: detect the unique key (not a low-cardinality column) so every row
+# matches exactly once. matched == n is the cartesian-blowup guard.
 # ===========================================================================
 
-_BLOWUP_N = 2_000  # quadratic blowup would build ~n^2/k rows here — kept small
 
+@pytest.mark.parametrize("backend", ["pandas", "polars", "xorq"])
+def test_key_diff_detects_unique_key_no_blowup(backend, tmp_path):
+    a, b = _gen(KEY_N, 0), _gen(KEY_N, 1)  # identical unique 'id', other columns differ
+    if backend == "pandas":
+        res = key_diff(a, b)
+    elif backend == "polars":
+        pytest.importorskip("polars")
+        res = key_diff_polars(pl.from_pandas(a), pl.from_pandas(b))
+    else:
+        pytest.importorskip("xorq")
+        ap, bp = tmp_path / "a.parquet", tmp_path / "b.parquet"
+        a.to_parquet(ap)
+        b.to_parquet(bp)
+        res = key_diff_xorq(ap, bp)
 
-def test_key_diff_pandas_no_cartesian_blowup():
-    a, b = _gen(_BLOWUP_N, 0), _gen(_BLOWUP_N, 1)
-    res = key_diff(a, b)
-    matched = res["matched"] if res else None
-    print(f"\n[compare-perf] key_diff (pandas) n={_BLOWUP_N} matched={matched} keys={res and res['keys']}")
-    # A sound key gives one matched row per input row.
-    assert res is not None and res["keys"] == ["id"] and matched == _BLOWUP_N, (
-        f"key_diff matched={matched} for n={_BLOWUP_N} on keys={res and res['keys']} — "
-        "expected matched==n on the unique 'id' (no cartesian blowup).")
-
-
-@needs_polars
-def test_key_diff_polars_no_cartesian_blowup():
-    a, b = pl.from_pandas(_gen(_BLOWUP_N, 0)), pl.from_pandas(_gen(_BLOWUP_N, 1))
-    res = key_diff_polars(a, b)
-    matched = res["matched"] if res else None
-    print(f"\n[compare-perf] key_diff (polars) n={_BLOWUP_N} matched={matched} keys={res and res['keys']}")
-    assert res is not None and res["keys"] == ["id"] and matched == _BLOWUP_N, (
-        f"key_diff_polars matched={matched} for n={_BLOWUP_N} on keys={res and res['keys']} — "
-        "expected matched==n on the unique 'id' (no cartesian blowup).")
+    assert res is not None, f"{backend}: expected a diff joined on the unique 'id'"
+    assert res["keys"] == ["id"], (
+        f"{backend}: detected keys {res['keys']}, expected the unique 'id'; a low-cardinality "
+        "key (e.g. 'cat', 10 distinct) would explode the outer join into a many-to-many product.")
+    # 1:1 alignment — one matched row per input row, no n^2 cartesian explosion.
+    assert res["matched"] == KEY_N, (
+        f"{backend}: matched={res['matched']} (expected {KEY_N}) — a cartesian blowup on a "
+        "low-cardinality key would produce far more.")
+    assert res["only_before"] == 0 and res["only_after"] == 0

--- a/tests/unit/compare_perf_test.py
+++ b/tests/unit/compare_perf_test.py
@@ -1,0 +1,247 @@
+"""Performance / big-O regression tests for buckaroo.compare.
+
+These guard the scaling claims the three diff backends make, not absolute
+speed. Each test measures an operation at two row counts and asserts on the
+*ratio* between them, which is largely machine-independent (both sizes scale
+by the same hardware factor), so the thresholds hold on a fast laptop and a
+slow CI runner alike. The whole module is sized to run in well under 10s.
+
+What the ratios encode:
+  - stats_diff*  is O(rows): a 10x row increase should cost ~10x, not ~100x.
+  - head_diff*   is lazy on the polars/xorq (parquet) backends: a 100x row
+                 increase should barely move the clock, because only the
+                 N-row preview (+ a metadata count) is read.
+  - key_diff_xorq detects a real unique key, so it stays ~linear and matches
+                 every row exactly once (matched == n).
+  - key_diff / key_diff_polars infer LOW-cardinality columns as "keys" and
+                 outer-join on them unguarded, so the join is many-to-many and
+                 the matched-row count grows ~O(n^2). Those two are xfail until
+                 the key inference is fixed (see PR #872 review).
+
+Run `pytest -s tests/unit/compare_perf_test.py` to see the timing table.
+"""
+import time
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from buckaroo.compare import (head_diff, head_diff_polars, head_diff_xorq, key_diff, key_diff_polars, key_diff_xorq, stats_diff, stats_diff_polars, stats_diff_xorq)
+
+# polars is a hard test dependency in this repo; xorq is gated to python < 3.14.
+# Gate per-backend (not at module level) so the pandas tests still run when an
+# optional backend is absent.
+try:
+    import polars as pl
+    HAS_POLARS = True
+except ImportError:
+    HAS_POLARS = False
+
+try:
+    import xorq.api  # noqa: F401
+    HAS_XORQ = True
+except ImportError:
+    HAS_XORQ = False
+
+needs_polars = pytest.mark.skipif(not HAS_POLARS, reason="requires buckaroo[polars]")
+needs_xorq = pytest.mark.skipif(not HAS_XORQ, reason="requires buckaroo[xorq] (python < 3.14)")
+
+
+# --- row counts -------------------------------------------------------------
+# Linear ops compare SMALL -> BIG (10x). Lazy ops compare TINY -> BIG (100x)
+# so a "reads the whole frame" regression shows up as ~100x, not ~1x.
+TINY = 10_000
+SMALL = 100_000
+BIG = 1_000_000
+
+
+def _gen(n, seed=0):
+    """Mixed-dtype frame: a unique int key, a low-cardinality column, nulls, a bool.
+
+    'id' is unique (a real join key). 'cat' has 10 distinct values, which is
+    exactly the kind of column the pandas/polars key heuristic wrongly treats
+    as a join key. Kept allocation-light so generating 1M rows is cheap.
+    """
+    rng = np.random.default_rng(seed)
+    df = pd.DataFrame({
+        "id": np.arange(n, dtype="int64"),
+        "cat": rng.integers(0, 10, n).astype(str),
+        "val1": rng.standard_normal(n),
+        "val2": rng.standard_normal(n),
+        "flag": rng.integers(0, 2, n).astype(bool)})
+    df.loc[df.index % 50 == 0, "val1"] = np.nan  # ~2% nulls
+    return df
+
+
+def _best_of(fn, n=3):
+    """Warmup once, then return the min of n timed runs (steady-state cost)."""
+    fn()
+    return min(_timed(fn) for _ in range(n))
+
+
+def _timed(fn):
+    t0 = time.perf_counter()
+    fn()
+    return time.perf_counter() - t0
+
+
+def _report(op, small_n, small_t, big_n, big_t):
+    ratio = big_t / max(small_t, 1e-9)
+    print(
+        f"\n[compare-perf] {op:<28} "
+        f"{small_n:>9,}={small_t * 1e3:7.1f}ms  "
+        f"{big_n:>9,}={big_t * 1e3:7.1f}ms  "
+        f"ratio={ratio:5.1f}x (rows x{big_n // small_n})")
+    return ratio
+
+
+@pytest.fixture(scope="session")
+def data(tmp_path_factory):
+    """Generate each row-size once: an in-memory frame plus a parquet file.
+
+    Tests pass the frame/path as BOTH sides of a diff — identical before/after
+    is a fine perf proxy (the per-side work is unchanged) and makes
+    key_diff_xorq match every row exactly once.
+    """
+    d = tmp_path_factory.mktemp("compare_perf")
+    frames, paths = {}, {}
+    for n in (TINY, SMALL, BIG):
+        df = _gen(n)
+        frames[n] = df
+        p = d / f"{n}.parquet"
+        df.to_parquet(p)
+        paths[n] = p
+    return {"frames": frames, "paths": paths}
+
+
+# ===========================================================================
+# stats_diff: O(rows). A 10x row jump should cost ~10x, never ~100x.
+# A correct linear backend lands near 10x; the ceiling still trips on an
+# accidental O(n^2) regression (~100x).
+# ===========================================================================
+
+_LINEAR_MAX = 25.0
+
+
+def test_stats_diff_linear_pandas(data):
+    s, b = data["frames"][SMALL], data["frames"][BIG]
+    small_t = _best_of(lambda: stats_diff(s, s), n=3)
+    big_t = _best_of(lambda: stats_diff(b, b), n=2)
+    ratio = _report("stats_diff (pandas)", SMALL, small_t, BIG, big_t)
+    assert ratio < _LINEAR_MAX, f"stats_diff scaling {ratio:.1f}x for 10x rows — superlinear?"
+
+
+@needs_polars
+def test_stats_diff_linear_polars(data):
+    s = pl.from_pandas(data["frames"][SMALL])
+    b = pl.from_pandas(data["frames"][BIG])
+    small_t = _best_of(lambda: stats_diff_polars(s, s), n=3)
+    big_t = _best_of(lambda: stats_diff_polars(b, b), n=2)
+    ratio = _report("stats_diff (polars)", SMALL, small_t, BIG, big_t)
+    assert ratio < _LINEAR_MAX, f"stats_diff_polars scaling {ratio:.1f}x for 10x rows — superlinear?"
+
+
+@needs_xorq
+def test_stats_diff_linear_xorq(data):
+    s, b = data["paths"][SMALL], data["paths"][BIG]
+    small_t = _best_of(lambda: stats_diff_xorq(s, s), n=3)
+    big_t = _best_of(lambda: stats_diff_xorq(b, b), n=1)
+    ratio = _report("stats_diff (xorq)", SMALL, small_t, BIG, big_t)
+    assert ratio < _LINEAR_MAX, f"stats_diff_xorq scaling {ratio:.1f}x for 10x rows — superlinear?"
+
+
+# ===========================================================================
+# head_diff: must NOT read the whole frame on the lazy (parquet) backends.
+# 100x more rows should stay near-flat; a non-lazy regression scales ~100x.
+# ===========================================================================
+
+_LAZY_MAX = 15.0
+
+
+@needs_polars
+def test_head_diff_lazy_polars(data):
+    t, b = data["paths"][TINY], data["paths"][BIG]
+    small_t = _best_of(lambda: head_diff_polars(t, t), n=3)
+    big_t = _best_of(lambda: head_diff_polars(b, b), n=3)
+    ratio = _report("head_diff (polars,lazy)", TINY, small_t, BIG, big_t)
+    assert ratio < _LAZY_MAX, (
+        f"head_diff_polars is {ratio:.1f}x slower for 100x rows — lazy scan should keep this "
+        "near-flat; it may be reading the full frame instead of N rows + metadata.")
+
+
+@needs_xorq
+def test_head_diff_lazy_xorq(data):
+    t, b = data["paths"][TINY], data["paths"][BIG]
+    small_t = _best_of(lambda: head_diff_xorq(t, t), n=3)
+    big_t = _best_of(lambda: head_diff_xorq(b, b), n=3)
+    ratio = _report("head_diff (xorq,lazy)", TINY, small_t, BIG, big_t)
+    assert ratio < _LAZY_MAX, (
+        f"head_diff_xorq is {ratio:.1f}x slower for 100x rows — limit(n)+count should keep this "
+        "near-flat; it may be materialising the full frame.")
+
+
+def test_head_diff_pandas_independent_of_rows(data):
+    # pandas head_diff is on an in-memory frame; it only renders head(10) + len(),
+    # so it is O(1) in row count.
+    s, b = data["frames"][SMALL], data["frames"][BIG]
+    small_t = _best_of(lambda: head_diff(s, s), n=3)
+    big_t = _best_of(lambda: head_diff(b, b), n=3)
+    ratio = _report("head_diff (pandas)", SMALL, small_t, BIG, big_t)
+    assert ratio < _LAZY_MAX, f"head_diff (pandas) scales with rows ({ratio:.1f}x) — should be ~O(1)."
+
+
+# ===========================================================================
+# key_diff: xorq picks a real unique key -> stays linear and matches 1:1.
+# ===========================================================================
+
+
+@needs_xorq
+def test_key_diff_xorq_linear_with_unique_key(data):
+    t, s = data["paths"][TINY], data["paths"][SMALL]
+    big_res = key_diff_xorq(s, s)
+    # It must detect the unique 'id', not the low-card 'cat', so every row
+    # matches exactly once: matched == n, no cartesian blowup.
+    assert big_res is not None and big_res["matched"] == SMALL, (
+        f"key_diff_xorq matched={big_res and big_res['matched']} (expected {SMALL}); "
+        f"detected keys={big_res and big_res['keys']} — should be a unique key.")
+    small_t = _best_of(lambda: key_diff_xorq(t, t), n=2)
+    big_t = _best_of(lambda: key_diff_xorq(s, s), n=2)
+    ratio = _report("key_diff (xorq,unique)", TINY, small_t, SMALL, big_t)
+    assert ratio < _LINEAR_MAX, (
+        f"key_diff_xorq is {ratio:.1f}x for 10x rows — should be ~linear on a unique key.")
+
+
+# ===========================================================================
+# key_diff cartesian blowup (pandas / polars). _infer_keys selects LOW-
+# cardinality columns and the outer join is unguarded, so a single side of
+# size n produces ~n^2/k matched rows. A correct key would give matched == n.
+# These are xfail until the key inference is fixed (PR #872 review finding).
+# ===========================================================================
+
+_BLOWUP_N = 2_000  # kept small: the quadratic result must still build fast
+
+
+@pytest.mark.xfail(reason="_infer_keys picks low-cardinality 'cat' -> cartesian blowup (PR#872 review)",
+    strict=False)
+def test_key_diff_pandas_no_cartesian_blowup():
+    a, b = _gen(_BLOWUP_N, 0), _gen(_BLOWUP_N, 1)
+    res = key_diff(a, b)
+    matched = res["matched"] if res else None
+    print(f"\n[compare-perf] key_diff (pandas) n={_BLOWUP_N} matched={matched} keys={res and res['keys']}")
+    # A sound key gives one matched row per input row. Allow modest slack.
+    assert res is not None and matched <= 2 * _BLOWUP_N, (
+        f"key_diff matched={matched} for n={_BLOWUP_N} on keys={res and res['keys']} — "
+        "cartesian blowup from low-cardinality key inference.")
+
+
+@needs_polars
+@pytest.mark.xfail(reason="_infer_keys_polars picks low-cardinality keys -> cartesian blowup (PR#872 review)",
+    strict=False)
+def test_key_diff_polars_no_cartesian_blowup():
+    a, b = pl.from_pandas(_gen(_BLOWUP_N, 0)), pl.from_pandas(_gen(_BLOWUP_N, 1))
+    res = key_diff_polars(a, b)
+    matched = res["matched"] if res else None
+    print(f"\n[compare-perf] key_diff (polars) n={_BLOWUP_N} matched={matched} keys={res and res['keys']}")
+    assert res is not None and matched <= 2 * _BLOWUP_N, (
+        f"key_diff_polars matched={matched} for n={_BLOWUP_N} on keys={res and res['keys']} — "
+        "cartesian blowup from low-cardinality key inference.")

--- a/tests/unit/compare_perf_test.py
+++ b/tests/unit/compare_perf_test.py
@@ -11,12 +11,10 @@ What the ratios encode:
   - head_diff*   is lazy on the polars/xorq (parquet) backends: a 100x row
                  increase should barely move the clock, because only the
                  N-row preview (+ a metadata count) is read.
-  - key_diff_xorq detects a real unique key, so it stays ~linear and matches
-                 every row exactly once (matched == n).
-  - key_diff / key_diff_polars infer LOW-cardinality columns as "keys" and
-                 outer-join on them unguarded, so the join is many-to-many and
-                 the matched-row count grows ~O(n^2). Those two are xfail until
-                 the key inference is fixed (see PR #872 review).
+  - key_diff* (all backends) detect a real unique key, so each stays ~linear
+                 and matches every row exactly once (matched == n). The
+                 deterministic matched count guards against the cartesian
+                 blowup the old low-cardinality key heuristic produced.
 
 Run `pytest -s tests/unit/compare_perf_test.py` to see the timing table.
 """
@@ -212,36 +210,32 @@ def test_key_diff_xorq_linear_with_unique_key(data):
 
 
 # ===========================================================================
-# key_diff cartesian blowup (pandas / polars). _infer_keys selects LOW-
-# cardinality columns and the outer join is unguarded, so a single side of
-# size n produces ~n^2/k matched rows. A correct key would give matched == n.
-# These are xfail until the key inference is fixed (PR #872 review finding).
+# key_diff must NOT cartesian-blow-up (pandas / polars). The detector picks the
+# unique 'id', so matched == n (one row per input row). The earlier low-
+# cardinality heuristic picked 'cat' (10 distinct) and produced ~n^2/k matched
+# rows; the deterministic matched count is the regression guard.
 # ===========================================================================
 
-_BLOWUP_N = 2_000  # kept small: the quadratic result must still build fast
+_BLOWUP_N = 2_000  # quadratic blowup would build ~n^2/k rows here — kept small
 
 
-@pytest.mark.xfail(reason="_infer_keys picks low-cardinality 'cat' -> cartesian blowup (PR#872 review)",
-    strict=False)
 def test_key_diff_pandas_no_cartesian_blowup():
     a, b = _gen(_BLOWUP_N, 0), _gen(_BLOWUP_N, 1)
     res = key_diff(a, b)
     matched = res["matched"] if res else None
     print(f"\n[compare-perf] key_diff (pandas) n={_BLOWUP_N} matched={matched} keys={res and res['keys']}")
-    # A sound key gives one matched row per input row. Allow modest slack.
-    assert res is not None and matched <= 2 * _BLOWUP_N, (
+    # A sound key gives one matched row per input row.
+    assert res is not None and res["keys"] == ["id"] and matched == _BLOWUP_N, (
         f"key_diff matched={matched} for n={_BLOWUP_N} on keys={res and res['keys']} — "
-        "cartesian blowup from low-cardinality key inference.")
+        "expected matched==n on the unique 'id' (no cartesian blowup).")
 
 
 @needs_polars
-@pytest.mark.xfail(reason="_infer_keys_polars picks low-cardinality keys -> cartesian blowup (PR#872 review)",
-    strict=False)
 def test_key_diff_polars_no_cartesian_blowup():
     a, b = pl.from_pandas(_gen(_BLOWUP_N, 0)), pl.from_pandas(_gen(_BLOWUP_N, 1))
     res = key_diff_polars(a, b)
     matched = res["matched"] if res else None
     print(f"\n[compare-perf] key_diff (polars) n={_BLOWUP_N} matched={matched} keys={res and res['keys']}")
-    assert res is not None and matched <= 2 * _BLOWUP_N, (
+    assert res is not None and res["keys"] == ["id"] and matched == _BLOWUP_N, (
         f"key_diff_polars matched={matched} for n={_BLOWUP_N} on keys={res and res['keys']} — "
-        "cartesian blowup from low-cardinality key inference.")
+        "expected matched==n on the unique 'id' (no cartesian blowup).")

--- a/tests/unit/compare_test.py
+++ b/tests/unit/compare_test.py
@@ -165,6 +165,154 @@ def test_key_diff_xorq_uses_detected_pk(tmp_path):
     assert keyed["only_after"] == 0
 
 
+# ---------------------------------------------------------------------------
+# pandas / polars key detection — the same algorithm as the xorq backend, so
+# all three pick the same key (or decline) on the same data.
+# ---------------------------------------------------------------------------
+
+
+def _pk_frames():
+    n = 4_000
+    uniq = pd.DataFrame({"ride_id": [f"R{i:06d}" for i in range(n)],
+        "member_casual": (["member", "casual"] * (n // 2)),
+        "rideable_type": (["classic", "electric", "docked"] * (n // 3 + 1))[:n]})
+    lowcard = pd.DataFrame({"member_casual": (["member", "casual"] * (n // 2)),
+        "rideable_type": (["classic", "electric", "docked"] * (n // 3 + 1))[:n],
+        "duration": [i % 600 for i in range(n)]})
+    rows = [(s, d) for s in range(80) for d in range(50)]
+    comp = pd.DataFrame({"station_id": [r[0] for r in rows], "as_of_date": [f"2024-{r[1]:02d}" for r in rows],
+        "reading": [r[0] + r[1] for r in rows]})
+    return uniq, lowcard, comp
+
+
+def _detect(backend, df, **kw):
+    from buckaroo import compare as C
+    if backend == "pandas":
+        return C._detect_pk_pd(df, **kw)
+    pl = pytest.importorskip("polars")
+    return C._detect_pk_polars(pl.from_pandas(df), **kw)
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_detect_pk_contract(backend):
+    """Single unique col wins; low-cardinality declines (None); composite found —
+    matching the xorq _detect_pk tests above."""
+    uniq, lowcard, comp = _pk_frames()
+    assert _detect(backend, uniq) == ["ride_id"]
+    assert _detect(backend, lowcard) is None
+    assert _detect(backend, comp) == ["station_id", "as_of_date"]
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_detect_pk_approximate_and_max_group(backend):
+    n = 4_000
+    approx = pd.DataFrame({"k": list(range(n - 40)) + list(range(40)), "v": [i % 10 for i in range(n)]})
+    assert _detect(backend, approx, threshold=1.0) is None     # 40 dups -> not exact
+    assert _detect(backend, approx, threshold=0.98) == ["k"]   # but a usable near-key
+
+    skew = pd.DataFrame({"k": [f"K{i:06d}" for i in range(n - 200)] + ["DUP"] * 200})
+    assert _detect(backend, skew, threshold=0.95, max_group=50) is None       # one value covers 200 rows
+    assert _detect(backend, skew, threshold=0.95, max_group=1_000) == ["k"]   # within cap
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_key_diff_uses_detected_pk_or_stops(backend):
+    """key_diff joins on the detected unique key (1:1, no blowup); with only
+    low-cardinality columns it stops and returns None."""
+    from buckaroo import compare as C
+    n = 2_000
+    a = pd.DataFrame({"id": range(n), "cat": [i % 10 for i in range(n)], "val": list(range(n))})
+    b = a.copy()
+    b.loc[0, "val"] = 999
+    lowcard = pd.DataFrame({"cat": [i % 5 for i in range(n)], "grp": [i % 7 for i in range(n)]})
+    if backend == "pandas":
+        kd, wrap = C.key_diff, (lambda df: df)
+    else:
+        pl = pytest.importorskip("polars")
+        kd, wrap = C.key_diff_polars, (lambda df: pl.from_pandas(df))
+    keyed = kd(wrap(a), wrap(b))
+    assert keyed is not None and keyed["keys"] == ["id"]
+    assert keyed["matched"] == n and keyed["only_before"] == 0 and keyed["only_after"] == 0
+    assert kd(wrap(lowcard), wrap(lowcard)) is None  # no simple PK -> stop, do not explode
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars", "xorq"])
+def test_key_diff_membership_null_safe(backend, tmp_path):
+    """A genuine null in a matched row's shared column must not be miscounted as
+    a non-matching row (regression for the first-non-key-column null probe)."""
+    from buckaroo import compare as C
+    n = 100
+    a = pd.DataFrame({"id": [f"k{i}" for i in range(n)], "val": [None] + list(range(n - 1))})
+    b = a.copy()
+    b.loc[0, "val"] = 1000
+    if backend == "pandas":
+        res = C.key_diff(a, b)
+    elif backend == "polars":
+        pl = pytest.importorskip("polars")
+        res = C.key_diff_polars(pl.from_pandas(a), pl.from_pandas(b))
+    else:
+        pytest.importorskip("xorq")
+        ap, bp = tmp_path / "a.parquet", tmp_path / "b.parquet"
+        a.to_parquet(ap)
+        b.to_parquet(bp)
+        res = C.key_diff_xorq(ap, bp)
+    assert res["matched"] == n and res["only_before"] == 0 and res["only_after"] == 0
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_probe_diff_gates(backend):
+    """probe_diff says can_diff only when a simple primary key exists."""
+    from buckaroo.compare import probe_diff
+    n = 1_000
+    keyed = pd.DataFrame({"id": range(n), "cat": [i % 10 for i in range(n)]})
+    lowcard = pd.DataFrame({"cat": [i % 5 for i in range(n)], "grp": [i % 7 for i in range(n)]})
+    if backend == "polars":
+        pl = pytest.importorskip("polars")
+        keyed, lowcard = pl.from_pandas(keyed), pl.from_pandas(lowcard)
+    good = probe_diff(keyed, keyed)
+    assert good["can_diff"] is True and good["keys"] == ["id"]
+    bad = probe_diff(lowcard, lowcard)
+    assert bad["can_diff"] is False and bad["keys"] is None
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_stats_diff_distinct_excludes_null(backend):
+    """distinct excludes null on pandas and polars alike (matches xorq nunique)."""
+    from buckaroo import compare as C
+    df = pd.DataFrame({"g": ["x", "y", None, None, "x"], "v": [1, 2, 3, 4, 5]})
+    if backend == "pandas":
+        rows = C.stats_diff(df, df)
+    else:
+        pl = pytest.importorskip("polars")
+        rows = C.stats_diff_polars(pl.from_pandas(df), pl.from_pandas(df))
+    g = next(r for r in rows if r["name"] == "g")["before"]
+    assert g["distinct"] == 2 and g["nulls"] == 2
+
+
+def test_probe_diff_rejects_mismatched_backends():
+    """probe_diff raises a clear error (not an opaque crash) on mixed inputs."""
+    pl = pytest.importorskip("polars")
+    from buckaroo.compare import probe_diff
+    a = pd.DataFrame({"id": [1, 2, 3]})
+    with pytest.raises(ValueError, match="same backend"):
+        probe_diff(a, pl.from_pandas(a))
+
+
+@pytest.mark.parametrize("backend", ["pandas", "polars"])
+def test_key_diff_bad_explicit_key_raises(backend):
+    """An explicit key absent from a side is a clear error, not a silent None."""
+    from buckaroo import compare as C
+    a = pd.DataFrame({"id": [1, 2, 3], "v": [1, 2, 3]})
+    b = pd.DataFrame({"id": [1, 2, 3], "v": [1, 2, 9]})
+    if backend == "pandas":
+        kd, wrap = C.key_diff, (lambda d: d)
+    else:
+        pl = pytest.importorskip("polars")
+        kd, wrap = C.key_diff_polars, (lambda d: pl.from_pandas(d))
+    with pytest.raises(ValueError, match="not present in both"):
+        kd(wrap(a), wrap(b), keys=["nope"])
+
+
 def test_single_non_a_join_key():
     """col_join_dfs works with a join key that is not named 'a'."""
     df1 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})

--- a/tests/unit/compare_test.py
+++ b/tests/unit/compare_test.py
@@ -115,9 +115,10 @@ def test_xorq_diff_accepts_expressions(tmp_path):
 
     n = 1_500
     base = pd.DataFrame({"ride_id": [f"R{i:05d}" for i in range(n)], "minutes": [i % 60 for i in range(n)]})
-    a_path = _write_parquet(tmp_path / "a", base) if False else (tmp_path / "a.parquet")
+    a_path = tmp_path / "a.parquet"
     base.to_parquet(a_path)
-    b = base.copy(); b.loc[0, "minutes"] = 999
+    b = base.copy()
+    b.loc[0, "minutes"] = 999
     b_path = tmp_path / "b.parquet"
     b.to_parquet(b_path)
 
@@ -146,7 +147,6 @@ def test_key_diff_xorq_uses_detected_pk(tmp_path):
     n = 2_000
     base = pd.DataFrame({"ride_id": [f"R{i:06d}" for i in range(n)], "member_casual": (["member", "casual"] * (n // 2)),
         "minutes": [i % 60 for i in range(n)]})
-    a = _write_parquet(tmp_path / "a", base) if False else None
     (tmp_path / "a").mkdir()
     (tmp_path / "b").mkdir()
     a_path = tmp_path / "a" / "t.parquet"

--- a/tests/unit/compare_test.py
+++ b/tests/unit/compare_test.py
@@ -4,6 +4,167 @@ import pytest
 from buckaroo.compare import col_join_dfs
 
 
+# ---------------------------------------------------------------------------
+# _detect_pk_xorq — streaming primary-key detection over a parquet file
+# ---------------------------------------------------------------------------
+
+
+def _write_parquet(tmp_path, df):
+    pytest.importorskip("pyarrow")
+    path = tmp_path / "t.parquet"
+    df.to_parquet(path)
+    return path
+
+
+def test_detect_pk_single_column(tmp_path):
+    """A single unique column is found (and preferred over composites)."""
+    pytest.importorskip("xorq")
+    from buckaroo.compare import _detect_pk_xorq
+
+    n = 20_000
+    df = pd.DataFrame({"ride_id": [f"R{i:08d}" for i in range(n)], "member_casual": (["member", "casual"] * (n // 2)),
+        "rideable_type": (["classic", "electric", "docked"] * (n // 3 + 1))[:n]})
+    path = _write_parquet(tmp_path, df)
+    assert _detect_pk_xorq(path) == ["ride_id"]
+
+
+def test_detect_pk_none_for_low_cardinality(tmp_path):
+    """No near-unique key → None (the citibike cartesian-blowup guard).
+
+    Old _infer_keys would pick a low-cardinality categorical (e.g.
+    member_casual) and produce a many-to-many join.
+    """
+    pytest.importorskip("xorq")
+    from buckaroo.compare import _detect_pk_xorq
+
+    n = 20_000
+    df = pd.DataFrame({"member_casual": (["member", "casual"] * (n // 2)),
+        "rideable_type": (["classic", "electric", "docked"] * (n // 3 + 1))[:n],
+        "duration": [i % 600 for i in range(n)]})
+    path = _write_parquet(tmp_path, df)
+    assert _detect_pk_xorq(path) is None
+
+
+def test_detect_pk_composite(tmp_path):
+    """A key unique only in combination is found; neither column alone is."""
+    pytest.importorskip("xorq")
+    from buckaroo.compare import _detect_pk_xorq
+
+    # station_id x as_of_date: 100 stations over 50 dates, one row each.
+    rows = [(s, d) for s in range(100) for d in range(50)]
+    df = pd.DataFrame({"station_id": [r[0] for r in rows], "as_of_date": [f"2024-{r[1]:02d}" for r in rows],
+        "reading": [r[0] + r[1] for r in rows]})
+    path = _write_parquet(tmp_path, df)
+    assert _detect_pk_xorq(path) == ["station_id", "as_of_date"]
+
+
+def test_detect_pk_empty(tmp_path):
+    """An empty frame yields no key rather than crashing."""
+    pytest.importorskip("xorq")
+    from buckaroo.compare import _detect_pk_xorq
+
+    df = pd.DataFrame({"a": pd.Series([], dtype="int64"), "b": pd.Series([], dtype="str")})
+    path = _write_parquet(tmp_path, df)
+    assert _detect_pk_xorq(path) is None
+
+
+def test_detect_pk_approximate_tolerance(tmp_path):
+    """An approximate key (a few duplicates) is accepted below threshold 1.0."""
+    pytest.importorskip("xorq")
+    from buckaroo.compare import _detect_pk_xorq
+
+    # 10_000 rows, 100 keys duplicated once each → distinct 9_900, uniqueness 0.99.
+    # "v" is a low-cardinality filler so "k" is the only near-key candidate.
+    n = 10_000
+    ids = list(range(n - 100)) + list(range(100))
+    df = pd.DataFrame({"k": ids, "v": [i % 10 for i in range(n)]})
+    path = _write_parquet(tmp_path, df)
+
+    assert _detect_pk_xorq(path, threshold=1.0) is None        # not an exact PK
+    assert _detect_pk_xorq(path, threshold=0.98) == ["k"]      # but a usable near-key
+
+
+def test_detect_pk_max_group_guard(tmp_path):
+    """A high-uniqueness but skewed key is rejected when its biggest group is too large."""
+    pytest.importorskip("xorq")
+    from buckaroo.compare import _detect_pk_xorq, _rank_pk_xorq
+
+    # 10_000 rows: 9_500 unique values + one sentinel covering 500 rows.
+    n = 10_000
+    ids = [f"K{i:06d}" for i in range(n - 500)] + ["DUP"] * 500
+    df = pd.DataFrame({"k": ids})
+    path = _write_parquet(tmp_path, df)
+
+    # Uniqueness clears 0.95, but one value covers 500 rows → would blow up a join.
+    ranked = _rank_pk_xorq(path, threshold=0.95, max_group=None)
+    assert ranked["keys"] == ["k"] and ranked["max_group"] == 500
+
+    assert _detect_pk_xorq(path, threshold=0.95, max_group=100) is None      # guarded out
+    assert _detect_pk_xorq(path, threshold=0.95, max_group=1_000) == ["k"]   # within cap
+
+
+def test_xorq_diff_accepts_expressions(tmp_path):
+    """The xorq diff composes expr1 ⋈ expr2 — not just parquet paths.
+
+    Passing expressions (each of which could carry its own .cache() node) must
+    give the same result as passing the file paths.
+    """
+    pytest.importorskip("xorq")
+    import xorq.api as xo
+    from buckaroo.compare import key_diff_xorq, stats_diff_xorq, head_diff_xorq
+
+    n = 1_500
+    base = pd.DataFrame({"ride_id": [f"R{i:05d}" for i in range(n)], "minutes": [i % 60 for i in range(n)]})
+    a_path = _write_parquet(tmp_path / "a", base) if False else (tmp_path / "a.parquet")
+    base.to_parquet(a_path)
+    b = base.copy(); b.loc[0, "minutes"] = 999
+    b_path = tmp_path / "b.parquet"
+    b.to_parquet(b_path)
+
+    a_expr = xo.deferred_read_parquet(str(a_path))
+    b_expr = xo.deferred_read_parquet(str(b_path))
+
+    keyed = key_diff_xorq(a_expr, b_expr)
+    assert keyed["keys"] == ["ride_id"]
+    assert keyed["matched"] == n and keyed["only_before"] == 0 and keyed["only_after"] == 0
+    # same as via paths
+    assert key_diff_xorq(a_path, b_path)["matched"] == n
+    # stats / head also accept expressions
+    assert any(s["name"] == "minutes" for s in stats_diff_xorq(a_expr, b_expr))
+    assert head_diff_xorq(a_expr, b_expr)["a_total"] == n
+
+
+def test_key_diff_xorq_uses_detected_pk(tmp_path):
+    """key_diff_xorq joins on the detected PK, not a low-card categorical.
+
+    With a real unique key present, matched rows align 1:1 (no blowup);
+    with only low-card columns, it declines to join (returns None).
+    """
+    pytest.importorskip("xorq")
+    from buckaroo.compare import key_diff_xorq
+
+    n = 2_000
+    base = pd.DataFrame({"ride_id": [f"R{i:06d}" for i in range(n)], "member_casual": (["member", "casual"] * (n // 2)),
+        "minutes": [i % 60 for i in range(n)]})
+    a = _write_parquet(tmp_path / "a", base) if False else None
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    a_path = tmp_path / "a" / "t.parquet"
+    b_path = tmp_path / "b" / "t.parquet"
+    base.to_parquet(a_path)
+    b = base.copy()
+    b.loc[0, "minutes"] = 999  # one changed row
+    b.to_parquet(b_path)
+
+    keyed = key_diff_xorq(a_path, b_path)
+    assert keyed is not None
+    assert keyed["keys"] == ["ride_id"]
+    # 1:1 alignment — matched count equals row count, no cartesian explosion.
+    assert keyed["matched"] == n
+    assert keyed["only_before"] == 0
+    assert keyed["only_after"] == 0
+
+
 def test_single_non_a_join_key():
     """col_join_dfs works with a join key that is not named 'a'."""
     df1 = pd.DataFrame({"id": [1, 2, 3], "val": [10, 20, 30]})

--- a/tests/unit/skip_columns_test.py
+++ b/tests/unit/skip_columns_test.py
@@ -1,0 +1,61 @@
+"""skip_columns: stats supplied via init_sd must not be recomputed.
+
+A column whose summary stats are provided externally (e.g. reused from a
+source dataframe in a diff/comparison) should be skipped by the stat pipeline
+— it still appears in the output (with structural metadata) but no stat
+expressions are built/executed for it.  Same behaviour across backends.
+"""
+import pandas as pd
+import pytest
+
+from buckaroo.pluggable_analysis_framework.stat_pipeline import StatPipeline
+from buckaroo.customizations.pd_stats_v2 import PD_ANALYSIS_V2
+
+
+def test_pandas_skip_columns_not_computed():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    pipe = StatPipeline(PD_ANALYSIS_V2, unit_test=False)
+    sd, errs = pipe.process_df_v1_compat(df, skip_columns={"b"})
+    assert "a" in sd and "b" in sd            # both columns still present
+    assert "mean" in sd["a"]                  # a was computed
+    assert "mean" not in sd["b"]              # b was skipped
+    assert set(sd["b"]) <= {"orig_col_name", "rewritten_col_name"}
+
+
+def test_pandas_no_skip_is_unchanged():
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    pipe = StatPipeline(PD_ANALYSIS_V2, unit_test=False)
+    sd, _ = pipe.process_df_v1_compat(df)
+    assert "mean" in sd["a"] and "mean" in sd["b"]
+
+
+def test_pandas_shim_threads_skip_columns():
+    from buckaroo.pluggable_analysis_framework.df_stats_v2 import DfStatsV2
+    df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    stats = DfStatsV2(df, PD_ANALYSIS_V2, skip_columns={"b"})
+    assert "mean" in stats.sdf["a"] and "mean" not in stats.sdf["b"]
+
+
+def test_polars_shim_threads_skip_columns():
+    pl = pytest.importorskip("polars")
+    from buckaroo.pluggable_analysis_framework.df_stats_v2 import PlDfStatsV2
+    from buckaroo.customizations.pl_stats_v2 import PL_ANALYSIS_V2
+    df = pl.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    stats = PlDfStatsV2(df, PL_ANALYSIS_V2, skip_columns={"b"})
+    assert "mean" in stats.sdf["a"] and "mean" not in stats.sdf["b"]
+
+
+def test_xorq_skip_columns_not_computed(tmp_path):
+    xo = pytest.importorskip("xorq.api")
+    from buckaroo.pluggable_analysis_framework.xorq_stat_pipeline import XorqStatPipeline
+    from buckaroo.customizations.xorq_stats_v2 import XORQ_STATS_V2
+
+    p = tmp_path / "t.parquet"
+    pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]}).to_parquet(p)
+    expr = xo.deferred_read_parquet(str(p))
+
+    pipe = XorqStatPipeline(XORQ_STATS_V2)
+    sd, errs = pipe.process_table(expr, skip_columns={"b"})
+    assert "a" in sd and "b" in sd
+    assert "mean" in sd["a"]
+    assert "mean" not in sd["b"]

--- a/tests/unit/skip_columns_test.py
+++ b/tests/unit/skip_columns_test.py
@@ -59,3 +59,50 @@ def test_xorq_skip_columns_not_computed(tmp_path):
     assert "a" in sd and "b" in sd
     assert "mean" in sd["a"]
     assert "mean" not in sd["b"]
+
+
+# ---------------------------------------------------------------------------
+# Notebook widget constructors must forward skip_stat_columns to the dataflow
+# (it was only wired into CustomizableDataflow + the server /load handler, not
+# the widget classes a notebook user instantiates).
+# ---------------------------------------------------------------------------
+
+
+def _by_orig(sd, orig_name):
+    return next(v for v in sd.values() if v.get("orig_col_name") == orig_name)
+
+
+def test_buckaroo_widget_threads_skip_stat_columns():
+    from buckaroo import BuckarooWidget
+    df = pd.DataFrame({"alpha": [1, 2, 3, 4], "beta": [10, 20, 30, 40]})
+    sd = BuckarooWidget(df, skip_stat_columns=["beta"]).dataflow.merged_sd
+    assert "mean" in _by_orig(sd, "alpha")      # computed
+    assert "mean" not in _by_orig(sd, "beta")   # skipped
+
+
+def test_buckaroo_infinite_widget_threads_skip_stat_columns():
+    from buckaroo import BuckarooInfiniteWidget
+    df = pd.DataFrame({"alpha": [1, 2, 3, 4], "beta": [10, 20, 30, 40]})
+    sd = BuckarooInfiniteWidget(df, skip_stat_columns=["beta"]).dataflow.merged_sd
+    assert "mean" in _by_orig(sd, "alpha")
+    assert "mean" not in _by_orig(sd, "beta")
+
+
+def test_widget_skip_preserves_supplied_init_sd():
+    """The point of skipping: stats supplied via init_sd survive because the
+    column is not recomputed. Without skip the computed value overrides them."""
+    from buckaroo import BuckarooWidget
+    df = pd.DataFrame({"alpha": [1, 2, 3, 4], "beta": [10, 20, 30, 40]})  # real beta mean = 25
+    supplied = {"beta": {"mean": 999.0}}
+    assert _by_orig(BuckarooWidget(df, init_sd=supplied).dataflow.merged_sd, "beta")["mean"] == 25.0
+    assert _by_orig(BuckarooWidget(df, init_sd=supplied, skip_stat_columns=["beta"]).dataflow.merged_sd,
+                    "beta")["mean"] == 999.0
+
+
+def test_polars_widget_threads_skip_stat_columns():
+    pl = pytest.importorskip("polars")
+    from buckaroo.polars_buckaroo import PolarsBuckarooWidget
+    pdf = pl.DataFrame({"alpha": [1, 2, 3, 4], "beta": [10, 20, 30, 40]})
+    sd = PolarsBuckarooWidget(pdf, skip_stat_columns=["beta"]).dataflow.merged_sd
+    assert "mean" in _by_orig(sd, "alpha")
+    assert "mean" not in _by_orig(sd, "beta")


### PR DESCRIPTION
## Summary

Extends `compare.py` with per-column summary statistics and outer-join diffs across three backends, complementing the existing `col_join_dfs` API.

- **pandas** — vectorised: one `isnull` pass, one `nunique` pass, one `agg(['mean','min','max','sum'])` across all numeric columns at once. Previous approach called each aggregation per-column.
- **polars** — three `.select()` calls (null counts, distinct counts, numeric aggs); `head_diff_polars` reads only N rows via `pl.scan_parquet` lazy scan.
- **xorq** — one ibis aggregate expression covering every column, executed once per parquet file. Total row count + all null/distinct/numeric stats in a single DuckDB query; nothing larger than a scalar summary row is materialised.

## New public API

All backends follow the same output schema so callers can swap freely:

```python
# pandas (takes pd.DataFrame)
stats_diff(a, b) -> list[dict]
head_diff(a, b, n=10) -> dict
key_diff(a, b) -> dict | None

# polars (takes pl.DataFrame; head_diff takes Path)
stats_diff_polars(a, b) -> list[dict]
head_diff_polars(a_path, b_path, n=10) -> dict
key_diff_polars(a, b) -> dict | None

# xorq (takes Path to parquet)
stats_diff_xorq(a_path, b_path) -> list[dict]
head_diff_xorq(a_path, b_path, n=10) -> dict
key_diff_xorq(a_path, b_path) -> dict | None
```

`col_join_dfs` is unchanged.

## Test plan

- [x] Existing `tests/unit/compare_test.py` (12 tests) passes
- [ ] New tests live in pydata-app which consumes this via editable install; all 26 diff tests pass there

🤖 Generated with [Claude Code](https://claude.com/claude-code)