### PR TITLE
fix(server): guard xorq git-provenance capture against fork SIGSEGV (#885)

### DIFF
--- a/buckaroo/server/git_state_guard.py
+++ b/buckaroo/server/git_state_guard.py
@@ -1,0 +1,113 @@
+"""Crash-safe wrapper around xorq's git-provenance capture.
+
+xorq records git provenance during expression compilation by shelling out to
+``git rev-parse HEAD`` / ``git diff`` / ``git diff --cached``
+(``xorq.common.utils.logging_utils.get_git_state``, called from
+``xorq/ibis_yaml/compiler.py``). Those bare-name ``subprocess.check_output``
+calls ``fork()`` — CPython only takes the ``posix_spawn`` path when the
+executable has a directory component, which ``"git"`` lacks.
+
+The buckaroo server is a long-lived, multithreaded Tornado process. Forking
+from a multithreaded process on macOS leaves the child's address space in a
+partially-copied state (threads other than the forking one are gone, but any
+lock they held stays held forever); git can then die with ``SIGSEGV`` and
+``subprocess`` re-raises it as ``CalledProcessError(returncode=-11)``. That
+exception propagates out of the xorq build/load call behind ``/load_expr`` and
+turns a best-effort logging detail into a hard 500. See issue #885.
+
+The root-cause fix belongs in xorq, but buckaroo can protect itself by
+installing a wrapper that:
+
+1. spawns git **fork-free** via ``os.posix_spawn`` — a vfork-style spawn that
+   does not clone the parent's address space or threads, so the
+   fork-from-multithreaded hazard cannot fire by construction; and
+2. **degrades to placeholders on any failure** (signal death, missing git,
+   timeout) instead of raising.
+
+Each call captures fresh — no permanent cache — so successive loads record the
+repo state at the time rather than freezing the first capture.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import shutil
+import tempfile
+
+# Matches xorq's get_git_state command set (sub-commands; "git" prepended at spawn).
+_GIT_COMMANDS = (["rev-parse", "HEAD"], ["diff"], ["diff", "--cached"])
+
+
+def _run_git(args: list, timeout: float = 10.0) -> str:
+    """Run ``git <args>`` without forking, via ``os.posix_spawn``.
+
+    Resolves git on PATH at call time (posix_spawn does not search PATH).
+    Returns stripped stdout; raises on a missing git, signal death, or non-zero
+    exit — all of which ``_capture`` turns into placeholders.
+    """
+    git = shutil.which("git")
+    if git is None:
+        raise FileNotFoundError("git not found on PATH")
+    devnull = os.open(os.devnull, os.O_WRONLY)
+    try:
+        with tempfile.TemporaryFile() as out:
+            file_actions = [
+                (os.POSIX_SPAWN_DUP2, out.fileno(), 1),  # stdout -> temp file
+                (os.POSIX_SPAWN_DUP2, devnull, 2),       # stderr -> /dev/null
+            ]
+            pid = os.posix_spawn(git, [git, *args], os.environ, file_actions=file_actions)
+            _, status = os.waitpid(pid, 0)
+            if os.WIFSIGNALED(status):
+                raise RuntimeError(f"git {args} killed by signal {os.WTERMSIG(status)}")
+            if not (os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0):
+                raise RuntimeError(f"git {args} exited non-zero (status={status})")
+            out.seek(0)
+            return out.read().decode().strip()
+    finally:
+        os.close(devnull)
+
+
+def _format(triple: tuple, hash_diffs: bool) -> dict:
+    """Shape a (commit, diff, diff_cached) triple like xorq's get_git_state does."""
+    commit, diff, diff_cached = triple
+    state = {"commit": commit, "diff": diff, "diff_cached": diff_cached}
+    if hash_diffs:
+        for key in ("diff", "diff_cached"):
+            state[f"{key}_hash"] = hashlib.md5(state.pop(key).encode()).hexdigest()
+    return state
+
+
+def _capture() -> tuple:
+    """Run the git commands fork-free; ``("unknown", "", "")`` on any failure."""
+    try:
+        out = [_run_git(cmd) for cmd in _GIT_COMMANDS]
+        return (out[0], out[1], out[2])
+    except BaseException:
+        # RuntimeError (signal death like SIGSEGV / non-zero exit),
+        # FileNotFoundError, OSError — none of it may reach the caller.
+        return ("unknown", "", "")
+
+
+def _safe_get_git_state(hash_diffs: bool = False) -> dict:
+    if os.environ.get("BUCKAROO_DISABLE_GIT_STATE"):
+        return _format(("unknown", "", ""), hash_diffs)
+    return _format(_capture(), hash_diffs)
+
+
+_safe_get_git_state._buckaroo_guarded = True  # type: ignore[attr-defined]
+
+
+def install_git_state_guard() -> None:
+    """Idempotently replace ``logging_utils.get_git_state`` with the safe version.
+
+    Lazy xorq import so importing this module doesn't pull in xorq eagerly.
+    A no-op if xorq isn't installed.
+    """
+    try:
+        from xorq.common.utils import logging_utils as lu
+    except ImportError:
+        return
+
+    if getattr(lu.get_git_state, "_buckaroo_guarded", False):
+        return
+    lu.get_git_state = _safe_get_git_state

--- a/buckaroo/server/git_state_guard.py
+++ b/buckaroo/server/git_state_guard.py
@@ -22,7 +22,7 @@ installing a wrapper that:
    does not clone the parent's address space or threads, so the
    fork-from-multithreaded hazard cannot fire by construction; and
 2. **degrades to placeholders on any failure** (signal death, missing git,
-   timeout) instead of raising.
+   non-zero exit) instead of raising.
 
 Each call captures fresh — no permanent cache — so successive loads record the
 repo state at the time rather than freezing the first capture.
@@ -32,22 +32,22 @@ from __future__ import annotations
 import hashlib
 import os
 import shutil
+import subprocess
 import tempfile
 
 # Matches xorq's get_git_state command set (sub-commands; "git" prepended at spawn).
 _GIT_COMMANDS = (["rev-parse", "HEAD"], ["diff"], ["diff", "--cached"])
 
+# ``os.posix_spawn`` is POSIX-only. The fork-from-multithreaded SIGSEGV this
+# module guards against is likewise POSIX/macOS-specific; on Windows
+# ``subprocess`` uses ``CreateProcess`` (no fork), so there is no hazard and we
+# simply shell out the ordinary way — which also keeps real git provenance
+# instead of degrading every Windows capture to placeholders.
+_HAS_POSIX_SPAWN = hasattr(os, "posix_spawn")
 
-def _run_git(args: list, timeout: float = 10.0) -> str:
-    """Run ``git <args>`` without forking, via ``os.posix_spawn``.
 
-    Resolves git on PATH at call time (posix_spawn does not search PATH).
-    Returns stripped stdout; raises on a missing git, signal death, or non-zero
-    exit — all of which ``_capture`` turns into placeholders.
-    """
-    git = shutil.which("git")
-    if git is None:
-        raise FileNotFoundError("git not found on PATH")
+def _run_git_posix_spawn(git: str, args: list) -> str:
+    """Run ``git <args>`` without forking, via ``os.posix_spawn`` (vfork-style)."""
     devnull = os.open(os.devnull, os.O_WRONLY)
     try:
         with tempfile.TemporaryFile() as out:
@@ -67,6 +67,27 @@ def _run_git(args: list, timeout: float = 10.0) -> str:
         os.close(devnull)
 
 
+def _run_git(args: list) -> str:
+    """Run ``git <args>`` and return stripped stdout.
+
+    Resolves git on PATH at call time (posix_spawn does not search PATH). Uses
+    ``os.posix_spawn`` where available (the fork-free path that avoids the
+    macOS hazard) and falls back to ``subprocess`` on platforms without it
+    (Windows), where there is no fork hazard. Raises on a missing git, signal
+    death, or non-zero exit — all of which ``_capture`` turns into placeholders.
+    """
+    git = shutil.which("git")
+    if git is None:
+        raise FileNotFoundError("git not found on PATH")
+    if _HAS_POSIX_SPAWN:
+        return _run_git_posix_spawn(git, args)
+    completed = subprocess.run(
+        [git, *args], stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+    if completed.returncode != 0:
+        raise RuntimeError(f"git {args} exited non-zero (returncode={completed.returncode})")
+    return completed.stdout.decode().strip()
+
+
 def _format(triple: tuple, hash_diffs: bool) -> dict:
     """Shape a (commit, diff, diff_cached) triple like xorq's get_git_state does."""
     commit, diff, diff_cached = triple
@@ -82,9 +103,11 @@ def _capture() -> tuple:
     try:
         out = [_run_git(cmd) for cmd in _GIT_COMMANDS]
         return (out[0], out[1], out[2])
-    except BaseException:
-        # RuntimeError (signal death like SIGSEGV / non-zero exit),
-        # FileNotFoundError, OSError — none of it may reach the caller.
+    except Exception:
+        # RuntimeError (child signal death like SIGSEGV / non-zero exit),
+        # FileNotFoundError, OSError — none of it may reach the caller. Child
+        # signal death surfaces here as RuntimeError via WIFSIGNALED, not as a
+        # BaseException, so Exception is the right (and tightest) breadth.
         return ("unknown", "", "")
 
 

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -14,6 +14,7 @@ import logging
 import traceback
 from pathlib import Path
 
+from buckaroo.server.git_state_guard import install_git_state_guard
 from buckaroo.server.window import clamp_window
 from buckaroo.xorq_buckaroo import (
     NoCleaningConfXorq, XorqAutocleaning, XorqDataflow, XorqDfStatsV2,
@@ -21,6 +22,13 @@ from buckaroo.xorq_buckaroo import (
     window_to_parquet)
 
 log = logging.getLogger(__name__)
+
+# xorq captures git provenance by forking `git` from the compiler; from the
+# long-lived multithreaded Tornado server that fork can SIGSEGV on macOS and
+# fail /load_expr with a 500 (#885). Installing the guard here — the single
+# module the server imports to touch xorq — makes every xorq build/load path
+# the server drives dispatch git fork-free and degrade instead of crashing.
+install_git_state_guard()
 
 
 def _make_cache_storage(cache_storage_path):

--- a/tests/unit/server/test_git_state_guard.py
+++ b/tests/unit/server/test_git_state_guard.py
@@ -1,0 +1,184 @@
+"""Regression tests for the git-state guard against the *real* xorq stack (#885).
+
+xorq records git provenance by shelling out to `git rev-parse HEAD` /
+`git diff` / `git diff --cached` from `logging_utils.get_git_state`, called
+inline on the compile path (`xorq/ibis_yaml/compiler.py`). Those bare-name
+`subprocess` calls fork, and `fork()` from the long-lived, multithreaded
+buckaroo Tornado server on macOS can die with SIGSEGV — `subprocess` then
+re-raises `CalledProcessError(returncode=-11)`, which propagates out of the
+xorq call behind `/load_expr` and turns a logging detail into a hard 500.
+
+These tests exercise the real xorq `get_git_state` (the unedited library
+function) through buckaroo's guard:
+
+- `test_*_fork_free`   — git is dispatched via `os.posix_spawn`, never fork.
+- `test_*_reflects_*`  — provenance is fresh per call (no permanent cache).
+- `test_*_degrades_*`  — a signal-killed git degrades to placeholders.
+- `test_loading_surface_installs_guard` — importing the server's xorq surface
+  installs the guard, so the server is protected without an explicit call.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("xorq.common.utils.logging_utils")
+
+from buckaroo.server import git_state_guard as g  # noqa: E402
+
+
+def _git(*args: str, cwd: Path) -> None:
+    subprocess.run(
+        ["git", *args], cwd=cwd, check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+# The three commands xorq's get_git_state runs. A forked command never reaches
+# os.posix_spawn, so "all three were spawned" is exactly "none of them forked".
+_PROVENANCE_COMMANDS = (("rev-parse", "HEAD"), ("diff",), ("diff", "--cached"))
+
+
+def _provenance_spawns(seen: list) -> list:
+    """From recorded posix_spawn argvs, the git sub-commands that were spawned."""
+    out = []
+    for argv in seen:
+        if argv and "git" in os.path.basename(str(argv[0])):
+            out.append(tuple(str(a) for a in argv[1:]))
+    return out
+
+
+def _assert_provenance_fork_free(seen: list, context: str) -> None:
+    prov = _provenance_spawns(seen)
+    forked = [cmd for cmd in _PROVENANCE_COMMANDS if cmd not in prov]
+    assert not forked, (
+        f"{context}: git {forked} forked instead of using os.posix_spawn — the "
+        f"macOS fork-from-multithreaded hazard. posix_spawn'd git calls: {prov}")
+
+
+@pytest.fixture
+def guard_env(monkeypatch):
+    """Snapshot/restore the swapped `lu.get_git_state` so tests don't leak."""
+    from xorq.common.utils import logging_utils as lu
+    original = lu.get_git_state
+    monkeypatch.delenv("BUCKAROO_DISABLE_GIT_STATE", raising=False)
+    try:
+        yield lu, g
+    finally:
+        lu.get_git_state = original
+
+
+@pytest.fixture
+def spawn_spy(monkeypatch):
+    """Record every `os.posix_spawn` argv; pass-through to the real one."""
+    seen = []
+    real = os.posix_spawn
+
+    def spy(path, argv, env, **kwargs):
+        seen.append(list(argv))
+        return real(path, argv, env, **kwargs)
+
+    monkeypatch.setattr(os, "posix_spawn", spy)
+    return seen
+
+
+@pytest.fixture
+def temp_git_repo(tmp_path: Path, monkeypatch) -> Path:
+    """A throwaway real git repo with one commit; cwd points here."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git("init", "-q", cwd=repo)
+    _git("config", "user.email", "t@example.com", cwd=repo)
+    _git("config", "user.name", "tester", cwd=repo)
+    (repo / "a.txt").write_text("one\n")
+    _git("add", "a.txt", cwd=repo)
+    _git("commit", "-q", "-m", "init", cwd=repo)
+    monkeypatch.chdir(repo)
+    return repo
+
+
+@pytest.fixture
+def segfault_git_repo(tmp_path: Path, monkeypatch) -> Path:
+    """A dir that looks like a repo, with a `git` on PATH that dies via SIGSEGV.
+
+    Mirrors the observed crash (git killed by signal -> returncode -11).
+    """
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)  # makes xorq's _git_is_present() true
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    fake_git = bindir / "git"
+    fake_git.write_text("#!/bin/sh\nkill -SEGV $$\n")
+    fake_git.chmod(0o755)
+    monkeypatch.chdir(repo)
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+    return repo
+
+
+def test_installed_guard_dispatches_git_fork_free(guard_env, spawn_spy, temp_git_repo):
+    """The real xorq get_git_state, through the guard, must use posix_spawn."""
+    lu, _ = guard_env
+    g.install_git_state_guard()
+
+    state = lu.get_git_state(hash_diffs=False)
+
+    # Capture actually ran in this repo (not the degraded placeholder), so the
+    # assertion below is about a real provenance call, not a no-op.
+    assert state["commit"] != "unknown", state
+    _assert_provenance_fork_free(spawn_spy, "guarded get_git_state")
+
+
+def test_guard_reflects_repo_state_changes(guard_env, temp_git_repo):
+    """Provenance is fresh per call — no permanent one-shot cache."""
+    lu, _ = guard_env
+    g.install_git_state_guard()
+
+    first = lu.get_git_state(hash_diffs=False)
+    assert first["diff_cached"] == ""
+
+    (temp_git_repo / "new.txt").write_text("hello\n")
+    _git("add", "new.txt", cwd=temp_git_repo)
+
+    second = lu.get_git_state(hash_diffs=False)
+    assert second["diff_cached"] != first["diff_cached"], (
+        "guard returned stale, permanently-cached provenance; each call must "
+        "reflect current repo state")
+    assert "new.txt" in second["diff_cached"]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell shim / signals")
+def test_guard_degrades_on_signal_death(guard_env, segfault_git_repo):
+    """A signal-killed git degrades to placeholders, never raises."""
+    lu, _ = guard_env
+
+    # The unguarded form xorq ships raises on signal death (the original bug).
+    with pytest.raises(subprocess.CalledProcessError) as excinfo:
+        subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL)
+    assert excinfo.value.returncode == -11  # -SIGSEGV
+
+    # The guard contains it: placeholder provenance instead of a raise.
+    g.install_git_state_guard()
+    state = lu.get_git_state(hash_diffs=False)
+    assert state == {"commit": "unknown", "diff": "", "diff_cached": ""}
+
+
+def test_loading_surface_installs_guard(guard_env):
+    """Importing the server's xorq surface installs the guard, so the server's
+    /load_expr path is protected without callers wiring it up explicitly."""
+    lu, _ = guard_env
+    import importlib
+
+    # Reload logging_utils to restore xorq's unguarded function, then reload
+    # the surface module so its import-time install() runs against it again.
+    from xorq.common.utils import logging_utils
+    importlib.reload(logging_utils)
+    assert not getattr(logging_utils.get_git_state, "_buckaroo_guarded", False)
+
+    import buckaroo.server.xorq_loading as xl
+    importlib.reload(xl)
+
+    assert getattr(logging_utils.get_git_state, "_buckaroo_guarded", False), (
+        "importing buckaroo.server.xorq_loading must install the git-state guard")

--- a/tests/unit/server/test_git_state_guard.py
+++ b/tests/unit/server/test_git_state_guard.py
@@ -118,6 +118,9 @@ def segfault_git_repo(tmp_path: Path, monkeypatch) -> Path:
     return repo
 
 
+@pytest.mark.skipif(
+    not hasattr(os, "posix_spawn"),
+    reason="posix_spawn (the fork-free path) is POSIX-only; Windows has no fork hazard")
 def test_installed_guard_dispatches_git_fork_free(guard_env, spawn_spy, temp_git_repo):
     """The real xorq get_git_state, through the guard, must use posix_spawn."""
     lu, _ = guard_env
@@ -147,6 +150,22 @@ def test_guard_reflects_repo_state_changes(guard_env, temp_git_repo):
         "guard returned stale, permanently-cached provenance; each call must "
         "reflect current repo state")
     assert "new.txt" in second["diff_cached"]
+
+
+def test_guard_subprocess_fallback_captures_real_provenance(
+        guard_env, temp_git_repo, monkeypatch):
+    """On platforms without os.posix_spawn (Windows), the guard must fall back
+    to subprocess and still capture real provenance — not degrade every capture
+    to placeholders. Exercised on POSIX by forcing the no-posix_spawn branch."""
+    lu, _ = guard_env
+    monkeypatch.setattr(g, "_HAS_POSIX_SPAWN", False)
+    g.install_git_state_guard()
+
+    state = lu.get_git_state(hash_diffs=False)
+
+    assert state["commit"] != "unknown", (
+        "subprocess fallback degraded to placeholders instead of capturing "
+        "real git provenance")
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX shell shim / signals")


### PR DESCRIPTION
## Summary

`/load_expr` can fail with a 500 on macOS. xorq captures git provenance during expression compilation by shelling out to `git rev-parse HEAD` / `git diff` / `git diff --cached` (`xorq.common.utils.logging_utils.get_git_state`, called from `xorq/ibis_yaml/compiler.py`). Those bare-name `subprocess.check_output` calls `fork()` — CPython only takes the `posix_spawn` path when the executable has a directory component, which `"git"` lacks.

The buckaroo server is a long-lived, multithreaded Tornado process. Forking from a multithreaded process on macOS leaves the child's address space in a partially-copied state, so any lock held by a now-dead thread stays held forever; `git` dies with `SIGSEGV` and `subprocess` re-raises `CalledProcessError(returncode=-11)`. That propagates out of the xorq call behind `/load_expr` and turns a best-effort logging detail into a hard 500. See #885.

## Fix

The root cause is in xorq, but buckaroo can protect itself. `buckaroo/server/git_state_guard.py` installs a wrapper over `logging_utils.get_git_state` that:

1. spawns git **fork-free** via `os.posix_spawn` (vfork-style — does not clone the parent's threads/address space, so the hazard cannot fire by construction); and
2. **degrades to placeholders** (`{"commit": "unknown", "diff": "", "diff_cached": ""}`) on any failure — signal death, missing git, non-zero exit — instead of raising.

Each call captures fresh (no permanent cache). `BUCKAROO_DISABLE_GIT_STATE=1` skips capture entirely. The guard is installed at import of `buckaroo/server/xorq_loading.py` — the single module the server imports to touch xorq — so every xorq build/load path the server drives is protected without callers wiring it up.

This mirrors the approach already shipping in pydata-app (`pydata_xorq._git_state_guard`).

## Test plan

- [x] `tests/unit/server/test_git_state_guard.py` — 4 tests against the **real** xorq stack: fork-free dispatch, fresh-per-call provenance, degrade-on-SIGSEGV, and import-time install on the server surface
- [x] tests seen failing on CI before the fix commit (TDD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)