### PR TITLE
fix(xorq): materialize past CachedNode so diff stats don't re-run the join

### DIFF
--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -20,6 +20,7 @@ Optional dependency: install with ``buckaroo[xorq]``.
 from __future__ import annotations
 
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pandas as pd
@@ -185,14 +186,73 @@ class XorqStatPipeline:
         if not any(not _is_batch_func(sf) for sf in self.ordered_stat_funcs):
             return table, None
         name = f"__buckaroo_histo_mat_{uuid.uuid4().hex[:12]}"
-        try:
-            # Pass the ibis expression directly to create_table — xorq
-            # materializes it in DataFusion without round-tripping through
-            # pandas (~3-4× cheaper than execute() + create_table(df)).
-            new_table = underlying.create_table(name, table, overwrite=True)
-        except Exception:
+        new_table = self._create_base_table(underlying, name, table)
+        if new_table is None:
             return table, None
         return new_table, (underlying, name)
+
+    def _create_base_table(self, underlying, name, table):
+        """Land ``table`` as a base table on ``underlying``, or None on failure.
+
+        Prefers the in-engine ``create_table(expr)`` path, which materialises
+        in DataFusion without a pandas round-trip (~3-4× cheaper than
+        ``execute()`` + ``create_table(df)``). That path compiles the
+        expression to SQL, so an op with no translation rule — notably
+        ``CachedNode`` from ``expr.cache()`` (the shape every catalog-diff
+        comparison carries) — makes it raise. Two fallbacks recover that:
+
+          1. Rewrite each ``CachedNode`` to a read of its on-disk cache file
+             and retry in-engine — no transport, the join still runs once.
+          2. Last resort, ``execute()`` to pandas and register the result.
+             Correct for any expression but pays a full transport.
+        """
+        try:
+            return underlying.create_table(name, table, overwrite=True)
+        except Exception:
+            pass
+        rewritten = self._resolve_cached_nodes(table, underlying)
+        if rewritten is not None:
+            try:
+                return underlying.create_table(name, rewritten, overwrite=True)
+            except Exception:
+                pass
+        try:
+            return underlying.create_table(name, table.execute(), overwrite=True)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _resolve_cached_nodes(table, underlying):
+        """Rewrite ``CachedNode``s in ``table`` to reads of their cache files.
+
+        ``CachedNode`` has no SQL translation, but its cached result is a
+        parquet on disk once materialised. Swapping each node for a
+        ``read_parquet`` of that file yields an equivalent expression the SQL
+        compiler can handle, keeping materialisation in-engine. Returns the
+        rewritten expression, or None if there are no cached nodes or any
+        cache file is missing (so the caller falls back to ``execute()``,
+        which populates the cache).
+        """
+        try:
+            from xorq.expr.relations import CachedNode
+        except Exception:
+            return None
+        nodes = list(table.op().find(CachedNode))
+        if not nodes:
+            return None
+        subs = {}
+        for cn in nodes:
+            try:
+                path = cn.cache.storage.get_path(cn.cache.calc_key(cn.parent))
+                if not Path(path).exists():
+                    return None
+                subs[cn] = underlying.read_parquet(str(path)).op()
+            except Exception:
+                return None
+        try:
+            return table.op().replace(subs).to_expr()
+        except Exception:
+            return None
 
     def unit_test(self) -> Tuple[bool, List[StatError]]:
         """Run pipeline against PERVERSE_DF wrapped as a xorq memtable.

--- a/scripts/perf/perf_diff_cachednode.py
+++ b/scripts/perf/perf_diff_cachednode.py
@@ -1,0 +1,78 @@
+"""Benchmark the stat pipeline over a diff-shaped (cache + join) expression.
+
+Catalog-diff comparisons feed the pipeline an ``a.cache() ⋈ b.cache()``
+expression. The ``cache()`` wrapper inserts a ``CachedNode``, which has no
+SQL translation — so ``_maybe_materialize``'s ``create_table(expr)`` path
+raises and (before the CachedNode fallback) silently no-ops. Every
+per-column histogram then re-runs the whole outer join.
+
+This measures the pipeline with materialization defeated (what the bare
+per-column path costs) against materialization succeeding via the fallback.
+
+Usage:
+    .venv/bin/python scripts/perf/perf_diff_cachednode.py
+"""
+from __future__ import annotations
+
+import tempfile
+import time
+import warnings
+
+warnings.filterwarnings("ignore")
+
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+
+import xorq.api as xo  # noqa: E402
+
+from buckaroo.customizations.xorq_stats_v2 import XORQ_STATS_V2  # noqa: E402
+from buckaroo.pluggable_analysis_framework.xorq_stat_pipeline import (  # noqa: E402
+    XorqStatPipeline)
+
+
+def make_diff_expr(n_rows, n_cols, base_path):
+    """An ``a.cache() ⋈ b.cache()`` comparison over n_rows × n_cols."""
+    rng = np.random.default_rng(0)
+    cols = {"group_pk": np.arange(n_rows)}
+    for i in range(n_cols):
+        cols[f"m{i}"] = rng.normal(100, 15, n_rows)
+    df = pd.DataFrame(cols)
+    cache = xo.ParquetSnapshotCache.from_kwargs(
+        source=xo.connect(), base_path=base_path)
+    con = xo.connect()
+    a = con.create_table("a", df).cache(cache=cache)
+    shifted = df.assign(**{f"m{i}": df[f"m{i}"] * 1.05 for i in range(n_cols)})
+    b = (con.create_table("b", shifted)
+         .cache(cache=cache)
+         .rename({f"m{i}_v2": f"m{i}" for i in range(n_cols)}))
+    joined = a.join(b, "group_pk")
+    return joined.select(
+        "group_pk",
+        *[c for i in range(n_cols) for c in (f"m{i}", f"m{i}_v2")])
+
+
+def time_pipeline(expr, materialize):
+    pipe = XorqStatPipeline(list(XORQ_STATS_V2), unit_test=False)
+    t0 = time.perf_counter()
+    if materialize:
+        pipe.process_table(expr)            # fix: materialize once, scan base table
+    else:
+        pipe._process_table_impl(expr)      # bare path: re-run the join per histogram
+    return time.perf_counter() - t0
+
+
+def main():
+    print(f"{'rows':>9} {'cols':>4} | {'no-mat':>10} | {'fix':>10} | speedup")
+    for n_rows, n_cols in [(1_000, 6), (100_000, 6), (1_000_000, 6), (100_000, 24)]:
+        base = tempfile.mkdtemp()
+        make_diff_expr(n_rows, n_cols, base).execute()  # warm on-disk caches
+        before = min(time_pipeline(make_diff_expr(n_rows, n_cols, base), False)
+                     for _ in range(2))
+        after = min(time_pipeline(make_diff_expr(n_rows, n_cols, base), True)
+                    for _ in range(2))
+        print(f"{n_rows:>9} {n_cols:>4} | {before * 1000:>7.0f} ms | "
+              f"{after * 1000:>7.0f} ms | {before / after:>4.1f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -500,3 +500,55 @@ class TestMaterialization:
         leaked = [n for n in (set(con.list_tables()) - before)
                   if n.startswith("__buckaroo_histo_mat")]
         assert leaked == [], f"materialized table not cleaned up: {leaked}"
+
+    @staticmethod
+    def _cached_join_expr(tmp_path):
+        """A cache()+join expression — the shape every catalog-diff
+        comparison carries. The cache() wrapper inserts a CachedNode, which
+        has no SQL translation, so the plain create_table(expr) materialize
+        path raises on it."""
+        cache = xo.ParquetSnapshotCache.from_kwargs(
+            source=xo.connect(), base_path=str(tmp_path))
+        df = pd.DataFrame({"k": range(20), "v": [float(i % 7) for i in range(20)]})
+        con = xo.connect()
+        a = con.create_table("cn_a", df).cache(cache=cache)
+        b = (con.create_table("cn_b", df.assign(v=df.v + 1))
+             .cache(cache=cache).rename({"v_v2": "v"}))
+        expr = a.join(b, "k").select("k", "v", "v_v2")
+        expr.execute()  # populate the on-disk cache files
+        return expr
+
+    def test_materializes_past_cached_node(self, tmp_path):
+        """A CachedNode-bearing expr (the diff shape) still materializes:
+        create_table(expr) can't compile CachedNode, so the fallback rewrites
+        each node to a read of its cache file and retries in-engine. Without
+        the fallback, materialization silently no-ops and every per-column
+        histogram re-runs the join."""
+        from xorq.expr.relations import CachedNode
+        from xorq.vendor.ibis.expr import operations as ops
+
+        expr = self._cached_join_expr(tmp_path)
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        materialized, cleanup = pipeline._maybe_materialize(expr)
+        try:
+            assert cleanup is not None, "materialization did not fire for CachedNode expr"
+            assert isinstance(materialized.op(), (ops.DatabaseTable, ops.InMemoryTable))
+            # In-engine path: the CachedNode is rewritten to a parquet read,
+            # not pulled through pandas.
+            assert not list(materialized.op().find(CachedNode))
+        finally:
+            if cleanup is not None:
+                cleanup[0].drop_table(cleanup[1])
+
+    def test_cached_node_stats_match_unmaterialized(self, tmp_path):
+        """Stats over the materialized base table equal stats over the raw
+        CachedNode expr — materialization is a perf optimization, not a
+        semantic change."""
+        expr = self._cached_join_expr(tmp_path)
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        raw, _ = pipeline._process_table_impl(expr)
+        mat, _ = pipeline.process_table(expr)
+        for col in raw:
+            for key in ("min", "max", "mean", "null_count", "distinct_count"):
+                assert raw[col].get(key) == mat[col].get(key), (col, key)
+            assert len(raw[col].get("histogram", [])) == len(mat[col].get("histogram", []))


### PR DESCRIPTION
## Summary

`_maybe_materialize` lands a lazy expression as a base table once, so the per-column histogram queries scan that table instead of re-executing the upstream chain N times. It materializes via `create_table(name, expr)`, which compiles the expression to SQL.

Catalog-diff comparisons feed the pipeline an `a.cache() ⋈ b.cache()` expression. `cache()` inserts a `CachedNode`, which has **no SQL translation rule** — so `create_table(expr)` raises, the `except Exception` swallows it, and materialization silently no-ops. Every per-column histogram then re-runs the whole outer join (and re-resolves both sides' caches). This is invisible on small data and dominates on large diffs.

## Fix

`_create_base_table` keeps the fast in-engine path and adds two fallbacks:

1. **Rewrite `CachedNode` → `read_parquet` of its on-disk cache file**, then retry `create_table` in-engine. No transport; the join still runs once. This is the path the diff shape takes.
2. **`execute()` + `create_table(df)`** as a last resort — correct for any expression, but pays a full pandas round-trip.

`_resolve_cached_nodes` returns `None` (→ fall back to `execute()`, which populates the cache) when a cache file is missing, so a cold cache is handled too.

## Performance

`scripts/perf/perf_diff_cachednode.py`, stat pipeline over an `a.cache() ⋈ b.cache()` diff expression:

```
     rows cols |     no-mat |        fix | speedup
     1000    6 |     300 ms |      96 ms |   3.1x
   100000    6 |     363 ms |     135 ms |   2.7x
  1000000    6 |     701 ms |     390 ms |   1.8x
   100000   24 |    1845 ms |     696 ms |   2.7x
```

## Tests

- `test_materializes_past_cached_node` — materialization fires for the diff shape and lands an in-engine base table with the `CachedNode` rewritten away (not pulled through pandas). Fails before the fix.
- `test_cached_node_stats_match_unmaterialized` — materialized stats are identical to the unmaterialized path.

Existing `TestMaterialization` cases (base-table skip, temp-table cleanup) and the rest of `test_xorq_stats_v2.py` (38 total) pass; full unit suite green (1101 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)