### PR TITLE
feat(xorq): emit histogram_bins stat for color_map gradient support

### DIFF
--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -283,6 +283,30 @@ def histogram(expr: XorqExpr, execute: XorqExecute, orig_col_name: str, is_numer
     return _categorical_histogram(execute, expr, orig_col_name)
 
 
+@stat(default=[])
+def histogram_bins(is_numeric: bool, is_bool: bool, distinct_count: int, min: float, max: float) -> list:
+    """Evenly-spaced numeric bin edges consumed by the JS ``color_map`` styler.
+
+    Returns 11 edges (10 equal-width bins) spanning [min, max] — the same
+    10-bucket layout used by ``_numeric_histogram``.  Pure computation: only
+    depends on ``min`` / ``max`` from the batch aggregate so no extra query
+    is needed.
+
+    The JS ``color_map`` rule reads ``histogram_stats[col].histogram_bins``
+    to map cell values onto a colour gradient (e.g. DIVERGING_RED_WHITE_BLUE).
+    An empty list causes that rule to fall back to ``inherit``, so non-numeric,
+    boolean, low-cardinality, and degenerate columns are safely skipped.
+    """
+    if not is_numeric or is_bool or distinct_count <= 5:
+        return []
+    if min is None or max is None:
+        return []
+    if min == max:
+        return []
+    width = (max - min) / 10
+    return [min + i * width for i in range(11)]
+
+
 # ============================================================
 # Convenience list — drop into XorqStatPipeline(XORQ_STATS_V2)
 # ============================================================
@@ -295,4 +319,4 @@ def histogram(expr: XorqExpr, execute: XorqExecute, orig_col_name: str, is_numer
 # ``PL_ANALYSIS_V2``) for those pipelines.
 
 XORQ_STATS_V2 = [typing_stats, _type, null_count, min, max, distinct_count, mean, std, median,
-    non_null_count, nan_per, distinct_per, histogram]
+    non_null_count, nan_per, distinct_per, histogram, histogram_bins]

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -238,6 +238,42 @@ class TestHistogram:
         total_pop = sum(b["cat_pop"] for b in h)
         assert abs(total_pop - 1.0) < 1e-6
 
+    def test_histogram_bins_numeric(self):
+        """histogram_bins must be 11 evenly-spaced edges for numeric columns."""
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(_make_table())
+        assert errors == []
+        bins = stats["ints"]["histogram_bins"]
+        assert isinstance(bins, list)
+        assert len(bins) == 11
+        assert bins[0] == stats["ints"]["min"]
+        assert abs(bins[-1] - stats["ints"]["max"]) < 1e-9
+        # evenly spaced
+        widths = [bins[i + 1] - bins[i] for i in range(10)]
+        assert all(abs(w - widths[0]) < 1e-9 for w in widths)
+
+    def test_histogram_bins_non_numeric_empty(self):
+        """histogram_bins must be empty for string columns."""
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(_make_table())
+        assert errors == []
+        assert stats["strs"]["histogram_bins"] == []
+
+    def test_histogram_bins_bool_empty(self):
+        """histogram_bins must be empty for boolean columns."""
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(_make_table())
+        assert errors == []
+        assert stats["bools"]["histogram_bins"] == []
+
+    def test_histogram_bins_constant_empty(self):
+        """Constant numeric column (min == max) must return empty histogram_bins."""
+        table = xo.memtable(pd.DataFrame({"const": [7, 7, 7, 7, 7, 7, 7]}))
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(table)
+        assert errors == []
+        assert stats["const"]["histogram_bins"] == []
+
 
 # ============================================================
 # Structured error capture — silent excepts must be gone

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -274,6 +274,14 @@ class TestHistogram:
         assert errors == []
         assert stats["const"]["histogram_bins"] == []
 
+    def test_histogram_bins_low_cardinality_empty(self):
+        """Numeric column with ≤ 5 distinct values must return empty histogram_bins."""
+        table = xo.memtable(pd.DataFrame({"few": [1, 2, 3, 4, 5, 1, 2, 3]}))
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(table)
+        assert errors == []
+        assert stats["few"]["histogram_bins"] == []
+
 
 # ============================================================
 # Structured error capture — silent excepts must be gone


### PR DESCRIPTION
## Summary

The xorq stat pipeline emitted `histogram` (a list of `{name, cat_pop}` display buckets) but never `histogram_bins` (numeric bin edges). The JS `color_map` styler reads `histogram_stats[col].histogram_bins` — built by `extractSDFT` scanning for a row keyed `"histogram_bins"` in the stats payload — so `histogram_stats` was always empty in the xorq server path and `color_map` fell back to `inherit` on every cell.

## Fix

Add a `histogram_bins` stat to `xorq_stats_v2.py`. It is a pure computed stat — no extra query — that derives 11 evenly-spaced edges from `min` and `max` already in the batch accumulator:

```python
width = (max - min) / 10
return [min + i * width for i in range(11)]
```

This gives the 10-bin layout that matches `_numeric_histogram`, so the JS color gradient and the histogram bars cover the same range. Non-numeric, boolean, low-cardinality (≤ 5 distinct), and degenerate (min == max or either None) columns return `[]`, causing `color_map` to fall back to `inherit` safely.

Add `histogram_bins` to `XORQ_STATS_V2`.

## Tests

- `test_histogram_bins_numeric` — 11 evenly-spaced edges, first == min, last == max, uniform width.
- `test_histogram_bins_non_numeric_empty` — string columns return `[]`.
- `test_histogram_bins_bool_empty` — boolean columns return `[]`.
- `test_histogram_bins_constant_empty` — constant column (min == max) returns `[]`.

All four tests fail before the fix commit; all 42 tests in `test_xorq_stats_v2.py` pass after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)