### PR TITLE
feat(js): add "fitContent" layout mode (self-sizing widget box)

### DIFF
--- a/packages/buckaroo-js-core/pw-tests/fitcontent-height.spec.ts
+++ b/packages/buckaroo-js-core/pw-tests/fitcontent-height.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Playwright test for the `layoutType: "fitContent"` height mode.
+ *
+ * The FitContentHeight story mounts the widget (5 rows) in a 600px container.
+ * In fitContent mode the widget sizes its own box to its content, so:
+ *   1. The widget root (.buckaroo-widget) is far shorter than the 600px host.
+ *   2. There is no gap between the bottom of the table and the bottom of the
+ *      widget (the widget ends flush with its content).
+ */
+import { test, expect } from "@playwright/test";
+import { waitForCells } from "./ag-pw-utils";
+
+const STORY_URL =
+  "http://localhost:6006/iframe.html?viewMode=story&id=buckaroo-fitcontentheight--primary&globals=&args=";
+
+const CONTAINER_HEIGHT = 600;
+
+test.describe("fitContent layout mode", () => {
+  test("widget sizes to its content, not the 600px host container", async ({ page }) => {
+    await page.goto(STORY_URL);
+    await waitForCells(page);
+
+    const dataGrid = page.locator(".df-viewer");
+    await expect
+      .poll(async () => (await dataGrid.textContent())?.includes("Alice"), { timeout: 10_000 })
+      .toBe(true);
+
+    // 1. The widget root collapsed well under the 600px container height.
+    await expect
+      .poll(
+        async () => {
+          const box = await page.locator(".buckaroo-widget").boundingBox();
+          return box ? Math.round(box.height) : CONTAINER_HEIGHT;
+        },
+        { timeout: 10_000, message: "Expected the widget to shrink below the 600px container" }
+      )
+      .toBeLessThan(CONTAINER_HEIGHT - 150);
+
+    // 2. No gap: the widget root ends flush with its content (.orig-df).
+    const gap = await page.evaluate(() => {
+      const root = document.querySelector(".buckaroo-widget");
+      const content = document.querySelector(".buckaroo-widget .orig-df");
+      if (!root || !content) return 9999;
+      return Math.round(root.getBoundingClientRect().bottom - content.getBoundingClientRect().bottom);
+    });
+    expect(gap).toBeLessThanOrEqual(8);
+  });
+});

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -14,7 +14,7 @@ import {
     getDs,
     IDisplayArgs,
 } from "./DFViewerParts/gridUtils";
-import { stampLayoutType } from "./DFViewerParts/displayArgsUtils";
+import { stampLayoutType, isFitContentLayout } from "./DFViewerParts/displayArgsUtils";
 import { DatasourceOrRaw, DFViewerInfinite } from "./DFViewerParts/DFViewerInfinite";
 import { IDatasource, IGetRowsParams } from "ag-grid-community";
 import { KeyAwareSmartRowCache, PayloadArgs, PayloadResponse, RequestFN } from "./DFViewerParts/SmartRowCache";
@@ -218,6 +218,7 @@ export function BuckarooInfiniteWidget({
         );
 
         const cDisp = effectiveDisplayArgs[buckaroo_state.df_display];
+        const fitContent = isFitContentLayout(effectiveDisplayArgs);
 
         const [data_wrapper, summaryStatsData] = useMemo(
             () => [
@@ -323,7 +324,7 @@ export function BuckarooInfiniteWidget({
 
         return (
             <div className="dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget"
-             style={{ width: "100%", height: "100%" }}>
+             style={{ width: "100%", height: fitContent ? "auto" : "100%" }}>
                 <div
                     className="orig-df flex flex-row"
                     style={{
@@ -403,6 +404,7 @@ export function DFViewerInfiniteDS({
         );
 
         const cDisp = effectiveDisplayArgs["main"];
+        const fitContent = isFitContentLayout(effectiveDisplayArgs);
 
         const [data_wrapper, summaryStatsData] = useMemo(
             () => [
@@ -433,7 +435,7 @@ export function DFViewerInfiniteDS({
         
         return (
             <div className="dcf-root flex flex-col buckaroo-widget buckaroo-infinite-widget"
-             style={{ width: "100%", height: "100%" }}>
+             style={{ width: "100%", height: fitContent ? "auto" : "100%" }}>
                 <div
                     className="orig-df flex flex-row"
                     style={{

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -222,7 +222,11 @@ export type ComponentConfig = {
     height_fraction?: number;
     // temporary debugging props
     dfvHeight?: number;
-    layoutType?: "autoHeight" | "normal";
+    // "autoHeight": grow to fit all rows (no scroll). "normal": fixed dfvHeight
+    // viewport with scroll. "fitContent": auto-detect between those AND size the
+    // widget's own outer box to its content, so the host container doesn't need
+    // to match the viewport height (removes the gap below short tables).
+    layoutType?: "autoHeight" | "normal" | "fitContent";
     shortMode?: boolean;
     selectionBackground?: string;
     className?: string;

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/displayArgsUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/displayArgsUtils.ts
@@ -1,5 +1,12 @@
 import type { IDisplayArgs } from "./gridUtils";
 
+// True when the (effective) "main" display args request the "fitContent" layout.
+// In that mode the widget's outer wrappers size to their content instead of
+// filling the host container, so the host doesn't have to match the viewport.
+export function isFitContentLayout(args: Record<string, IDisplayArgs>): boolean {
+    return args?.main?.df_viewer_config?.component_config?.layoutType === "fitContent";
+}
+
 // When autoHeight is undefined the server value is left intact.
 // true → "autoHeight", false → "normal" (overrides server).
 export function stampLayoutType(

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -394,6 +394,26 @@ describe("testing utility functions in gridUtils ", () => {
       it("does not throw without an explicit dfvHeight", () => {
         expect(() => getHeightStyle2(5000, 0, { layoutType: "fitContent" })).not.toThrow();
       });
+
+      // dfvHeight is the cap: the box grows to fit content up to dfvHeight, then
+      // switches to a fixed-height, virtualized, scrolling viewport. With a 400px
+      // cap (~16 rows at the default 21px row height) a small table fits and a
+      // large one scrolls.
+      it("grows to content (capped, no scroll) when it fits under dfvHeight", () => {
+        const result = getHeightStyle2(5, 0, { layoutType: "fitContent", dfvHeight: 400 });
+        expect(result.domLayout).toBe("autoHeight");
+        expect(result.classMode).toBe("short-mode");
+        // shortDivStyle caps the auto-grown box at dfvHeight.
+        expect(result.applicableStyle.maxHeight).toBe(400);
+      });
+
+      it("caps at dfvHeight and scrolls when content exceeds it", () => {
+        const result = getHeightStyle2(100, 0, { layoutType: "fitContent", dfvHeight: 400 });
+        expect(result.domLayout).toBe("normal");
+        expect(result.classMode).toBe("regular-mode");
+        // regularDivStyle pins the viewport at dfvHeight; rows beyond it scroll.
+        expect(result.applicableStyle.height).toBe(400);
+      });
     });
   });
 

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.test.ts
@@ -365,6 +365,36 @@ describe("testing utility functions in gridUtils ", () => {
         getHeightStyle2(500, 0, {})
       ).not.toThrow();
     });
+
+    describe("fitContent layout", () => {
+      // fitContent drives the grid exactly like auto-detect (autoHeight when the
+      // rows fit, normal + scroll when they don't); the outer box is sized to
+      // content by the widget wrappers. It must never reach AG Grid as a literal
+      // "fitContent" domLayout.
+      it("uses autoHeight + short-mode when the rows fit", () => {
+        const result = getHeightStyle2(5, 0, { layoutType: "fitContent" });
+        expect(result.domLayout).toBe("autoHeight");
+        expect(result.classMode).toBe("short-mode");
+      });
+
+      it("falls back to normal + scroll when the rows don't fit", () => {
+        const result = getHeightStyle2(5000, 0, { layoutType: "fitContent" });
+        expect(result.domLayout).toBe("normal");
+        expect(result.classMode).toBe("regular-mode");
+      });
+
+      it("never emits 'fitContent' as a domLayout", () => {
+        for (const rows of [1, 5, 50, 5000]) {
+          expect(getHeightStyle2(rows, 0, { layoutType: "fitContent" }).domLayout).not.toBe(
+            "fitContent"
+          );
+        }
+      });
+
+      it("does not throw without an explicit dfvHeight", () => {
+        expect(() => getHeightStyle2(5000, 0, { layoutType: "fitContent" })).not.toThrow();
+      });
+    });
   });
 
   describe("getAutoSize", () => {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -541,7 +541,8 @@ export const heightStyle = (hArgs: HeightStyleArgs): HeightStyleI => {
             maxRowsWithoutScrolling
         };
     }
-    const domLayout: DomLayoutType = compC?.layoutType || (shortMode ? "autoHeight" : "normal");
+    // NOTE: "fitContent" is not handled yet — see the following commit.
+    const domLayout: DomLayoutType = (compC?.layoutType as DomLayoutType) || (shortMode ? "autoHeight" : "normal");
     if (compC?.layoutType === "normal" && !compC?.dfvHeight && !compC?.height_fraction) {
         throw new Error(
             'Buckaroo: layoutType: "normal" requires an explicit height. ' +

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/gridUtils.ts
@@ -541,8 +541,14 @@ export const heightStyle = (hArgs: HeightStyleArgs): HeightStyleI => {
             maxRowsWithoutScrolling
         };
     }
-    // NOTE: "fitContent" is not handled yet — see the following commit.
-    const domLayout: DomLayoutType = (compC?.layoutType as DomLayoutType) || (shortMode ? "autoHeight" : "normal");
+    // "fitContent" sizes the widget's own outer box to its content (the widget
+    // wrappers drop their height:100% when the layout is fitContent), so a host
+    // no longer has to match the inner viewport height. For the grid it behaves
+    // like auto-detect: autoHeight when the rows fit, normal + scroll (capped
+    // at dfvHeight) when they don't. It must never reach AG Grid as a literal
+    // domLayout value.
+    const explicitLayout = compC?.layoutType === "fitContent" ? undefined : compC?.layoutType;
+    const domLayout: DomLayoutType = explicitLayout || (shortMode ? "autoHeight" : "normal");
     if (compC?.layoutType === "normal" && !compC?.dfvHeight && !compC?.height_fraction) {
         throw new Error(
             'Buckaroo: layoutType: "normal" requires an explicit height. ' +

--- a/packages/buckaroo-js-core/src/server/BuckarooView.tsx
+++ b/packages/buckaroo-js-core/src/server/BuckarooView.tsx
@@ -8,7 +8,7 @@ import { Operation } from "../components/OperationUtils";
 import { OperationResult, baseOperationResults } from "../components/DependentTabs";
 import { DFData, DFDataOrPayload } from "../components/DFViewerParts/DFWhole";
 import { IDisplayArgs } from "../components/DFViewerParts/gridUtils";
-import { stampLayoutType } from "../components/DFViewerParts/displayArgsUtils";
+import { stampLayoutType, isFitContentLayout } from "../components/DFViewerParts/displayArgsUtils";
 import { IModel } from "./IModel";
 
 export type BuckarooServerMode = "viewer" | "buckaroo";
@@ -264,7 +264,11 @@ export function BuckarooView({
         [dfDisplayArgs, autoHeight],
     );
 
-    const wrapperStyle: React.CSSProperties = autoHeight
+    // autoHeight and fitContent both size the widget to its content, so the
+    // wrapper must not impose height:100% (which would re-introduce the gap a
+    // taller host container leaves below the table).
+    const contentSized = autoHeight || isFitContentLayout(effectiveDisplayArgs);
+    const wrapperStyle: React.CSSProperties = contentSized
         ? { width: "100%", ...(style ?? {}) }
         : { width: "100%", height: "100%", ...(style ?? {}) };
 

--- a/packages/buckaroo-js-core/src/stories/FitContentHeight.stories.tsx
+++ b/packages/buckaroo-js-core/src/stories/FitContentHeight.stories.tsx
@@ -1,0 +1,144 @@
+/**
+ * Story for the `layoutType: "fitContent"` height mode.
+ *
+ * The widget (5 rows) is mounted in a deliberately over-tall 600px container.
+ * In "fitContent" mode the widget sizes its own outer box to its content, so it
+ * collapses well below 600px with no gap — the host did not have to match the
+ * viewport height. The red border marks the container; with fitContent the
+ * widget should end flush with the table, not stretch to the border.
+ */
+import type { Meta, StoryObj } from "@storybook/react";
+import React, { useMemo, useState } from "react";
+import { BuckarooInfiniteWidget } from "../components/BuckarooWidgetInfinite";
+import { DFData, DFViewerConfig, PinnedRowConfig } from "../components/DFViewerParts/DFWhole";
+import { IDisplayArgs } from "../components/DFViewerParts/gridUtils";
+import {
+  KeyAwareSmartRowCache,
+  PayloadArgs,
+  PayloadResponse,
+} from "../components/DFViewerParts/SmartRowCache";
+import { BuckarooOptions, BuckarooState, DFMeta } from "../components/WidgetTypes";
+import { CommandConfigT } from "../components/CommandUtils";
+import { Operation } from "../components/OperationUtils";
+import { baseOperationResults } from "../components/DependentTabs";
+
+const NAMES = ["Alice", "Bob", "Charlie", "Diana", "Eve"];
+const TOTAL_ROWS = 5;
+
+const allData: DFData = NAMES.map((name, i) => ({
+  index: i,
+  name,
+  age: 25 + i * 3,
+  score: 80 + i * 3.5,
+}));
+
+const summaryStatsData: DFData = [
+  { index: "dtype", name: "object", age: "int64", score: "float64" },
+  { index: "count", name: 5, age: 5, score: 5 },
+];
+
+const SUMMARY_PINNED: PinnedRowConfig[] = summaryStatsData.map((row) => ({
+  primary_key_val: row.index as string,
+  displayer_args: { displayer: "obj" as const },
+}));
+
+// The fitContent layout lives on component_config, exactly where the server /
+// Python side would set it.
+const colConfig: DFViewerConfig = {
+  column_config: [
+    { col_name: "name", header_name: "name", displayer_args: { displayer: "obj" } },
+    { col_name: "age", header_name: "age", displayer_args: { displayer: "integer", min_digits: 1, max_digits: 5 } },
+    { col_name: "score", header_name: "score", displayer_args: { displayer: "float", min_fraction_digits: 1, max_fraction_digits: 2 } },
+  ],
+  pinned_rows: [],
+  left_col_configs: [{ col_name: "index", header_name: "index", displayer_args: { displayer: "string" } }],
+  component_config: { layoutType: "fitContent" },
+};
+
+const df_display_args: Record<string, IDisplayArgs> = {
+  main: { data_key: "main", df_viewer_config: colConfig, summary_stats_key: "all_stats" },
+  summary: {
+    data_key: "main",
+    df_viewer_config: { ...colConfig, pinned_rows: SUMMARY_PINNED },
+    summary_stats_key: "all_stats",
+  },
+};
+
+const dfMeta: DFMeta = {
+  total_rows: TOTAL_ROWS,
+  columns: 3,
+  filtered_rows: TOTAL_ROWS,
+  rows_shown: TOTAL_ROWS,
+};
+
+const buckarooOptions: BuckarooOptions = {
+  sampled: [],
+  cleaning_method: [],
+  post_processing: [],
+  df_display: ["main", "summary"],
+  show_commands: [],
+};
+
+const commandConfig: CommandConfigT = { argspecs: {}, defaultArgs: {} };
+
+const FitContentComponent: React.FC = () => {
+  const [buckarooState, setBuckarooState] = useState<BuckarooState>({
+    sampled: false,
+    cleaning_method: false,
+    quick_command_args: {},
+    post_processing: false,
+    df_display: "main",
+    show_commands: false,
+  });
+  const [operations, setOperations] = useState<Operation[]>([]);
+
+  const src = useMemo(() => {
+    const cache = new KeyAwareSmartRowCache((pa: PayloadArgs) => {
+      const dataEnd = Math.min(pa.end, allData.length);
+      const resp: PayloadResponse = {
+        key: pa,
+        data: dataEnd <= pa.start ? [] : allData.slice(pa.start, dataEnd),
+        length: allData.length,
+      };
+      setTimeout(() => cache.addPayloadResponse(resp), 10);
+    });
+    return cache;
+  }, []);
+
+  const df_data_dict = useMemo(
+    () => ({ main: [] as DFData, all_stats: summaryStatsData, empty: [] as DFData }),
+    []
+  );
+
+  return (
+    <div
+      data-testid="height-container"
+      style={{ height: 600, width: 900, background: "#181D1F", border: "2px solid red" }}
+    >
+      <BuckarooInfiniteWidget
+        df_meta={dfMeta}
+        df_data_dict={df_data_dict}
+        df_display_args={df_display_args}
+        operations={operations}
+        on_operations={setOperations}
+        operation_results={baseOperationResults}
+        command_config={commandConfig}
+        buckaroo_state={buckarooState}
+        on_buckaroo_state={setBuckarooState}
+        buckaroo_options={buckarooOptions}
+        src={src}
+      />
+    </div>
+  );
+};
+
+const meta = {
+  title: "Buckaroo/FitContentHeight",
+  component: FitContentComponent,
+  parameters: { layout: "padded" },
+} satisfies Meta<typeof FitContentComponent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {};

--- a/scripts/test_playwright_storybook.sh
+++ b/scripts/test_playwright_storybook.sh
@@ -94,6 +94,7 @@ FAILED_TESTS=()
 STORYBOOK_TESTS=(
     "pw-tests/transcript-replayer.spec.ts"
     "pw-tests/outside-params.spec.ts"
+    "pw-tests/fitcontent-height.spec.ts"
     # "pw-tests/example.spec.ts"  # Has pre-existing failures, excluded for now
 )
 


### PR DESCRIPTION
## Problem

A fixed-height host that embeds Buckaroo (e.g. a `60vh` wrapper) gets a dark gap below short tables. Buckaroo sizes its grid to `window.innerHeight / 2` and fills its container with `height: 100%`, so when the content is shorter than the container, the leftover space shows through. The [height-modes docs](https://buckaroo-data.readthedocs.io/en/latest/articles/height-modes.html) tell hosts to make "the outer container match the inner viewport" — that manual coordination is the thing that breaks when a host picks its own size.

## Change

Adds a third `component_config.layoutType` value, **`"fitContent"`**, alongside `"autoHeight"` and `"normal"`:

- **Grid:** behaves exactly like auto-detect — `autoHeight` when the rows fit, `normal` + virtualized scroll (capped at `dfvHeight`) when they don't. `heightStyle` maps `fitContent` to that and never emits it as a literal AG Grid `domLayout`.
- **Outer box:** the widget wrappers drop their `height: 100%` when the layout is `fitContent`, so the widget sizes its own box to its content. The host gives it an `auto` / `max-height` wrapper and gets no gap — without having to match the viewport, and without reaching into AG Grid's DOM.

Wired into **both** modes: `BuckarooInfiniteWidget` (`"buckaroo"`) and `DFViewerInfiniteDS` (`"viewer"`), plus `BuckarooView`'s `anywidget` wrapper. New `isFitContentLayout()` helper.

This replaces the earlier `onHeightChange` callback approach (an earlier version of this PR): a self-sizing layout needs no height reported back to the host, and — unlike a JS callback — it works the same in Jupyter/anywidget, where JS can't call back into Python.

## Tests

- **jest** (`gridUtils.test.ts`, runs in `JS / Build + Test`): `fitContent` routes to `autoHeight`/`normal`, never emits `"fitContent"` as a domLayout, doesn't throw without an explicit `dfvHeight`.
- **Playwright/Storybook** (`fitcontent-height.spec.ts` + `FitContentHeight` story, registered in `scripts/test_playwright_storybook.sh`): the widget (5 rows) in a 600px container collapses well below 600px and ends flush with its content (no gap).

Per TDD, the first commit lands both test layers failing on CI; the implementation follows.