### PR TITLE
feat(search): make search debounce configurable via component_config (#891)

### DIFF
--- a/buckaroo/dataflow/styling_core.py
+++ b/buckaroo/dataflow/styling_core.py
@@ -167,7 +167,8 @@ ComponentConfig = TypedDict('ComponentConfig', {
     'shortMode': NotRequired[bool],
     'selectionBackground': NotRequired[str],
     'className': NotRequired[str],
-    'theme': NotRequired[ThemeConfig]})
+    'theme': NotRequired[ThemeConfig],
+    'searchDebounceMs': NotRequired[int]})
 
 DFViewerConfig = TypedDict('DFViewerConfig', {
     'pinned_rows': List[PinnedRowConfig],

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -338,7 +338,7 @@ export function BuckarooInfiniteWidget({
                         buckarooOptions={buckaroo_options}
                         themeConfig={cDisp.df_viewer_config?.component_config?.theme}
                         inFlight={inFlight}
-                        componentConfig={cDisp.df_viewer_config?.component_config as Record<string, unknown> | undefined}
+                        componentConfig={effectiveDisplayArgs['main']?.df_viewer_config?.component_config as Record<string, unknown> | undefined}
                     />
                     <DFViewerInfinite
                         key={effectiveDataframeId}

--- a/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
+++ b/packages/buckaroo-js-core/src/components/BuckarooWidgetInfinite.tsx
@@ -338,6 +338,7 @@ export function BuckarooInfiniteWidget({
                         buckarooOptions={buckaroo_options}
                         themeConfig={cDisp.df_viewer_config?.component_config?.theme}
                         inFlight={inFlight}
+                        componentConfig={cDisp.df_viewer_config?.component_config as Record<string, unknown> | undefined}
                     />
                     <DFViewerInfinite
                         key={effectiveDataframeId}

--- a/packages/buckaroo-js-core/src/components/DCFCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DCFCell.tsx
@@ -62,6 +62,7 @@ export function WidgetDCFCell({
                     setBuckarooState={on_buckaroo_state}
                     buckarooOptions={buckaroo_options}
                     themeConfig={cDisp.df_viewer_config?.component_config?.theme}
+                    componentConfig={cDisp.df_viewer_config?.component_config as Record<string, unknown> | undefined}
                 />
                 <DFViewer
                     df_data={dfData}

--- a/packages/buckaroo-js-core/src/components/DCFCell.tsx
+++ b/packages/buckaroo-js-core/src/components/DCFCell.tsx
@@ -62,7 +62,7 @@ export function WidgetDCFCell({
                     setBuckarooState={on_buckaroo_state}
                     buckarooOptions={buckaroo_options}
                     themeConfig={cDisp.df_viewer_config?.component_config?.theme}
-                    componentConfig={cDisp.df_viewer_config?.component_config as Record<string, unknown> | undefined}
+                    componentConfig={df_display_args['main']?.df_viewer_config?.component_config as Record<string, unknown> | undefined}
                 />
                 <DFViewer
                     df_data={dfData}

--- a/packages/buckaroo-js-core/src/components/StatusBar.tsx
+++ b/packages/buckaroo-js-core/src/components/StatusBar.tsx
@@ -215,13 +215,16 @@ export const fakeSearchCell = function (_params: any) {
         _params.setValue(v)
     }
 
-    // Live search: after SEARCH_DEBOUNCE_MS of no keystrokes, push the term
-    // upstream. Buttons / Enter bypass the debounce and fire immediately.
+    // Live search: after debounceMs of no keystrokes, push the term upstream.
+    // Reads searchDebounceMs from the AG-Grid context's componentConfig blob
+    // (set by the Python-side ComponentConfig). Buttons / Enter bypass the
+    // debounce and fire immediately.
+    const debounceMs: number = (_params.context?.componentConfig?.searchDebounceMs as number | undefined) ?? SEARCH_DEBOUNCE_MS;
     useEffect(() => {
         if (searchVal === (value || '')) return;  // initial mount, no-op
-        const t = setTimeout(() => submit(searchVal), SEARCH_DEBOUNCE_MS);
+        const t = setTimeout(() => submit(searchVal), debounceMs);
         return () => clearTimeout(t);
-    }, [searchVal, value]);
+    }, [searchVal, value, debounceMs]);
 
     const keyPressHandler = (event:React.KeyboardEvent<HTMLInputElement> ) => {
         if (event.key === "Enter") {
@@ -312,6 +315,7 @@ export function StatusBar({
     heightOverride,
     themeConfig,
     inFlight,
+    componentConfig,
 }: {
     dfMeta: DFMeta;
     buckarooState: BuckarooState;
@@ -324,6 +328,12 @@ export function StatusBar({
     // grid is otherwise ambiguous between "zero rows" and "still computing".
     // When set, renders a small "computing…" dot in the status-bar chrome.
     inFlight?: boolean;
+    /** Opaque component_config blob from Python. Passed into the AG-Grid
+     *  context so any cell renderer can read config keys without additional
+     *  prop threading. New config keys (e.g. searchDebounceMs) are added to
+     *  Python's ComponentConfig TypedDict; cell renderers read them via
+     *  params.context.componentConfig. */
+    componentConfig?: Record<string, unknown>;
 }) {
     if (false) {
 	console.log("heightOverride", heightOverride);
@@ -531,7 +541,8 @@ export function StatusBar({
                     context={{
                         buckarooState,
                         setBuckarooState,
-                        buckarooOptions
+                        buckarooOptions,
+                        componentConfig,
                     }}
                 ></AgGridReact>
             </div>


### PR DESCRIPTION
## Summary

- Adds `searchDebounceMs` to Python's `ComponentConfig` TypedDict in `styling_core.py`
- `StatusBar` accepts a new `componentConfig: Record<string, unknown>` prop and places it in its AG-Grid `context`
- `fakeSearchCell` reads `params.context.componentConfig.searchDebounceMs` for the keystroke debounce, falling back to the existing 300 ms default

## Usage

```python
BuckarooInfiniteWidget(df, component_config={'searchDebounceMs': 2000})
```

Any field added to Python's `ComponentConfig` is now automatically available to AG-Grid cell renderers in the status bar via `params.context.componentConfig` — no prop threading required.

## Test plan

- [ ] JS build passes (`pnpm run build`)
- [ ] 284 jest tests pass (`pnpm test`)
- [ ] Manually verify: set `searchDebounceMs=2000`, type in search box, confirm dispatch waits 2 s after last keystroke
- [ ] Confirm default behavior (300 ms) is unchanged when `searchDebounceMs` is not set

Closes #891

🤖 Generated with [Claude Code](https://claude.com/claude-code)