### PR TITLE
feat(xorq): load display klasses from <project_root>/display/*.py

### DIFF
--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -434,6 +434,7 @@ class LoadExprHandler(tornado.web.RequestHandler):
             extra_klasses = (
                 xorq_loading.load_project_stat_klasses(project_root)
                 + xorq_loading.load_project_post_processing_klasses(project_root)
+                + xorq_loading.load_project_display_klasses(project_root)
                 if project_root else [])
             xorq_dataflow = xorq_loading.XorqServerDataflow(
                 expr, skip_main_serial=True, extra_klasses=extra_klasses,
@@ -718,7 +719,8 @@ class ReloadExprHandler(tornado.web.RequestHandler):
         try:
             extra_klasses = (
                 xorq_loading.load_project_stat_klasses(session.project_root)
-                + xorq_loading.load_project_post_processing_klasses(session.project_root))
+                + xorq_loading.load_project_post_processing_klasses(session.project_root)
+                + xorq_loading.load_project_display_klasses(session.project_root))
             xorq_dataflow = xorq_loading.XorqServerDataflow(
                 session.expr, skip_main_serial=True, extra_klasses=extra_klasses)
         except Exception:

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -315,6 +315,82 @@ def _compile_project_post_processing(name: str, path: Path):
     })
 
 
+# ---------------------------------------------------------------------------
+# project-authored display klasses (loaded from <project_root>/display/*.py)
+# ---------------------------------------------------------------------------
+
+
+def load_project_display_klasses(project_root) -> list:
+    """Scan ``<project_root>/display/*.py`` for ``ColAnalysis`` subclasses
+    with a ``df_display_name`` attribute and return them as ``extra_klasses``.
+
+    Unlike the stat and post-processing loaders, display files define full
+    class bodies rather than a single function. Each file is exec'd with
+    ``ColAnalysis`` and the standard styling base classes in scope; any
+    class found in the resulting namespace that (a) subclasses ``ColAnalysis``
+    and (b) carries a ``df_display_name`` string is collected.
+
+    Because ``filter_analysis(klasses, "df_display_name")`` maps display-name
+    → last-klass-wins, a display klass loaded here overrides the built-in
+    ``DefaultMainStyling`` (``df_display_name = "main"``) for this session
+    only — ``_XORQ_ANALYSIS_KLASSES`` is not mutated.
+
+    Files whose name starts with ``_`` are skipped (parking convention).
+    Errors in any one file are logged and the file is skipped.
+    """
+    display_dir = Path(project_root) / "display"
+    if not display_dir.is_dir():
+        return []
+
+    from buckaroo.pluggable_analysis_framework.col_analysis import ColAnalysis  # noqa: PLC0415
+    from buckaroo.customizations.styling import (  # noqa: PLC0415
+        DefaultMainStyling, DefaultSummaryStatsStyling, StylingAnalysis)
+
+    klasses: list = []
+    for path in sorted(display_dir.glob("*.py")):
+        if path.name.startswith("_"):
+            continue
+        try:
+            found = _compile_project_display(path, ColAnalysis,
+                DefaultMainStyling, DefaultSummaryStatsStyling, StylingAnalysis)
+            klasses.extend(found)
+        except Exception as e:
+            log.warning("project display %s skipped: %s", path, e)
+    return klasses
+
+
+def _compile_project_display(path: Path, ColAnalysis, *extra_bases):
+    """Exec one display file and return all ColAnalysis subclasses with
+    ``df_display_name`` found in its namespace. Raises on syntax errors
+    so the loader can log-and-skip. Returns an empty list when a valid
+    file defines no qualifying classes (not an error)."""
+    source = path.read_text()
+    safe = _safe_builtins()
+    # class syntax requires __build_class__; classmethod/staticmethod are
+    # standard descriptors needed for display klass method definitions.
+    safe["__build_class__"] = __build_class__
+    safe["classmethod"] = classmethod
+    safe["staticmethod"] = staticmethod
+    globs: dict = {"__builtins__": safe, "__name__": str(path.stem), "ColAnalysis": ColAnalysis}
+    for base in extra_bases:
+        globs[base.__name__] = base
+
+    # Track identities of pre-injected classes so we don't return them as
+    # user-defined klasses — they're context for the file, not the output.
+    injected_ids = {id(ColAnalysis)} | {id(b) for b in extra_bases}
+
+    exec(compile(source, str(path), "exec"), globs)
+
+    found = []
+    for obj in globs.values():
+        if (isinstance(obj, type)
+                and id(obj) not in injected_ids
+                and issubclass(obj, ColAnalysis)
+                and isinstance(getattr(obj, "df_display_name", None), str)):
+            found.append(obj)
+    return found
+
+
 def handle_infinite_request_xorq(xorq_dataflow: XorqServerDataflow,
         payload_args: dict, search_string: str = "") -> tuple[dict, bytes]:
     """Drive one infinite_request window against a xorq expression.

--- a/buckaroo/server/xorq_loading.py
+++ b/buckaroo/server/xorq_loading.py
@@ -350,6 +350,11 @@ def load_project_display_klasses(project_root) -> list:
     for path in sorted(display_dir.glob("*.py")):
         if path.name.startswith("_"):
             continue
+        if not path.stem.isidentifier():
+            log.warning(
+                "project display %s: filename stem is not a valid python identifier; skipping",
+                path)
+            continue
         try:
             found = _compile_project_display(path, ColAnalysis,
                 DefaultMainStyling, DefaultSummaryStatsStyling, StylingAnalysis)
@@ -366,11 +371,22 @@ def _compile_project_display(path: Path, ColAnalysis, *extra_bases):
     file defines no qualifying classes (not an error)."""
     source = path.read_text()
     safe = _safe_builtins()
-    # class syntax requires __build_class__; classmethod/staticmethod are
-    # standard descriptors needed for display klass method definitions.
+    # __build_class__ is the CPython hook that executes class bodies; without
+    # it, any ``class Foo:`` statement raises NameError. Adding it opens more
+    # exec surface than the function-only stat/post-processing loaders — class
+    # bodies run arbitrary code at definition time (descriptors,
+    # __init_subclass__, metaclasses). Display files are project-developer-
+    # authored, not end-user input, so this is acceptable; keep that scope in
+    # mind if the sandbox model is ever revisited.
     safe["__build_class__"] = __build_class__
     safe["classmethod"] = classmethod
     safe["staticmethod"] = staticmethod
+    # super() is a builtin but not in _SAFE_BUILTIN_NAMES; without it,
+    # calling super() inside any method succeeds at class-definition time
+    # but raises NameError at render time — the common override pattern
+    # (subclass DefaultMainStyling, call super().style_column(...)) would
+    # silently break.
+    safe["super"] = super
     globs: dict = {"__builtins__": safe, "__name__": str(path.stem), "ColAnalysis": ColAnalysis}
     for base in extra_bases:
         globs[base.__name__] = base

--- a/packages/buckaroo-js-core/src/baked_data/colorMap.ts
+++ b/packages/buckaroo-js-core/src/baked_data/colorMap.ts
@@ -521,3 +521,7 @@ export const BLUE_TO_YELLOW = [
     "#fedd5a",
     "#fedd59",
 ];
+
+// DIVERGING_RED_WHITE_BLUE reversed: blue (low/negative) → white (zero) → red (high/positive).
+// Use when large positive change should be alarming (red) and no change should be calm (blue/white).
+export const DIVERGING_BLUE_WHITE_RED = [...DIVERGING_RED_WHITE_BLUE].reverse();

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/DFWhole.ts
@@ -115,7 +115,7 @@ export const cellRendererDisplayers = [
     "SVGDisplayer",
 ];
 
-export type ColorMap = "BLUE_TO_YELLOW" | "DIVERGING_RED_WHITE_BLUE" | string[];
+export type ColorMap = "BLUE_TO_YELLOW" | "DIVERGING_RED_WHITE_BLUE" | "DIVERGING_BLUE_WHITE_RED" | string[];
 
 //ColorMapRules
 export interface ColorMapRules {

--- a/packages/buckaroo-js-core/src/components/DFViewerParts/Styler.tsx
+++ b/packages/buckaroo-js-core/src/components/DFViewerParts/Styler.tsx
@@ -2,7 +2,7 @@ import {
     CellClassParams,
 } from "ag-grid-community";
 
-import { BLUE_TO_YELLOW, DIVERGING_RED_WHITE_BLUE } from "../../baked_data/colorMap";
+import { BLUE_TO_YELLOW, DIVERGING_RED_WHITE_BLUE, DIVERGING_BLUE_WHITE_RED } from "../../baked_data/colorMap";
 import {
     ColorMappingConfig,
     ColorMapRules,
@@ -18,6 +18,8 @@ const getColorMap =  (cm:ColorMap): string[] => {
 	return BLUE_TO_YELLOW
     } else if (cm === "DIVERGING_RED_WHITE_BLUE") {
 	return DIVERGING_RED_WHITE_BLUE
+    } else if (cm === "DIVERGING_BLUE_WHITE_RED") {
+	return DIVERGING_BLUE_WHITE_RED
     } else {
 	return cm
     }

--- a/tests/unit/server/test_project_display_klasses.py
+++ b/tests/unit/server/test_project_display_klasses.py
@@ -1,0 +1,160 @@
+"""Tests for ``load_project_display_klasses`` — scan a project's
+``display/<name>.py`` directory, exec each file in a restricted sandbox,
+and return ``ColAnalysis`` subclasses that carry a ``df_display_name``
+attribute. These slot into ``extra_klasses`` on ``XorqServerDataflow``
+and override or extend the built-in display configs (``DefaultMainStyling``,
+etc.) for that session only.
+
+Mirrors ``test_project_post_processing.py`` for the display channel.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from buckaroo.server.xorq_loading import load_project_display_klasses
+
+MINIMAL_DISPLAY = (
+    "class MyDisplay(ColAnalysis):\n"
+    "    df_display_name = 'my_display'\n"
+)
+
+MAIN_OVERRIDE = (
+    "class MainOverride(DefaultMainStyling):\n"
+    "    df_display_name = 'main'\n"
+)
+
+
+def test_returns_empty_when_display_dir_missing(tmp_path: Path):
+    assert load_project_display_klasses(tmp_path) == []
+
+
+def test_returns_empty_when_display_dir_empty(tmp_path: Path):
+    (tmp_path / "display").mkdir()
+    assert load_project_display_klasses(tmp_path) == []
+
+
+def test_picks_up_one_display_klass(tmp_path: Path):
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "my_display.py").write_text(MINIMAL_DISPLAY)
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+    assert klasses[0].df_display_name == "my_display"
+
+
+def test_skips_file_without_qualifying_class(tmp_path: Path):
+    """A file with no ColAnalysis subclass carrying df_display_name is
+    not an error — it's just ignored. A file that does qualify still loads."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "no_display.py").write_text("x = 42\n")
+    (d / "my_display.py").write_text(MINIMAL_DISPLAY)
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+    assert klasses[0].df_display_name == "my_display"
+
+
+def test_skips_class_without_df_display_name(tmp_path: Path):
+    """A ColAnalysis subclass without df_display_name is not collected —
+    only named display configs are returned."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "unnamed.py").write_text(
+        "class Unnamed(ColAnalysis):\n"
+        "    pass\n")
+    assert load_project_display_klasses(tmp_path) == []
+
+
+def test_skips_underscore_prefixed_files(tmp_path: Path):
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "_disabled.py").write_text(MINIMAL_DISPLAY)
+    (d / "my_display.py").write_text(MINIMAL_DISPLAY)
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+
+
+def test_skips_non_identifier_filename(tmp_path: Path):
+    """A filename stem that is not a valid Python identifier (e.g.
+    ``my-display.py``) is logged and skipped, matching the stat and
+    post-processing loaders."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "my-display.py").write_text(MINIMAL_DISPLAY)
+    (d / "my_display.py").write_text(MINIMAL_DISPLAY)
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+
+
+def test_skips_file_that_tries_to_import(tmp_path: Path):
+    """The sandbox strips __import__ so ``import os`` raises; the file is
+    logged and skipped; other files in the same dir still load."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "evil.py").write_text(
+        "import os\n"
+        "class Evil(ColAnalysis):\n"
+        "    df_display_name = 'evil'\n")
+    (d / "my_display.py").write_text(MINIMAL_DISPLAY)
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+    assert klasses[0].df_display_name == "my_display"
+
+
+def test_base_classes_are_not_returned_as_user_klasses(tmp_path: Path):
+    """ColAnalysis and the styling base classes are injected into the
+    sandbox as context; they must not appear in the returned list even
+    though they are present in the exec'd namespace."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "my_display.py").write_text(MINIMAL_DISPLAY)
+    klasses = load_project_display_klasses(tmp_path)
+    names = {k.__name__ for k in klasses}
+    assert "ColAnalysis" not in names
+    assert "DefaultMainStyling" not in names
+    assert "DefaultSummaryStatsStyling" not in names
+    assert "StylingAnalysis" not in names
+
+
+def test_subclass_of_default_main_styling_is_collected(tmp_path: Path):
+    """A display file may subclass DefaultMainStyling (injected into scope)
+    to override the built-in 'main' display for this session."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "main_override.py").write_text(MAIN_OVERRIDE)
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+    assert klasses[0].df_display_name == "main"
+
+
+def test_super_is_available_in_display_klass_methods(tmp_path: Path):
+    """super() must be accessible inside methods of loaded display klasses.
+    Without it in the sandbox, super()-using overrides load successfully
+    but raise NameError at render time — a confusing late failure."""
+    d = tmp_path / "display"
+    d.mkdir()
+    (d / "super_display.py").write_text(
+        "class SuperDisplay(DefaultMainStyling):\n"
+        "    df_display_name = 'main'\n"
+        "    @classmethod\n"
+        "    def style_column(cls, col, sd):\n"
+        "        return super().style_column(col, sd)\n")
+    klasses = load_project_display_klasses(tmp_path)
+    assert len(klasses) == 1
+    # Trigger the method to confirm super() resolves at call time, not just
+    # at class-definition time.
+    klasses[0].style_column("a", {})
+
+
+def test_multiple_files_all_collected(tmp_path: Path):
+    d = tmp_path / "display"
+    d.mkdir()
+    for name in ("alpha", "beta", "gamma"):
+        (d / f"{name}.py").write_text(
+            f"class D(ColAnalysis):\n"
+            f"    df_display_name = '{name}'\n")
+    klasses = load_project_display_klasses(tmp_path)
+    display_names = sorted(k.df_display_name for k in klasses)
+    assert display_names == ["alpha", "beta", "gamma"]

--- a/tests/unit/server/test_project_display_klasses.py
+++ b/tests/unit/server/test_project_display_klasses.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
 
 from buckaroo.server.xorq_loading import load_project_display_klasses
 


### PR DESCRIPTION
## Summary

- Adds `load_project_display_klasses(project_root)` to `xorq_loading.py`, scanning `<project_root>/display/*.py` for `ColAnalysis` subclasses with a `df_display_name` attribute
- Wires it into both `/load_expr` handler call sites alongside the existing stat and post-processing loaders
- Files are exec'd with `ColAnalysis`, `DefaultMainStyling`, `DefaultSummaryStatsStyling`, and `StylingAnalysis` in scope so subclasses can inherit from any of them without an import statement

## Motivation

The stat and post-processing loaders let project code inject per-stat and post-processing behaviour into a session without touching built-in defaults. Display klasses fill the same gap for named display configs: a project can override `df_display_name = "main"` for one session (e.g. hide certain generated columns in a diff viewer) or add a new named display (e.g. `"detailed_pct"`) without mutating `_XORQ_ANALYSIS_KLASSES` or reaching for global `column_config_overrides`.

## Implementation notes

- `_compile_project_display` pre-records the identities of injected base classes so they are not returned as user-defined klasses — only classes that appear in the exec'd file's namespace but were not already in scope are collected
- `__build_class__`, `classmethod`, `staticmethod`, and `__name__` are added to the sandbox alongside the existing safe builtins; class syntax and `@classmethod` decorators require them
- Last-klass-wins for duplicate `df_display_name` (via `filter_analysis`) means a display file overriding `"main"` naturally supersedes `DefaultMainStyling` for that session only

🤖 Generated with [Claude Code](https://claude.com/claude-code)