### PR TITLE
chore: remove erroneous Bloomberg attribution

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Bloomberg
+Copyright (c) Paddy Mullen
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/source/articles/related_projects.rst
+++ b/docs/source/articles/related_projects.rst
@@ -10,7 +10,7 @@ There are a couple of projects like Buckaroo that aim to provide a better table 
 
 #. `Mito <https://github.com/mito-ds/monorepo>`_.  Source Available table/code editing widget for Jupyter.  More aimed at easing transition to pandas from excel users.  GNU Affero licensed
 #. `Microsoft DataWrangler <https://github.com/microsoft/vscode-data-wrangler>`_ .  Closed source, provides a very similar experience inside of VSCode's notebook experience.  Only works inside of VSCode by the `VS Marketplace Terms of Use <https://cdn.vsassets.io/v/M190_20210811.1/_content/Microsoft-Visual-Studio-Marketplace-Terms-of-Use.pdf>`_
-#. `IpyDatagrid <https://github.com/bloomberg/ipydatagrid>`_.  Open source.  Bloomberg's Jupyter table widget. I used the ipydatagrid repo structure as the basis for buckaroo (js build setup only)
+#. `IpyDatagrid <https://github.com/bloomberg/ipydatagrid>`_.  Open source.  A Jupyter table widget built on top of ipywidgets.
 #. `IPyAgGrid <https://github.com/widgetti/ipyaggrid>`_ .  Open source.  Wraps `AG Grid <https://www.ag-grid.com/>`_  in a jupyter widget.  Buckaroo also uses AG Grid.
 #. `Bamboolib <https://github.com/tkrabel/bamboolib>`_  An originally open source tool aimed at building a similar experience, more aimed as a low-code tool for beginners.  The parent company 8080labs was acquired by Databricks.  Code no longer available.
 #. `QGrid <https://github.com/quantopian/qgrid>`_.  Open source, unmaintained.  A slick table widget built by Quantopian, no code gen or data manipulation features

--- a/packages/buckaroo-js-core/LICENSE
+++ b/packages/buckaroo-js-core/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 Bloomberg
+Copyright (c) Paddy Mullen
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
## Summary

- `LICENSE.txt`: copyright holder updated to Paddy Mullen — the Bloomberg copyright was copied from ipydatagrid early in the project and no Bloomberg code remains
- `related_projects.rst`: IpyDatagrid kept as a related project; removed the note claiming buckaroo's build setup derived from that repo

Buckaroo has been built on anywidget for over a year with no Bloomberg-derived code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)