### PR TITLE
feat(server): optional dataframe backends — add [server] extra, make polars/xorq additive

### DIFF
--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -226,7 +226,8 @@ class LoadHandler(tornado.web.RequestHandler):
         except ImportError:
             self.set_status(400)
             self.write({"error_code": "missing_dependency",
-                "message": "backend='polars' requires polars to be installed"})
+                "message": "backend='polars' requires polars. "
+                "Install with `pip install buckaroo[polars]`."})
             return None, None
         except ValueError as e:
             self.set_status(400)
@@ -256,6 +257,15 @@ class LoadHandler(tornado.web.RequestHandler):
         except FileNotFoundError:
             self.set_status(404)
             self.write({"error_code": "file_not_found", "message": f"File not found: {path}"})
+            return None, None
+        except ImportError:
+            # The lazy path imports polars on demand; an absent polars means
+            # the [polars] extra wasn't installed. Surface a clean 400 with the
+            # install hint instead of a generic 500 (mirrors the xorq path).
+            self.set_status(400)
+            self.write({"error_code": "missing_dependency",
+                "message": "mode='lazy' requires polars. "
+                "Install with `pip install buckaroo[polars]`."})
             return None, None
         except ValueError as e:
             self.set_status(400)

--- a/docs/source/articles/embedding.rst
+++ b/docs/source/articles/embedding.rst
@@ -512,6 +512,11 @@ The Buckaroo server is a Tornado application that loads files
 server-side and serves the table over WebSocket. It's the Infinite
 widget without a notebook.
 
+Install it with ``pip install 'buckaroo[server]'`` — that pulls in
+Tornado and pandas (the pandas backend) without polars or xorq. Add
+``buckaroo[polars]`` for the lazy/polars backend or ``buckaroo[xorq]``
+for the xorq backend; each is additive on top of ``[server]``.
+
 Start it:
 
 .. code-block:: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,16 +79,24 @@ dev = [
     "pl-series-hash==0.2.1",
     "marimo>=0.19.7",
 ]
-polars = [
-    "polars>=1.24.0",
-    "polars[timezone]",
-    "pl-series-hash==0.2.1",
-    # Server runtime (buckaroo.server) needs tornado + pandas; the dataflow
-    # pipeline is pandas-keyed even when input is polars. Bundling them here
-    # means `pip install 'buckaroo[polars]'` is enough to boot the sidecar.
+# Headless data server (the `buckaroo-server` entrypoint / Tauri sidecar).
+# pandas is the base engine: the dataflow/stats pipeline is pandas-keyed even
+# when the input is polars or xorq, so it lives here rather than in an optional
+# backend extra. `pip install 'buckaroo[server]'` boots the server against
+# pandas files with no polars/xorq pulled in — the backend extras below add
+# those only when needed.
+server = [
     "tornado>=6.0",
     "pandas; python_version >= '3.13'",
     "pandas>=1.3.5; python_version < '3.13'",
+]
+# polars backend for the server + the polars notebook widget. Additive on top
+# of [server]; only the polars wheels are extra.
+polars = [
+    "buckaroo[server]",
+    "polars>=1.24.0",
+    "polars[timezone]",
+    "pl-series-hash==0.2.1",
 ]
 
 test = [
@@ -118,15 +126,14 @@ test = [
 # value_counts) on polars-written parquets that contain Categorical
 # columns. Fixed in xorq-datafusion 0.2.7, shipped with xorq 0.3.25.
 xorq = [
+    "buckaroo[server]",
+    # xorq drives the lazy path via its own parquet readers, so a polars-free
+    # xorq install is supported — [server] supplies pandas + tornado.
     "xorq>=0.3.25 ; python_version < '3.14'",
-    # Server runtime (buckaroo.server) — polars is no longer required to
-    # boot; pandas + tornado are. xorq drives the lazy path via its own
-    # parquet readers, so a polars-free xorq install is supported.
-    "tornado>=6.0",
-    "pandas; python_version >= '3.13'",
-    "pandas>=1.3.5; python_version < '3.13'",
 ]
-mcp = ["mcp", "tornado>=6.0", "polars"]
+# MCP server. Builds on [server] (pandas + tornado); polars is no longer
+# forced — add buckaroo[polars] alongside if a polars backend is wanted.
+mcp = ["buckaroo[server]", "mcp"]
 marimo = [
     "marimo>=0.19.7",
     "pandas; python_version >= '3.13'",

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 import tempfile
+from unittest import mock
 
 import pandas as pd
 import pytest
@@ -98,6 +99,30 @@ class TestLoad(tornado.testing.AsyncHTTPTestCase):
                     body=json.dumps({"session": "test-3", "path": f.name}),
                     headers={"Content-Type": "application/json"})
                 self.assertEqual(resp.code, 400)
+            finally:
+                os.unlink(f.name)
+
+    def test_load_lazy_without_polars_returns_missing_dependency(self):
+        # mode="lazy" needs polars. When polars is absent the loader raises
+        # ImportError; the handler must surface a clean 400 pointing at the
+        # install extra, not a generic 500. Simulate polars-absent by making
+        # load_file_lazy raise ImportError (mirrors `pip install buckaroo`
+        # without the polars extra).
+        def _no_polars(path):
+            raise ImportError("No module named 'polars'")
+
+        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as f:
+            _write_test_csv(f.name)
+            try:
+                with mock.patch("buckaroo.server.handlers.load_file_lazy", _no_polars):
+                    resp = self.fetch("/load", method="POST",
+                        body=json.dumps({"session": "test-lazy-nopolars",
+                            "path": f.name, "mode": "lazy"}),
+                        headers={"Content-Type": "application/json"})
+                self.assertEqual(resp.code, 400)
+                body = json.loads(resp.body)
+                self.assertEqual(body["error_code"], "missing_dependency")
+                self.assertIn("buckaroo[polars]", body["message"])
             finally:
                 os.unlink(f.name)
 

--- a/uv.lock
+++ b/uv.lock
@@ -281,7 +281,8 @@ marimo = [
 ]
 mcp = [
     { name = "mcp" },
-    { name = "polars" },
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "tornado" },
 ]
 notebook = [
@@ -296,6 +297,11 @@ polars = [
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pl-series-hash" },
     { name = "polars", extra = ["timezone"] },
+    { name = "tornado" },
+]
+server = [
+    { name = "pandas", version = "2.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "tornado" },
 ]
 test = [
@@ -379,19 +385,22 @@ requires-dist = [
     { name = "packaging", marker = "extra == 'test'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'dev'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'marimo'" },
+    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'mcp'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'polars'" },
+    { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'server'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'test'" },
     { name = "pandas", marker = "python_full_version >= '3.13' and extra == 'xorq'" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'dev'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'marimo'", specifier = ">=1.3.5" },
+    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'mcp'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'polars'", specifier = ">=1.3.5" },
+    { name = "pandas", marker = "python_full_version < '3.13' and extra == 'server'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'test'", specifier = ">=1.3.5" },
     { name = "pandas", marker = "python_full_version < '3.13' and extra == 'xorq'", specifier = ">=1.3.5" },
     { name = "pandera", marker = "extra == 'test'" },
     { name = "pl-series-hash", marker = "extra == 'dev'", specifier = "==0.2.1" },
     { name = "pl-series-hash", marker = "extra == 'polars'", specifier = "==0.2.1" },
     { name = "playwright", marker = "extra == 'dev'" },
-    { name = "polars", marker = "extra == 'mcp'" },
     { name = "polars", marker = "extra == 'polars'", specifier = ">=1.24.0" },
     { name = "polars", extras = ["timezone"], marker = "extra == 'polars'" },
     { name = "pyarrow", marker = "python_full_version < '3.13'", specifier = ">=18.0.0" },
@@ -413,12 +422,13 @@ requires-dist = [
     { name = "toml", marker = "extra == 'dev'" },
     { name = "tornado", marker = "extra == 'mcp'", specifier = ">=6.0" },
     { name = "tornado", marker = "extra == 'polars'", specifier = ">=6.0" },
+    { name = "tornado", marker = "extra == 'server'", specifier = ">=6.0" },
     { name = "tornado", marker = "extra == 'xorq'", specifier = ">=6.0" },
     { name = "twine", marker = "extra == 'packaging-tools'" },
     { name = "watchfiles", marker = "extra == 'dev'" },
     { name = "xorq", marker = "python_full_version < '3.14' and extra == 'xorq'", specifier = ">=0.3.25" },
 ]
-provides-extras = ["dev", "jupyterlab", "marimo", "mcp", "notebook", "packaging-tools", "polars", "test", "xorq"]
+provides-extras = ["dev", "jupyterlab", "marimo", "mcp", "notebook", "packaging-tools", "polars", "server", "test", "xorq"]
 
 [package.metadata.requires-dev]
 datacompy = [{ name = "datacompy", specifier = ">=0.15.0" }]


### PR DESCRIPTION
## What

Make the dataframe backends genuinely optional for the headless Buckaroo
server, so you can install only what you need.

Before this PR there was no way to run `buckaroo-server` with just a pandas
backend: `tornado` was absent from the core dependencies, and every
server-capable extra (`polars`, `xorq`, `mcp`) forced polars or xorq in.
pandas is the base engine — the dataflow/stats pipeline is pandas-keyed even
when the input is polars or xorq — so it belongs in a base server extra, with
the dataframe backends layered on top.

## Changes

- **New `[server]` extra** (`tornado` + `pandas`). `pip install
  'buckaroo[server]'` boots the pandas-backed server with no polars/xorq
  pulled in.
- **`[polars]` and `[xorq]` now build on `buckaroo[server]`** (self-referential
  extra), so they are purely additive — only the backend wheels are extra.
- **`[mcp]` no longer forces polars.** The MCP tool drives `/load` with the
  default pandas backend (`buckaroo_mcp_tool.py:284`) and never needs polars.
  Add `buckaroo[polars]` alongside it if a polars backend is wanted.
- **Graceful degradation:** the lazy `/load` path (`mode='lazy'`) now returns
  a `400 missing_dependency` pointing at `pip install buckaroo[polars]` when
  polars is absent, instead of a generic 500. Matches the eager polars and
  xorq paths.
- Document the `[server]` install in the embedding guide.

## Resolution (verified)

`pip install` into a pristine venv:

| extra | pulls |
|-------|-------|
| `buckaroo[server]` | tornado + pandas (no polars/xorq) |
| `buckaroo[polars]` | + polars (tornado/pandas via `[server]`) |
| `buckaroo[xorq]`   | + xorq, **no polars** |
| `buckaroo[mcp]`    | + mcp, **no polars** |

## Tests

Test-first (bugfix flow): the failing test was seen red on CI run
[27288952055](https://github.com/buckaroo-data/buckaroo/actions/runs/27288952055)
(`test_load_lazy_without_polars_returns_missing_dependency`, `500 != 400`)
before the fix landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
