### PR TITLE
fix(stats): use approx_nunique for distinct_count in the xorq batch aggregate

### DIFF
--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -56,6 +56,10 @@ def _is_numeric_not_bool(dtype) -> bool:
     return dtype.is_numeric() and not dtype.is_boolean()
 
 
+def _not_float(dtype) -> bool:
+    return not dtype.is_floating()
+
+
 # ============================================================
 # Typing — derive type flags from the schema dtype string
 # ============================================================
@@ -140,7 +144,7 @@ def max(col: XorqColumn) -> float:
     return col.max().cast("float64")
 
 
-@stat()
+@stat(column_filter=_not_float)
 def distinct_count(col: XorqColumn) -> int:
     """Approximate distinct count (HyperLogLog, ~1% error) where supported.
 
@@ -151,12 +155,19 @@ def distinct_count(col: XorqColumn) -> int:
     is displayed as a ratio, and the histogram branch thresholds
     (distinct_count > 5 / <= 5) sit where HLL is exact in practice.
 
-    Allowlist, not denylist: DataFusion's approx_distinct raises for
-    unimplemented dtypes (Float64, Boolean at least), and one failing
-    expression aborts the entire batch aggregate — every batched stat for
-    every column. Unverified dtypes keep the exact aggregate; the memory
-    blowup is dominated by high-cardinality string columns, which are
-    covered.
+    Float columns skip the stat entirely (column_filter): DataFusion's
+    approx_distinct raises on Float64, exact COUNT(DISTINCT) costs memory
+    proportional to cardinality (~2.2GB measured on a 30M-distinct float
+    column), and a distinct count over floats is rarely meaningful. The
+    pipeline pre-populates ``distinct_count`` as None so dependents
+    (histogram, histogram_bins, distinct_per) still run.
+
+    Allowlist, not denylist, for the remaining dtypes: approx_distinct
+    raises for other unimplemented dtypes too (Boolean at least), and one
+    failing expression aborts the entire batch aggregate — every batched
+    stat for every column. Unverified dtypes keep the exact aggregate;
+    the memory blowup is dominated by high-cardinality string columns,
+    which are covered.
     """
     dt = col.type()
     if dt.is_string() or dt.is_integer() or dt.is_timestamp() or dt.is_date():
@@ -198,6 +209,9 @@ def nan_per(length: int, null_count: int) -> float:
 
 @stat()
 def distinct_per(length: int, distinct_count: int) -> float:
+    if distinct_count is None:
+        # Float columns skip distinct_count; the ratio is undefined.
+        return None
     if not length:
         return 0.0
     return distinct_count / length
@@ -292,6 +306,10 @@ def histogram(expr: XorqExpr, execute: XorqExecute, orig_col_name: str, is_numer
     (where ``min``/``max`` are filtered out by ``column_filter``) don't cascade-
     exclude this stat — the categorical branch ignores them.
 
+    ``distinct_count`` is ``None`` for float columns (the stat is skipped
+    there — see ``distinct_count``); floats always take the numeric
+    branch, where the <= 5 fallthrough rarely applied anyway.
+
     All queries go through the injected ``execute`` callable so a
     pipeline-supplied backend isn't bypassed.
 
@@ -301,7 +319,7 @@ def histogram(expr: XorqExpr, execute: XorqExecute, orig_col_name: str, is_numer
     """
     if length == 0:
         return []
-    if is_numeric and not is_bool and distinct_count > 5:
+    if is_numeric and not is_bool and (distinct_count is None or distinct_count > 5):
         return _numeric_histogram(execute, expr, orig_col_name, min, max)
     return _categorical_histogram(execute, expr, orig_col_name)
 
@@ -320,7 +338,11 @@ def histogram_bins(is_numeric: bool, is_bool: bool, distinct_count: int, min: fl
     An empty list causes that rule to fall back to ``inherit``, so non-numeric,
     boolean, low-cardinality, and degenerate columns are safely skipped.
     """
-    if not is_numeric or is_bool or distinct_count <= 5:
+    if not is_numeric or is_bool:
+        return []
+    # distinct_count is None for float columns (stat skipped there) —
+    # treat unknown cardinality as high enough to want bins.
+    if distinct_count is not None and distinct_count <= 5:
         return []
     if min is None or max is None:
         return []

--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -142,6 +142,25 @@ def max(col: XorqColumn) -> float:
 
 @stat()
 def distinct_count(col: XorqColumn) -> int:
+    """Approximate distinct count (HyperLogLog, ~1% error) where supported.
+
+    Exact COUNT(DISTINCT) folded into the shared batch aggregate defeats
+    DataFusion's single-distinct rewrite: 3.8GB peak on a 131M-row string
+    column with 6.2M distinct values vs 238MB for approx_nunique in the
+    same batch shape (#906). No consumer needs exactness — distinct_per
+    is displayed as a ratio, and the histogram branch thresholds
+    (distinct_count > 5 / <= 5) sit where HLL is exact in practice.
+
+    Allowlist, not denylist: DataFusion's approx_distinct raises for
+    unimplemented dtypes (Float64, Boolean at least), and one failing
+    expression aborts the entire batch aggregate — every batched stat for
+    every column. Unverified dtypes keep the exact aggregate; the memory
+    blowup is dominated by high-cardinality string columns, which are
+    covered.
+    """
+    dt = col.type()
+    if dt.is_string() or dt.is_integer() or dt.is_timestamp() or dt.is_date():
+        return col.approx_nunique().cast("int64")
     return col.nunique().cast("int64")
 
 

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -106,7 +106,8 @@ class XorqStatPipeline:
     # actual provider stat (e.g. ``min`` for numeric cols) is filtered
     # out by column_filter.
     EXTERNAL_KEYS = frozenset(
-        {"orig_col_name", "rewritten_col_name", "dtype", "length", "min", "max"})
+        {"orig_col_name", "rewritten_col_name", "dtype", "length", "min", "max",
+         "distinct_count"})
 
     def __init__(self, stat_funcs: list, backend: Any = None, unit_test: bool = True,
                  cache_storage=None):
@@ -330,11 +331,13 @@ class XorqStatPipeline:
         # keys. ``length`` is filled in by the batch query below. ``min`` /
         # ``max`` start as None so dependents (histogram) don't cascade-
         # exclude on non-numeric columns; ``min`` / ``max`` overwrite for
-        # numeric cols.
+        # numeric cols. ``distinct_count`` likewise starts as None so float
+        # columns (where the stat is column_filtered out) keep their
+        # dependents (histogram, histogram_bins, distinct_per) runnable.
         accumulators: Dict[str, Dict[str, StatResult]] = {}
         for col in columns:
             accumulators[col] = {"orig_col_name": Ok(col), "rewritten_col_name": Ok(col), "dtype": Ok(str(schema[col])),
-                "length": Ok(0), "min": Ok(None), "max": Ok(None)}
+                "length": Ok(0), "min": Ok(None), "max": Ok(None), "distinct_count": Ok(None)}
 
         # ---- Phase 1: batch aggregate ----------------------------------
         # ``length`` is a table-level scalar (same value for every column),

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -127,6 +127,25 @@ class TestBatchAggregate:
         assert stats["ints"]["distinct_count"] == 7
         assert stats["strs"]["distinct_count"] == 7
 
+    def test_distinct_count_uses_approx(self):
+        """distinct_count must build ApproxCountDistinct, not exact CountDistinct.
+
+        Exact COUNT(DISTINCT) folded into the shared batch aggregate defeats
+        DataFusion's single-distinct rewrite: 3.8GB peak on a 131M-row string
+        column with 6.2M distinct values, vs 238MB for approx_nunique in the
+        same batch shape (#906).
+        """
+        from xorq.vendor.ibis.expr import operations as ops
+
+        from buckaroo.customizations.xorq_stats_v2 import distinct_count
+
+        expr = distinct_count._stat_func.func(col=_make_table().strs)
+        op = expr.op()
+        assert list(op.find(ops.ApproxCountDistinct)), (
+            "distinct_count should aggregate via approx_nunique")
+        assert not list(op.find(ops.CountDistinct)), (
+            "exact COUNT(DISTINCT) must not enter the batch aggregate")
+
 
 # ============================================================
 # Numeric-only stats: mean, std, median

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -143,8 +143,29 @@ class TestBatchAggregate:
         op = expr.op()
         assert list(op.find(ops.ApproxCountDistinct)), (
             "distinct_count should aggregate via approx_nunique")
-        assert not list(op.find(ops.CountDistinct)), (
-            "exact COUNT(DISTINCT) must not enter the batch aggregate")
+        # ApproxCountDistinct subclasses CountDistinct, so filter it out to
+        # check no *exact* distinct aggregate remains.
+        exact = [n for n in op.find(ops.CountDistinct)
+                 if not isinstance(n, ops.ApproxCountDistinct)]
+        assert not exact, "exact COUNT(DISTINCT) must not enter the batch aggregate"
+
+    def test_distinct_count_exact_fallback_for_unsupported_dtypes(self):
+        """Dtypes without DataFusion approx_distinct support keep exact nunique.
+
+        approx_distinct raises for Float64 and Boolean, and one failing
+        expression aborts the whole batch aggregate — so unsupported dtypes
+        must fall back to the exact aggregate rather than error.
+        """
+        from xorq.vendor.ibis.expr import operations as ops
+
+        from buckaroo.customizations.xorq_stats_v2 import distinct_count
+
+        table = _make_table()
+        for colname in ("floats", "bools"):
+            expr = distinct_count._stat_func.func(col=table[colname])
+            op = expr.op()
+            assert not list(op.find(ops.ApproxCountDistinct)), colname
+            assert list(op.find(ops.CountDistinct)), colname
 
 
 # ============================================================

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -149,23 +149,41 @@ class TestBatchAggregate:
                  if not isinstance(n, ops.ApproxCountDistinct)]
         assert not exact, "exact COUNT(DISTINCT) must not enter the batch aggregate"
 
-    def test_distinct_count_exact_fallback_for_unsupported_dtypes(self):
-        """Dtypes without DataFusion approx_distinct support keep exact nunique.
+    def test_distinct_count_exact_fallback_for_bool(self):
+        """Booleans keep exact nunique — approx_distinct raises on Boolean.
 
-        approx_distinct raises for Float64 and Boolean, and one failing
-        expression aborts the whole batch aggregate — so unsupported dtypes
-        must fall back to the exact aggregate rather than error.
+        One failing expression aborts the whole batch aggregate, and exact
+        COUNT(DISTINCT bool) is trivially cheap (<= 3 entries of hash state),
+        so booleans must fall back to the exact aggregate rather than error.
         """
         from xorq.vendor.ibis.expr import operations as ops
 
         from buckaroo.customizations.xorq_stats_v2 import distinct_count
 
-        table = _make_table()
-        for colname in ("floats", "bools"):
-            expr = distinct_count._stat_func.func(col=table[colname])
-            op = expr.op()
-            assert not list(op.find(ops.ApproxCountDistinct)), colname
-            assert list(op.find(ops.CountDistinct)), colname
+        expr = distinct_count._stat_func.func(col=_make_table().bools)
+        op = expr.op()
+        assert not list(op.find(ops.ApproxCountDistinct))
+        assert list(op.find(ops.CountDistinct))
+
+    def test_distinct_count_skipped_for_floats(self):
+        """Float columns skip distinct_count entirely.
+
+        approx_distinct raises on Float64, and exact COUNT(DISTINCT) costs
+        memory proportional to cardinality (~2.2GB measured on a 30M-distinct
+        column) for a number that is rarely meaningful on floats. The stat is
+        skipped: distinct_count and distinct_per resolve to None, while the
+        numeric histogram and histogram_bins must still be produced.
+        """
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(_make_table())
+        assert errors == []
+        assert stats["floats"]["distinct_count"] is None
+        assert stats["floats"]["distinct_per"] is None
+        assert len(stats["floats"]["histogram"]) > 0
+        assert len(stats["floats"]["histogram_bins"]) == 11
+        # non-float columns are unaffected
+        assert stats["ints"]["distinct_count"] == 7
+        assert stats["strs"]["distinct_per"] == 1.0
 
 
 # ============================================================


### PR DESCRIPTION
Fixes #906.

Exact `COUNT(DISTINCT col)` folded into the shared batch aggregate (alongside `count(*)` and the other batched stats) defeats DataFusion's single-distinct rewrite. Measured on a 131.7M-row string column with 6.18M distinct values: 3,750MB peak RSS for the batch shape vs 775MB for `nunique` standalone vs 238MB for `approx_nunique` in the same batch shape (~1% error). Details and repro in #906.

Dispatch by dtype:
- **string / integer / timestamp / date** → `approx_nunique` (allowlist of dtypes verified supported by DataFusion's `approx_distinct`; one failing expression aborts the entire batch aggregate, so unverified dtypes must not guess).
- **float** → skipped entirely (per review): `approx_distinct` raises on Float64, the exact aggregate costs memory proportional to cardinality (~2.2GB measured at 30M distinct), and nunique on floats is rarely meaningful. The pipeline pre-populates `distinct_count` as `None` (same pattern as `min`/`max` on non-numeric columns) so float columns keep their numeric histogram and `histogram_bins`; `distinct_per` resolves to `None`.
- **everything else (boolean, decimal, ...)** → exact `nunique` (boolean is ≤3 hash entries by construction; other dtypes are rare and keep current behavior).

`distinct_count` feeds `distinct_per` and the histogram branch threshold (`distinct_count > 5`) — neither needs exactness, and HLL is exact in practice at low cardinality, so branch behavior for small columns is unchanged.

Row count is not available when the batched expressions are built (`length` is computed by the same aggregate query), so there is no size-based exact/approx dispatch here — see #911 for that mechanism.

TDD: each behavior change landed as a failing test first (red on CI), then the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)