### PR TITLE
fix(stats): sample the categorical histogram input above 100k rows

### DIFF
--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -238,9 +238,25 @@ def _numeric_histogram(execute: Callable[[Any], pd.DataFrame], expr: Any, col: s
     return out
 
 
-def _categorical_histogram(execute: Callable[[Any], pd.DataFrame], expr: Any, col: str) -> list:
+# Above this many rows the exact top-10 query is replaced by one over a
+# ~CATEGORICAL_HISTOGRAM_SAMPLE_ROWS row sample. The exact query holds a
+# hash entry per distinct value just to return 10 rows — ~1GB transient
+# per high-cardinality string column (#907). Sampling bounds the group-by
+# input (and therefore the hash state) to the sample size.
+CATEGORICAL_HISTOGRAM_EXACT_MAX_ROWS = 100_000
+CATEGORICAL_HISTOGRAM_SAMPLE_ROWS = 100_000
+
+
+def _categorical_histogram(execute: Callable[[Any], pd.DataFrame], expr: Any, col: str,
+        length: int = 0) -> list:
+    source = expr
+    if length > CATEGORICAL_HISTOGRAM_EXACT_MAX_ROWS:
+        # ``seed`` is unsupported on the DataFusion backend, so the sample
+        # (and the resulting cat_pop estimates) varies run to run. With
+        # cache_storage set the first run's snapshot is what gets reused.
+        source = expr.sample(CATEGORICAL_HISTOGRAM_SAMPLE_ROWS / length)
     query = (
-        expr.group_by(col)
+        source.group_by(col)
         .aggregate(__count=lambda t: t.count())
         .order_by(xo.desc("__count"))
         .limit(10)
@@ -284,7 +300,7 @@ def histogram(expr: XorqExpr, execute: XorqExecute, orig_col_name: str, is_numer
         return []
     if is_numeric and not is_bool and distinct_count > 5:
         return _numeric_histogram(execute, expr, orig_col_name, min, max)
-    return _categorical_histogram(execute, expr, orig_col_name)
+    return _categorical_histogram(execute, expr, orig_col_name, length)
 
 
 @stat(default=[])

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -215,6 +215,39 @@ class TestHistogram:
         total_pop = sum(b["cat_pop"] for b in h)
         assert abs(total_pop - 100.0) < 0.6  # per-bucket 1dp rounding drift
 
+    def test_categorical_histogram_bounded_above_100k_rows(self):
+        """Above 100k rows the categorical histogram must sample, not group the full table.
+
+        The exact top-10 query (group_by(col).count().order_by(desc).limit(10))
+        materializes a hash entry per distinct value: ~1GB transient per
+        high-cardinality string column on a 26M-row table (#907). Above the
+        100k-row threshold the group-by input must be bounded by a Sample
+        node; at or below the threshold the exact query is preserved.
+        """
+        from xorq.vendor.ibis.expr import operations as ops
+
+        from buckaroo.customizations.xorq_stats_v2 import histogram
+
+        fn = histogram._stat_func.func
+        table = _make_table_categorical()
+        captured = []
+
+        def execute(query):
+            captured.append(query)
+            return query.execute()
+
+        fn(expr=table, execute=execute, orig_col_name="cat", is_numeric=False,
+           is_bool=False, length=200_000, distinct_count=8, min=None, max=None)
+        assert len(captured) == 1
+        assert list(captured[0].op().find(ops.Sample)), (
+            "categorical histogram over >100k rows must bound its input with a sample")
+
+        small = fn(expr=table, execute=execute, orig_col_name="cat", is_numeric=False,
+            is_bool=False, length=11, distinct_count=8, min=None, max=None)
+        assert not list(captured[1].op().find(ops.Sample)), (
+            "at or below 100k rows the exact top-10 query must be preserved")
+        assert [b["name"] for b in small][0] == "a"
+
     def test_histogram_constant_column_empty(self):
         """Constant numeric column (min == max) → empty histogram, not crash."""
         table = xo.memtable(pd.DataFrame({"const": [7, 7, 7, 7]}))

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -248,6 +248,23 @@ class TestHistogram:
             "at or below 100k rows the exact top-10 query must be preserved")
         assert [b["name"] for b in small][0] == "a"
 
+    def test_categorical_histogram_sampled_finds_dominant_value(self):
+        """Sampled top-10 still surfaces the dominant category above the threshold.
+
+        Half the rows share one value, the rest are unique — any ~100k-row
+        sample puts the shared value on top with cat_pop near 100 (the other
+        top-10 entries are singletons).
+        """
+        n = 150_000
+        vals = ["common"] * (n // 2) + [f"u{i}" for i in range(n - n // 2)]
+        table = xo.memtable(pd.DataFrame({"cat": vals}))
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        stats, errors = pipeline.process_table(table)
+        assert errors == []
+        h = stats["cat"]["histogram"]
+        assert h[0]["name"] == "common"
+        assert h[0]["cat_pop"] > 90
+
     def test_histogram_constant_column_empty(self):
         """Constant numeric column (min == max) → empty histogram, not crash."""
         table = xo.memtable(pd.DataFrame({"const": [7, 7, 7, 7]}))


### PR DESCRIPTION
Fixes #907.

`_categorical_histogram` runs `group_by(col).count().order_by(desc).limit(10)` over the full table — a hash entry per distinct value to return 10 rows. Measured 841–949MB transient per high-cardinality string column (6.2M distinct), one query per non-numeric column. Details and repro in #907.

`histogram` already receives `length` resolved from the batch aggregate, so this dispatches on size: at or below 100,000 rows the exact query is unchanged; above it the group-by input is bounded to a ~100k-row sample (`Table.sample`), making `cat_pop` a sample estimate. The numeric histogram path is untouched (already bounded at 10 buckets).

First commit is the failing test (TDD); fix follows after CI confirms the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)