### PR TITLE
fix(stats): materialize the stat source only for chained sources (#915)

### DIFF
--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -101,6 +101,45 @@ def _is_batch_func(sf: StatFunc) -> bool:
     return True
 
 
+# Relational ops whose result a per-column re-scan recomputes expensively, so
+# materialising the source once amortises across the per-column histogram
+# queries. Everything else — scans, projections, unions, limits — streams
+# cheaply via predicate + projection pushdown, so materialising it is pure
+# overhead, and multi-GB of resident overhead on a wide or tall source (#915).
+# Resolved by name so an op renamed/absent across ibis versions is skipped
+# rather than raising.
+_MATERIALIZE_WORTHY_OP_NAMES = (
+    "Filter", "Aggregate", "JoinChain", "JoinLink", "Distinct", "Sort", "DropNull")
+
+
+def _materialize_worthy_ops():
+    if not HAS_XORQ:
+        return ()
+    from xorq.vendor.ibis.expr import operations as ops  # noqa: PLC0415
+    return tuple(getattr(ops, n) for n in _MATERIALIZE_WORTHY_OP_NAMES if hasattr(ops, n))
+
+
+def _source_worth_materializing(source) -> bool:
+    """True if the source op tree carries a chain — filter / aggregate / join /
+    distinct / sort / drop_null — whose re-execution per per-column query
+    materialising the source once would avoid.
+
+    A source built only from scans, projections, unions and limits streams
+    cheaply, so materialising it is pure overhead (#915). The check is op-tree
+    based, hence independent of how the expression was spelled (``.filter`` vs
+    ``[bool]``, ``group_by().agg`` vs ``.agg`` vs ``.count``, any ``*_join``).
+
+    Conservative: a classification failure returns False (stream). Streaming is
+    memory-safe; the unbounded in-memory copy is the failure mode we avoid."""
+    worthy = _materialize_worthy_ops()
+    if not worthy:
+        return False
+    try:
+        return bool(list(source.op().find(worthy)))
+    except Exception:
+        return False
+
+
 class XorqStatPipeline:
     """v2 stat pipeline for ``ibis.Table`` inputs.
 
@@ -277,6 +316,12 @@ class XorqStatPipeline:
         # materialisation scan would be pure overhead.
         if not any(not _is_batch_func(sf) for sf in self.ordered_stat_funcs):
             return None
+        # Only worth materialising when re-scanning would recompute an expensive
+        # chain (filter / aggregate / join / …). A scan / projection / union
+        # streams cheaply; materialising a wide or tall one is multi-GB of pure
+        # overhead (#915).
+        if not _source_worth_materializing(source):
+            return None
 
         name = f"__buckaroo_histo_mat_{uuid.uuid4().hex[:12]}"
         mat = self._create_base_table(underlying, name, source)
@@ -358,6 +403,11 @@ class XorqStatPipeline:
         # would re-execute the filter chain), materialization is just
         # wasted work — skip it.
         if not any(not _is_batch_func(sf) for sf in self.ordered_stat_funcs):
+            return table, None
+        # Only worth materialising when the source carries an expensive chain
+        # (filter / aggregate / join / …) a per-column re-scan would recompute;
+        # a scan / projection / union streams cheaply (#915).
+        if not _source_worth_materializing(table):
             return table, None
         name = f"__buckaroo_histo_mat_{uuid.uuid4().hex[:12]}"
         new_table = self._create_base_table(underlying, name, table)

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -106,10 +106,13 @@ def _is_batch_func(sf: StatFunc) -> bool:
 # queries. Everything else — scans, projections, unions, limits — streams
 # cheaply via predicate + projection pushdown, so materialising it is pure
 # overhead, and multi-GB of resident overhead on a wide or tall source (#915).
+# ``Sample`` is here for correctness, not just cost: an unseeded sample
+# re-drawn per query would compute length/min/max/histogram over different row
+# sets, so the run must share a single materialised sample.
 # Resolved by name so an op renamed/absent across ibis versions is skipped
 # rather than raising.
 _MATERIALIZE_WORTHY_OP_NAMES = (
-    "Filter", "Aggregate", "JoinChain", "JoinLink", "Distinct", "Sort", "DropNull")
+    "Filter", "Aggregate", "JoinChain", "JoinLink", "Distinct", "Sort", "DropNull", "Sample")
 
 
 def _materialize_worthy_ops():
@@ -121,8 +124,9 @@ def _materialize_worthy_ops():
 
 def _source_worth_materializing(source) -> bool:
     """True if the source op tree carries a chain — filter / aggregate / join /
-    distinct / sort / drop_null — whose re-execution per per-column query
-    materialising the source once would avoid.
+    distinct / sort / drop_null / sample — whose re-execution per per-column
+    query materialising the source once would avoid (and, for an unseeded
+    sample, must avoid so every stat sees the same rows).
 
     A source built only from scans, projections, unions and limits streams
     cheaply, so materialising it is pure overhead (#915). The check is op-tree

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -903,11 +903,15 @@ class TestMaterializeHeuristic:
         assert stats["misses"] > 0 and stats["snapshots"] == stats["misses"]
         assert {"n", "cat"} <= set(summary)
 
-    @pytest.mark.parametrize("shape", ["filter", "aggregate", "agg-shorthand", "distinct"])
+    @pytest.mark.parametrize("shape", ["filter", "aggregate", "agg-shorthand", "distinct", "sample"])
     def test_chain_source_is_materialized(self, shape, tmp_path):
         t = self._base()
         src = {"filter": t.filter(t.n > 1), "aggregate": t.group_by("cat").aggregate(c=t.count()),
-            "agg-shorthand": t.group_by("cat").count(), "distinct": t.select("cat").distinct()}[shape]
+            "agg-shorthand": t.group_by("cat").count(), "distinct": t.select("cat").distinct(),
+            # A sample source MUST materialize: an unseeded sample re-drawn per
+            # per-column query would compute length/min/max/histogram over
+            # different rows (Codex review on #916).
+            "sample": t.sample(0.5)}[shape]
         stats, _ = self._run(src, tmp_path)
         assert stats["materialized"] is True, (
             f"a {shape} source carries an expensive chain — materialize once (#915)")

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -859,3 +859,55 @@ class TestSnapshotCacheRun:
         for col in plain:
             for key in ("length", "min", "max", "mean", "null_count", "distinct_count"):
                 assert cold[col].get(key) == plain[col].get(key), (col, key)
+
+
+class TestMaterializeHeuristic:
+    """#915: materialize the source only when its op tree carries an expensive
+    chain (filter / aggregate / join / distinct / sort / drop_null) worth
+    amortising across the per-column queries. A scan / projection / union /
+    limit streams cheaply via predicate + projection pushdown, so materialising
+    it is pure overhead — and multi-GB of resident overhead on a wide or tall
+    source (#915, e.g. a 131M-row union or a 24M×20 read landing 25GB in RAM).
+
+    The decision is op-tree based, so it is independent of how the expression
+    was spelled — hence the parametrised formation styles below."""
+
+    @staticmethod
+    def _cache(tmp_path):
+        return xo.ParquetSnapshotCache.from_kwargs(
+            source=xo.connect(), base_path=str(tmp_path))
+
+    @staticmethod
+    def _base():
+        con = xo.connect()
+        df = pd.DataFrame(
+            {"n": list(range(40)), "cat": [c for c in "abcdefgh" for _ in range(5)]})
+        return con.create_table("heur_src", df)
+
+    def _run(self, src, tmp_path):
+        p = XorqStatPipeline(
+            XORQ_STATS_V2, unit_test=False, cache_storage=self._cache(tmp_path))
+        summary, _ = p.process_table(src)
+        return p._cache_stats, summary
+
+    @pytest.mark.parametrize("shape", ["union", "projection", "column-list", "limit"])
+    def test_cheap_source_streams_not_materialized(self, shape, tmp_path):
+        t = self._base()
+        src = {"union": t.select("n", "cat").union(t.select("n", "cat")), "projection": t.select("n", "cat"),
+            "column-list": t[["n", "cat"]], "limit": t.limit(30)}[shape]
+        stats, summary = self._run(src, tmp_path)
+        assert stats["materialized"] is False, (
+            f"a {shape} source has no chain to amortise — must stream, not "
+            f"materialize into RAM (#915)")
+        # still a real cold run: stats computed and snapshots written
+        assert stats["misses"] > 0 and stats["snapshots"] == stats["misses"]
+        assert {"n", "cat"} <= set(summary)
+
+    @pytest.mark.parametrize("shape", ["filter", "aggregate", "agg-shorthand", "distinct"])
+    def test_chain_source_is_materialized(self, shape, tmp_path):
+        t = self._base()
+        src = {"filter": t.filter(t.n > 1), "aggregate": t.group_by("cat").aggregate(c=t.count()),
+            "agg-shorthand": t.group_by("cat").count(), "distinct": t.select("cat").distinct()}[shape]
+        stats, _ = self._run(src, tmp_path)
+        assert stats["materialized"] is True, (
+            f"a {shape} source carries an expensive chain — materialize once (#915)")


### PR DESCRIPTION
## Summary

Fixes #915. #913 materialised the stat-cache source into an in-memory DataFusion table on every snapshot miss, gated only on op *type* (skip base tables) — never on whether materialising pays off. A 131M-row union landed ~25GB in RAM with no time win, and any plain `read_parquet` did too.

This gates materialisation on the source **op tree**: materialise only when it carries a chain — filter / aggregate / join / distinct / sort / drop_null — whose re-execution per per-column query the one-time materialisation avoids. A source built only from scans / projections / unions / limits streams cheaply via predicate + projection pushdown, so materialising it is pure overhead. Applied to both the cache path (`_ensure_cache_materialization`) and the no-cache path (`_maybe_materialize`).

Because the decision is op-tree based (`source.op().find(...)`), it is independent of how the expression was spelled — `.filter` vs `[bool]`, `group_by().aggregate` vs `.agg` vs `.count`, any `*_join` all collapse to the same `Filter` / `Aggregate` / `JoinChain` ops. Op classes are resolved by name, so one renamed/absent across ibis versions is skipped rather than raising. Conservative on failure: anything it can't classify streams (memory-safe), since the unbounded in-memory copy is the failure mode being avoided.

## Verified

Parking demo, cold snapshot cache, fresh process:

| source | shape | before (#913) | after |
|---|---|---|---|
| union of two parquets | 131,666,457 × 4 | `materialized=True`, ~25GB | **`materialized=False`, 347MB, 2.2s** |
| filter chain (existing test) | small | `materialized=True` | `materialized=True` (unchanged) |

`tests/unit/test_xorq_stats_v2.py` (62) and the broader xorq / stat / cache suite (494) pass.

## Scope — what this does *not* fix

The heuristic only decides whether to copy the source into RAM. A wide all-string read — the parking demo's 23.9M-row × 20-`large_string` `camera_violations` — measures ~25GB **whether materialised or streamed**, because the cost there is the per-column / batch stat work over 20 high-cardinality string columns (the single batch aggregate decompresses every column at once), not the materialisation. This PR correctly stops materialising it (no longer pays the copy on top) but does not address that wide-string stat cost — worth a separate issue. #915 is updated to reflect this; the union is the clean materialisation case.

## Test plan

- [x] `TestMaterializeHeuristic::test_cheap_source_streams_not_materialized` — union / projection / column-list / limit (failing before this change)
- [x] `TestMaterializeHeuristic::test_chain_source_is_materialized` — filter / aggregate / agg-shorthand / distinct
- [x] existing `TestMaterialization` + `TestSnapshotCacheRun` (filter chain and cached join still materialise)
