### PR TITLE
feat(stats): perf/memory smoke tests for summary stats (perf_smoke_test)

### DIFF
--- a/buckaroo/pluggable_analysis_framework/perf_smoke.py
+++ b/buckaroo/pluggable_analysis_framework/perf_smoke.py
@@ -1,0 +1,197 @@
+"""Perf/memory smoke testing for summary stats.
+
+``StatPipeline.unit_test()`` runs stats against the 10-row PERVERSE_DF and
+catches raised errors. Nothing catches a stat that is *correct but
+pathological* — a per-row python loop, an O(n^2) algorithm, a huge
+intermediate allocation. Those sail through a 10-row unit test and only
+surface as a hung widget or an OOM on real data. User- and LLM/MCP-authored
+stats (``add_analysis``, project stat dirs) are the usual source.
+
+``perf_smoke_test()`` runs each stat against a seeded synthetic frame and
+flags per-stat wall-time and peak-memory blowups::
+
+    from buckaroo.pluggable_analysis_framework.perf_smoke import perf_smoke_test
+
+    passed, findings = perf_smoke_test([MyStatClass, my_stat_func])
+    for f in findings:
+        print(f.message)
+
+Pass the same stat list you would hand to a widget or pipeline — stats that
+``require`` keys from other stats need their providers in the list.
+
+Design notes:
+
+- Limits are machine-relative: the time limit is a ratio against canonical
+  pandas ops timed on the same frame on the same machine (plus an absolute
+  floor), so the check behaves the same on a fast laptop and a slow CI
+  runner. The memory limit is a ratio against the input frame's size, also
+  floored.
+- Stats run at a small scale first, then full scale, and a flagged stat is
+  never run again — a quadratic stat can't make the smoke test itself run
+  away.
+- Errors raised by stats are ignored here; that's ``unit_test()``'s job.
+- Peak memory is measured with ``tracemalloc``, which sees numpy/pandas
+  allocations. Polars/Arrow-native allocations are invisible to it; this
+  harness targets the pandas pipeline.
+"""
+from __future__ import annotations
+
+import dataclasses
+import time
+import tracemalloc
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import numpy as np
+import pandas as pd
+
+from .stat_pipeline import StatPipeline, _normalize_inputs
+from .stat_func import StatFunc
+
+DEFAULT_ROWS = 10_000
+MEMORY_FLOOR_BYTES = 20_000_000
+
+
+def make_smoke_df(rows: int = DEFAULT_ROWS, seed: int = 42) -> pd.DataFrame:
+    """Seeded synthetic frame exercising the shapes stats commonly choke on:
+    plain ints, floats with nans, low-cardinality strings (categorical-ish),
+    and all-distinct strings (worst case for value_counts-style work)."""
+    rng = np.random.default_rng(seed)
+    return pd.DataFrame({'int_col': rng.integers(0, 1_000, rows),
+        'float_col': np.where(rng.random(rows) < 0.05, np.nan, rng.random(rows)),
+        'str_low_card': pd.Series(rng.integers(0, 20, rows)).map('cat_{}'.format),
+        'str_high_card': [f'id_{i:08d}' for i in range(rows)]})
+
+
+@dataclass
+class SmokeFinding:
+    stat_name: str
+    column: str
+    kind: str  # 'time' | 'memory'
+    measured: float  # seconds for 'time', bytes for 'memory'
+    limit: float
+    rows: int
+    message: str
+
+
+class _SmokeSkip(Exception):
+    """Raised inside a wrapped stat that was already flagged, so the pipeline
+    records an Err instead of running the pathological code again."""
+
+
+def _baseline_seconds(df: pd.DataFrame) -> float:
+    """Time canonical per-column pandas work on the smoke frame. A reasonable
+    stat does far less than this; the time limit is a multiple of it."""
+    def work():
+        for col in df.columns:
+            ser = df[col]
+            ser.value_counts()
+            ser.sort_values()
+            ser.nunique()
+
+    work()  # warm caches so the measured pass isn't paying first-call cost
+    t0 = time.perf_counter()
+    work()
+    return time.perf_counter() - t0
+
+
+class _Recorder:
+    """Shared state between perf_smoke_test and the wrapped stat funcs:
+    current column/scale/limits going in, findings and flagged stats out."""
+
+    def __init__(self):
+        self.findings: List[SmokeFinding] = []
+        self.flagged: set = set()
+        self.column = '<unknown>'
+        self.rows = 0
+        self.time_limit = float('inf')
+        self.memory_limit = float('inf')
+
+    def configure(self, rows: int, time_limit: float, memory_limit: float) -> None:
+        self.rows = rows
+        self.time_limit = time_limit
+        self.memory_limit = memory_limit
+
+    def record(self, stat_name: str, seconds: float, peak_bytes: float) -> None:
+        if seconds > self.time_limit:
+            self.flagged.add(stat_name)
+            self.findings.append(SmokeFinding(
+                stat_name=stat_name, column=self.column, kind='time', measured=seconds,
+                limit=self.time_limit, rows=self.rows,
+                message=(
+                    f"stat '{stat_name}' took {seconds:.2f}s on column '{self.column}' "
+                    f"of a {self.rows}-row frame (limit {self.time_limit:.2f}s). "
+                    f"Likely a per-row python loop or an O(n^2) algorithm — "
+                    f"vectorize with pandas/numpy operations.")))
+        if peak_bytes > self.memory_limit:
+            self.flagged.add(stat_name)
+            self.findings.append(SmokeFinding(
+                stat_name=stat_name, column=self.column, kind='memory', measured=peak_bytes,
+                limit=self.memory_limit, rows=self.rows,
+                message=(
+                    f"stat '{stat_name}' allocated a peak of {peak_bytes / 1e6:.0f}MB on column "
+                    f"'{self.column}' of a {self.rows}-row frame (limit {self.memory_limit / 1e6:.0f}MB). "
+                    f"Avoid materializing large intermediates (pairwise matrices, "
+                    f"cross joins, full copies per row).")))
+
+
+def _wrap(sf: StatFunc, recorder: _Recorder) -> StatFunc:
+    inner = sf.func
+
+    def measured(*args, **kwargs):
+        if sf.name in recorder.flagged:
+            raise _SmokeSkip(f"'{sf.name}' skipped after an earlier perf finding")
+        before_bytes = tracemalloc.get_traced_memory()[0]
+        tracemalloc.reset_peak()
+        t0 = time.perf_counter()
+        try:
+            return inner(*args, **kwargs)
+        finally:
+            elapsed = time.perf_counter() - t0
+            peak = tracemalloc.get_traced_memory()[1] - before_bytes
+            recorder.record(sf.name, elapsed, peak)
+
+    return dataclasses.replace(sf, func=measured)
+
+
+def perf_smoke_test(stat_funcs: list, rows: int = DEFAULT_ROWS, max_time_ratio: float = 20.0,
+        time_floor_seconds: float = 0.25, max_memory_ratio: float = 20.0,
+        memory_floor_bytes: float = MEMORY_FLOOR_BYTES) -> Tuple[bool, List[SmokeFinding]]:
+    """Smoke-test stats for perf/memory pathologies on synthetic data.
+
+    Accepts the same mixed input as StatPipeline (StatFunc, @stat functions,
+    stat group classes, ColAnalysis subclasses). Returns
+    ``(passed, findings)`` mirroring ``unit_test()``'s shape.
+
+    A stat is flagged when a single per-column call exceeds
+    ``max(time_floor_seconds, max_time_ratio * baseline)`` wall-time or
+    ``max(memory_floor_bytes, max_memory_ratio * frame_bytes)`` peak traced
+    memory. Defaults are deliberately loose — this catches
+    order-of-magnitude blowups, not 2x regressions.
+    """
+    recorder = _Recorder()
+    wrapped = [_wrap(sf, recorder) for sf in _normalize_inputs(stat_funcs)]
+    pipeline = StatPipeline(wrapped, unit_test=False)
+
+    was_tracing = tracemalloc.is_tracing()
+    if not was_tracing:
+        tracemalloc.start()
+    try:
+        small = max(500, rows // 10)
+        scales = [small, rows] if small < rows else [rows]
+        for n in scales:
+            df = make_smoke_df(n)
+            baseline = _baseline_seconds(df)
+            recorder.configure(
+                rows=n,
+                time_limit=max(time_floor_seconds, max_time_ratio * baseline),
+                memory_limit=max(memory_floor_bytes,
+                                 max_memory_ratio * float(df.memory_usage(deep=True).sum())))
+            for col in df.columns:
+                recorder.column = col
+                pipeline.process_df(df[[col]])
+    finally:
+        if not was_tracing:
+            tracemalloc.stop()
+
+    return (not recorder.findings), recorder.findings

--- a/tests/unit/perf_smoke_test.py
+++ b/tests/unit/perf_smoke_test.py
@@ -1,0 +1,66 @@
+"""Tests for perf_smoke_test — perf/memory smoke testing of summary stats.
+
+StatPipeline.unit_test() runs stats against the 10-row PERVERSE_DF and only
+catches raised errors. perf_smoke_test() catches stats that are *correct but
+pathological* — per-row python loops, O(n^2) algorithms, huge intermediate
+allocations — which is what user- and LLM/MCP-authored stats tend to get
+wrong.
+"""
+
+import numpy as np
+
+from buckaroo.pluggable_analysis_framework.perf_smoke import perf_smoke_test
+from buckaroo.pluggable_analysis_framework.stat_func import stat, RawSeries
+
+
+@stat()
+def smoke_length(ser: RawSeries) -> int:
+    return len(ser)
+
+
+@stat()
+def smoke_null_count(ser: RawSeries) -> int:
+    return int(ser.isna().sum())
+
+
+def test_well_behaved_stats_pass():
+    passed, findings = perf_smoke_test([smoke_length, smoke_null_count], rows=2_000)
+    assert passed is True
+    assert findings == []
+
+
+def test_slow_stat_flagged():
+    # The classic LLM-authored shape: a nested python loop over the series.
+    # Quadratic, so it sails through the 10-row unit_test but is unusable on
+    # real data.
+    @stat()
+    def slow_pairwise(ser: RawSeries) -> int:
+        total = 0
+        for v in ser:
+            for w in ser:
+                if v == w:
+                    total += 1
+        return total
+
+    passed, findings = perf_smoke_test([slow_pairwise], rows=2_000)
+    assert passed is False
+    time_findings = [f for f in findings if f.kind == 'time' and f.stat_name == 'slow_pairwise']
+    assert time_findings
+    assert 'slow_pairwise' in time_findings[0].message
+    # Once flagged, the stat must not keep running: at most one time finding
+    # per scale, not one per column.
+    assert len(time_findings) <= 2
+
+
+def test_memory_hog_flagged():
+    # ~64MB scratch allocation on a ~0.3MB input frame.
+    @stat()
+    def memory_hog(ser: RawSeries) -> float:
+        scratch = np.ones((len(ser), 4_000))
+        return float(scratch.sum())
+
+    passed, findings = perf_smoke_test([memory_hog], rows=2_000)
+    assert passed is False
+    mem_findings = [f for f in findings if f.kind == 'memory' and f.stat_name == 'memory_hog']
+    assert mem_findings
+    assert 'memory_hog' in mem_findings[0].message


### PR DESCRIPTION
## Problem

`StatPipeline.unit_test()` runs stats against the 10-row `PERVERSE_DF` and catches raised errors. Nothing catches a stat that is *correct but pathological* — a per-row python loop, an O(n²) algorithm, or a huge intermediate allocation. Those sail through the 10-row unit test and only surface as a hung widget or an OOM on real data.

This matters most for user- and LLM/MCP-authored stats added via `add_analysis` or project stat dirs: the author often doesn't anticipate scaling problems, and there is no authoring-time feedback. (#903 covers a different class of the same authoring problem — non-deterministic expressions on the xorq side; this PR covers the perf/memory class on the pandas pipeline. #127 was a coarse widget-level version of this idea back in 2023.)

## What this adds

`buckaroo.pluggable_analysis_framework.perf_smoke.perf_smoke_test(stat_funcs, ...)` — a callable smoke harness:

- builds a seeded synthetic frame (`make_smoke_df`: int, float-with-nans, low-cardinality string, high-cardinality string)
- wraps each `StatFunc` with wall-time + `tracemalloc` peak-memory instrumentation (no changes to `stat_pipeline.py`)
- runs at a small scale first, then full scale; a stat flagged at either scale is not run again, so a quadratic stat can't make the smoke test itself run away
- limits are machine-relative (ratio against canonical pandas ops timed on the same frame, plus absolute floors), so the check behaves the same on a fast laptop and a slow CI runner
- returns `(passed, findings)` where each finding names the stat, the column, the measured value vs the limit, and a hint about the likely cause — written to be actionable for an LLM author

Errors raised by stats are intentionally out of scope (that's `unit_test()`'s job); xorq-side perf is a backend/SQL concern and stays out of scope too.

## TDD

First commit is the failing tests only; the implementation follows after CI shows them failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


First cut of #920, which tracks the follow-ups: dataset variety, a CI per-stat time/memory report, and smoke-testing stats added at runtime.
