### PR TITLE
fix(stats): classify distinct_count by approx support across all arrow dtypes (#918)

### DIFF
--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -56,8 +56,18 @@ def _is_numeric_not_bool(dtype) -> bool:
     return dtype.is_numeric() and not dtype.is_boolean()
 
 
-def _not_float(dtype) -> bool:
-    return not dtype.is_floating()
+def _distinct_count_supported(dtype) -> bool:
+    """Columns distinct_count runs on. Skips floats and nested types.
+
+    approx_distinct raises on both Float64 and nested (struct/array/map) types,
+    so they fall to exact COUNT(DISTINCT). On a high-cardinality column that is
+    the multi-GB hash set #906 fixed for strings — ~25GB measured streaming the
+    stats over a 24M-row ``struct<url, description>`` column, all of it the
+    exact distinct on that one column. #908 only routed scalar string / integer
+    / timestamp / date to approx; nested types kept the exact aggregate and so
+    inherited the same blowup. A distinct count over a struct is rarely
+    meaningful anyway. Booleans/decimals stay (low-cardinality in practice)."""
+    return not (dtype.is_floating() or dtype.is_nested())
 
 
 # ============================================================
@@ -144,7 +154,7 @@ def max(col: XorqColumn) -> float:
     return col.max().cast("float64")
 
 
-@stat(column_filter=_not_float)
+@stat(column_filter=_distinct_count_supported)
 def distinct_count(col: XorqColumn) -> int:
     """Approximate distinct count (HyperLogLog, ~1% error) where supported.
 
@@ -155,19 +165,19 @@ def distinct_count(col: XorqColumn) -> int:
     is displayed as a ratio, and the histogram branch thresholds
     (distinct_count > 5 / <= 5) sit where HLL is exact in practice.
 
-    Float columns skip the stat entirely (column_filter): DataFusion's
-    approx_distinct raises on Float64, exact COUNT(DISTINCT) costs memory
-    proportional to cardinality (~2.2GB measured on a 30M-distinct float
-    column), and a distinct count over floats is rarely meaningful. The
-    pipeline pre-populates ``distinct_count`` as None so dependents
-    (histogram, histogram_bins, distinct_per) still run.
+    Float and nested (struct/array/map) columns skip the stat entirely
+    (column_filter — see ``_distinct_count_supported``): approx_distinct raises
+    on both, so they fall to exact COUNT(DISTINCT), whose memory is proportional
+    to cardinality (~2.2GB on a 30M-distinct float; ~25GB on a 24M-row
+    high-cardinality struct), and a distinct count over either is rarely
+    meaningful. The pipeline pre-populates ``distinct_count`` as None so
+    dependents (histogram, histogram_bins, distinct_per) still run.
 
-    Allowlist, not denylist, for the remaining dtypes: approx_distinct
-    raises for other unimplemented dtypes too (Boolean at least), and one
-    failing expression aborts the entire batch aggregate — every batched
-    stat for every column. Unverified dtypes keep the exact aggregate;
-    the memory blowup is dominated by high-cardinality string columns,
-    which are covered.
+    For the dtypes that remain, approx_distinct still raises on some (Boolean at
+    least), and one failing expression aborts the entire batch aggregate — every
+    batched stat for every column. So only the verified scalar dtypes below take
+    the approx path; the rest (Boolean, decimal, …) keep the exact aggregate,
+    which is bounded for the low-cardinality types that reach it.
     """
     dt = col.type()
     if dt.is_string() or dt.is_integer() or dt.is_timestamp() or dt.is_date():

--- a/buckaroo/customizations/xorq_stats_v2.py
+++ b/buckaroo/customizations/xorq_stats_v2.py
@@ -56,18 +56,31 @@ def _is_numeric_not_bool(dtype) -> bool:
     return dtype.is_numeric() and not dtype.is_boolean()
 
 
-def _distinct_count_supported(dtype) -> bool:
-    """Columns distinct_count runs on. Skips floats and nested types.
+def _distinct_count_approx(dtype) -> bool:
+    """Dtypes xorq-datafusion's approx_distinct (HyperLogLog, bounded memory)
+    supports, verified empirically across the arrow dtypes (#918): integer,
+    string (dictionary columns decode to string), binary, and temporal
+    (date / time / timestamp). approx_distinct raises on float, decimal,
+    boolean and nested types."""
+    return (dtype.is_integer() or dtype.is_string() or dtype.is_binary()
+            or dtype.is_temporal())
 
-    approx_distinct raises on both Float64 and nested (struct/array/map) types,
-    so they fall to exact COUNT(DISTINCT). On a high-cardinality column that is
-    the multi-GB hash set #906 fixed for strings — ~25GB measured streaming the
-    stats over a 24M-row ``struct<url, description>`` column, all of it the
-    exact distinct on that one column. #908 only routed scalar string / integer
-    / timestamp / date to approx; nested types kept the exact aggregate and so
-    inherited the same blowup. A distinct count over a struct is rarely
-    meaningful anyway. Booleans/decimals stay (low-cardinality in practice)."""
-    return not (dtype.is_floating() or dtype.is_nested())
+
+def _distinct_count_supported(dtype) -> bool:
+    """Columns distinct_count runs on. The approx path (bounded HLL) covers the
+    dtypes in ``_distinct_count_approx``; booleans keep exact COUNT(DISTINCT)
+    (<= 2 distinct, trivially cheap).
+
+    Everything else — float, decimal, and nested struct/array/map — has no
+    approx_distinct AND unbounded cardinality, where exact COUNT(DISTINCT) is
+    the multi-GB hash set #906 fixed for strings: ~2.2GB on a 30M-distinct
+    float, 10GB on a 24M-row unique-per-row ``struct<url, description>``. #908
+    routed only scalar string/integer/timestamp/date to approx and left the
+    rest on exact, so binary/time (approx-capable) paid nothing while
+    decimal/struct (approx-incapable, high-card) inherited the blowup. Skip the
+    unbounded ones: distinct_count resolves to None and dependents
+    (distinct_per, histogram, histogram_bins) still run."""
+    return _distinct_count_approx(dtype) or dtype.is_boolean()
 
 
 # ============================================================
@@ -165,24 +178,18 @@ def distinct_count(col: XorqColumn) -> int:
     is displayed as a ratio, and the histogram branch thresholds
     (distinct_count > 5 / <= 5) sit where HLL is exact in practice.
 
-    Float and nested (struct/array/map) columns skip the stat entirely
-    (column_filter — see ``_distinct_count_supported``): approx_distinct raises
-    on both, so they fall to exact COUNT(DISTINCT), whose memory is proportional
-    to cardinality (~2.2GB on a 30M-distinct float; ~25GB on a 24M-row
-    high-cardinality struct), and a distinct count over either is rarely
-    meaningful. The pipeline pre-populates ``distinct_count`` as None so
-    dependents (histogram, histogram_bins, distinct_per) still run.
-
-    For the dtypes that remain, approx_distinct still raises on some (Boolean at
-    least), and one failing expression aborts the entire batch aggregate — every
-    batched stat for every column. So only the verified scalar dtypes below take
-    the approx path; the rest (Boolean, decimal, …) keep the exact aggregate,
-    which is bounded for the low-cardinality types that reach it.
+    Type handling is split out so it can't drift from the column_filter:
+    ``_distinct_count_approx`` lists the approx-capable dtypes (the only ones
+    that reach the approx branch), ``_distinct_count_supported`` adds boolean
+    (exact, <= 2 distinct) and skips the unbounded exact-only dtypes (float,
+    decimal, nested) entirely — the pipeline pre-populates their distinct_count
+    as None so dependents (histogram, histogram_bins, distinct_per) still run.
+    Picking the approx vs exact branch on the same predicate keeps approx off
+    any dtype it would raise on (one raising expression aborts the whole batch).
     """
-    dt = col.type()
-    if dt.is_string() or dt.is_integer() or dt.is_timestamp() or dt.is_date():
+    if _distinct_count_approx(col.type()):
         return col.approx_nunique().cast("int64")
-    return col.nunique().cast("int64")
+    return col.nunique().cast("int64")  # only booleans reach here (exact, <= 2)
 
 
 @stat(column_filter=_is_numeric_not_bool)

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -186,6 +186,30 @@ class TestBatchAggregate:
         assert stats["ints"]["distinct_count"] == 7
         assert stats["strs"]["distinct_per"] == 1.0
 
+    def test_distinct_count_skipped_for_nested_types(self):
+        """Struct / array / map columns skip distinct_count.
+
+        approx_distinct raises on nested types, so they fall to exact
+        COUNT(DISTINCT) — and a high-cardinality nested column is the same
+        multi-GB hash set #906 fixed for strings: ~25GB measured streaming the
+        stats over a 24M-row ``struct<url, description>`` column, all of it the
+        exact distinct on that one column (#908 only routed scalar string /
+        integer / timestamp / date to approx). They must be filtered out like
+        floats so distinct_count resolves to None and dependents still run.
+        """
+        from xorq.vendor.ibis.expr import datatypes as dt
+
+        from buckaroo.customizations.xorq_stats_v2 import distinct_count
+
+        cf = distinct_count._stat_func.column_filter
+        assert cf(dt.Struct({"url": "string", "description": "string"})) is False
+        assert cf(dt.Array(dt.string)) is False
+        assert cf(dt.Map(dt.string, dt.string)) is False
+        # scalar columns still computed; the existing float skip is preserved
+        assert cf(dt.string) is True
+        assert cf(dt.int64) is True
+        assert cf(dt.float64) is False
+
 
 # ============================================================
 # Numeric-only stats: mean, std, median

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -210,6 +210,44 @@ class TestBatchAggregate:
         assert cf(dt.int64) is True
         assert cf(dt.float64) is False
 
+    @pytest.mark.parametrize("dtype, supported, approx", [
+        # approx_nunique works (HLL, bounded) — empirically verified across the
+        # arrow dtypes on xorq-datafusion 0.2.7 (#918):
+        ("int64", True, True),
+        ("int32", True, True),
+        ("string", True, True),
+        ("binary", True, True),         # approx works; was wrongly on exact
+        ("date", True, True),
+        ("time", True, True),           # approx works; was wrongly on exact
+        ("timestamp", True, True),
+        # approx raises but cardinality is bounded -> keep exact:
+        ("boolean", True, False),       # <= 2 distinct
+        # approx raises AND cardinality unbounded -> skip (exact is a multi-GB
+        # hash set on high cardinality):
+        ("float64", False, False),
+        ("decimal", False, False),      # was wrongly on exact
+        ("struct", False, False),
+        ("array", False, False),
+        ("map", False, False),
+    ])
+    def test_distinct_count_type_classification(self, dtype, supported, approx):
+        """Every arrow dtype is classified approx / exact / skip — never an
+        unbounded exact COUNT(DISTINCT) on a type approx can't cover."""
+        from xorq.vendor.ibis.expr import datatypes as dt
+
+        from buckaroo.customizations.xorq_stats_v2 import (
+            _distinct_count_approx, distinct_count)
+
+        d = {"int64": dt.int64, "int32": dt.int32, "string": dt.string,
+            "binary": dt.binary, "date": dt.date, "time": dt.time,
+            "timestamp": dt.Timestamp(), "boolean": dt.boolean,
+            "float64": dt.float64, "decimal": dt.Decimal(5, 2),
+            "struct": dt.Struct({"a": "string"}), "array": dt.Array(dt.string),
+            "map": dt.Map(dt.string, dt.string)}[dtype]
+        cf = distinct_count._stat_func.column_filter
+        assert cf(d) is supported, f"{dtype}: column_filter (supported)"
+        assert _distinct_count_approx(d) is approx, f"{dtype}: approx path"
+
 
 # ============================================================
 # Numeric-only stats: mean, std, median


### PR DESCRIPTION
Fixes #918.

## Summary

`distinct_count` (#908) routes string / integer / timestamp / date to `approx_nunique` and leaves **every other dtype on exact `COUNT(DISTINCT)`**. An audit of `approx_distinct` support across the arrow dtypes (xorq-datafusion 0.2.7) shows that's wrong two ways:

- **approx-capable dtypes stuck on exact**: `binary` and `time` support `approx_nunique` but weren't routed to it, so they pay exact `COUNT(DISTINCT)` — a multi-GB hash set waiting on a high-cardinality column.
- **approx-incapable high-cardinality dtypes on exact**: `decimal` and nested (`struct`/`array`/`map`) raise on `approx_distinct` and have unbounded cardinality, so exact blows up. **10GB measured** on a 24M-row unique-per-row `struct<url, description>` (parking's `camera_violations.summons_image`); 401MB just to scan that column.

## Audit (single query per dtype, xorq-datafusion 0.2.7)

| dtype | `approx_nunique` | exact `nunique` | correct handling |
|---|---|---|---|
| integer | OK | OK | approx |
| string (+ dictionary) | OK | OK | approx |
| binary / large_binary | OK | OK | **approx** (was exact) |
| date / timestamp | OK | OK | approx |
| time | OK | OK | **approx** (was exact) |
| boolean | raises | OK | exact (≤ 2 distinct) |
| float | raises | OK | skip |
| decimal | raises | OK | **skip** (was exact) |
| struct / array / map | raises | OK | **skip** (was exact — 10GB) |

(`uint`, `duration`, `interval`, fixed-size-binary, `null`, `union` aren't representable through xorq's ibis, so they can't reach this stat.)

## Fix (this PR)

Split the type predicate so the approx/exact branch and the `column_filter` can't drift (`_distinct_count_approx`):

- **approx** (bounded HLL): integer, string, binary, temporal (date/time/timestamp)
- **exact**: boolean only
- **skip**: float, decimal, nested — `distinct_count` resolves to None, dependents (`distinct_per`, `histogram`, `histogram_bins`) still run

## Context

Follow-up to #906 / #908 (same exact-`COUNT(DISTINCT)` blowup; this covers the dtypes they didn't). Found diagnosing a slow load in buckaroo-data/tallyman. 


## Test plan
- [x] `test_distinct_count_type_classification` — every dtype asserted approx/exact/skip (13 cases)
- [x] `test_distinct_count_skipped_for_nested_types`; existing approx/bool/float distinct tests unchanged
- [x] end-to-end over a mixed int/string/binary/time/decimal/float/bool table: binary/time get approx, decimal/float resolve to None, batch aggregate runs with no errors
- [x] full `tests/unit/test_xorq_stats_v2.py` (68) green
