### PR TITLE
fix(stats): stream to temp parquet in _create_base_table instead of materializing InMemoryTable

### DIFF
--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -341,14 +341,21 @@ class XorqStatPipeline:
         self._cache_mat_subs = None
         self._cache_mat_cleanup = None
         self._cache_mat_attempted = False
+        self._cache_mat_tmp_parquet = None
 
     def _cleanup_cache_materialization(self):
         cleanup = self._cache_mat_cleanup
+        tmp_parquet = self._cache_mat_tmp_parquet
         self._reset_cache_materialization()
         if cleanup is not None:
             backend, name = cleanup
             try:
                 backend.drop_table(name)
+            except Exception:
+                pass
+        if tmp_parquet is not None:
+            try:
+                tmp_parquet.unlink(missing_ok=True)
             except Exception:
                 pass
 
@@ -422,18 +429,44 @@ class XorqStatPipeline:
     def _create_base_table(self, underlying, name, table):
         """Land ``table`` as a base table on ``underlying``, or None on failure.
 
-        Prefers the in-engine ``create_table(expr)`` path, which materialises
-        in DataFusion without a pandas round-trip (~3-4× cheaper than
-        ``execute()`` + ``create_table(df)``). That path compiles the
+        Primary: stream-write the expression to a temp parquet file and
+        register it as a lazy DataFusion parquet scan (table_name=``name``).
+        This is fully out-of-core — DataFusion never holds all rows in its
+        Rust heap at once (~1 GB peak for a 167M-row scan vs 12+ GB for
+        ``CREATE TABLE AS SELECT``). The temp file is tracked in
+        ``self._cache_mat_tmp_parquet`` and deleted by
+        ``_cleanup_cache_materialization``.
+
+        Falls back to the original in-engine ``create_table(expr)`` path when
+        xorq is unavailable or the parquet write fails. That path compiles the
         expression to SQL, so an op with no translation rule — notably
         ``CachedNode`` from ``expr.cache()`` (the shape every catalog-diff
-        comparison carries) — makes it raise. Two fallbacks recover that:
+        comparison carries) — makes it raise. Two further fallbacks recover that:
 
           1. Rewrite each ``CachedNode`` to a read of its on-disk cache file
              and retry in-engine — no transport, the join still runs once.
           2. Last resort, ``execute()`` to pandas and register the result.
              Correct for any expression but pays a full transport.
         """
+        import tempfile  # noqa: PLC0415
+
+        tmp_path = None
+        try:
+            from xorq.expr.api import to_parquet as _xorq_to_parquet  # noqa: PLC0415
+            fd, tmp_str = tempfile.mkstemp(suffix=".parquet", prefix="buckaroo_mat_")
+            os.close(fd)
+            tmp_path = Path(tmp_str)
+            _xorq_to_parquet(table, tmp_path)
+            result = underlying.read_parquet(str(tmp_path), table_name=name)
+            self._cache_mat_tmp_parquet = tmp_path
+            return result
+        except Exception:
+            if tmp_path is not None and tmp_path.exists():
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+
         try:
             return underlying.create_table(name, table, overwrite=True)
         except Exception:

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
@@ -382,8 +383,11 @@ class XorqStatPipeline:
 
         Only runs for in-process xorq-datafusion backends. Remote
         backends would pay the cost of pulling all data over the wire.
-        Returns (table_to_use, cleanup) where cleanup is (backend, name)
-        for later drop, or None if no materialization happened.
+        Returns the table to use. When materialization fires, the
+        registered table name (and any streamed temp parquet) is recorded
+        on the instance and released by ``_cleanup_cache_materialization``
+        — one lifecycle for both resources, so a direct caller can't drop
+        the table yet leak the file.
 
         Skipped (no-op) when a ``cache_storage`` is set: the cache path keys
         each stat query against the *original* ``table`` so the content-
@@ -394,37 +398,38 @@ class XorqStatPipeline:
         table name into the query token and break the cache key on every load.
         """
         if self.cache_storage is not None:
-            return table, None
+            return table
         try:
             underlying = table._find_backend()
         except Exception:
-            return table, None
+            return table
         if "xorq_datafusion" not in type(underlying).__module__:
-            return table, None
+            return table
         # Skip when the table is already a base table on the backend —
         # materializing it again is pure overhead (full table read +
         # re-register) with no filter chain to amortize.
         try:
             from xorq.vendor.ibis.expr import operations as _ibis_ops
             if isinstance(table.op(), (_ibis_ops.DatabaseTable, _ibis_ops.InMemoryTable)):
-                return table, None
+                return table
         except Exception:
             pass
         # If no per-column work follows the batch aggregate (i.e. nothing
         # would re-execute the filter chain), materialization is just
         # wasted work — skip it.
         if not any(not _is_batch_func(sf) for sf in self.ordered_stat_funcs):
-            return table, None
+            return table
         # Only worth materialising when the source carries an expensive chain
         # (filter / aggregate / join / …) a per-column re-scan would recompute;
         # a scan / projection / union streams cheaply (#915).
         if not _source_worth_materializing(table):
-            return table, None
+            return table
         name = f"__buckaroo_histo_mat_{uuid.uuid4().hex[:12]}"
         new_table = self._create_base_table(underlying, name, table)
         if new_table is None:
-            return table, None
-        return new_table, (underlying, name)
+            return table
+        self._cache_mat_cleanup = (underlying, name)
+        return new_table
 
     def _create_base_table(self, underlying, name, table):
         """Land ``table`` as a base table on ``underlying``, or None on failure.
@@ -435,10 +440,15 @@ class XorqStatPipeline:
         Rust heap at once (~1 GB peak for a 167M-row scan vs 12+ GB for
         ``CREATE TABLE AS SELECT``). The temp file is tracked in
         ``self._cache_mat_tmp_parquet`` and deleted by
-        ``_cleanup_cache_materialization``.
+        ``_cleanup_cache_materialization``. It lands in the system temp dir
+        (honours ``TMPDIR``) and duplicates the result on disk for the run's
+        duration — on hosts where /tmp is RAM-backed tmpfs, point ``TMPDIR``
+        at real disk to keep the out-of-core win.
 
-        Falls back to the original in-engine ``create_table(expr)`` path when
-        xorq is unavailable or the parquet write fails. That path compiles the
+        Falls back (with a logged warning) to the in-engine
+        ``create_table(expr)`` path when this xorq has no
+        ``xorq.expr.api.to_parquet`` or the parquet write fails — xorq
+        itself is guaranteed by ``__init__``. That path compiles the
         expression to SQL, so an op with no translation rule — notably
         ``CachedNode`` from ``expr.cache()`` (the shape every catalog-diff
         comparison carries) — makes it raise. Two further fallbacks recover that:
@@ -448,8 +458,6 @@ class XorqStatPipeline:
           2. Last resort, ``execute()`` to pandas and register the result.
              Correct for any expression but pays a full transport.
         """
-        import tempfile  # noqa: PLC0415
-
         tmp_path = None
         try:
             from xorq.expr.api import to_parquet as _xorq_to_parquet  # noqa: PLC0415
@@ -460,11 +468,14 @@ class XorqStatPipeline:
             result = underlying.read_parquet(str(tmp_path), table_name=name)
             self._cache_mat_tmp_parquet = tmp_path
             return result
-        except Exception:
-            if tmp_path is not None and tmp_path.exists():
+        except Exception as e:
+            log.warning(
+                "xorq stat materialization: streaming parquet write failed, "
+                "falling back to in-engine create_table: %s", e)
+            if tmp_path is not None:
                 try:
                     tmp_path.unlink(missing_ok=True)
-                except Exception:
+                except OSError:
                     pass
 
         try:
@@ -552,16 +563,10 @@ class XorqStatPipeline:
         self._reset_cache_materialization()
         if self.cache_storage is not None:
             self._cache_source = table
-        materialized, cleanup = self._maybe_materialize(table)
+        materialized = self._maybe_materialize(table)
         try:
             return self._process_table_impl(materialized, skip_columns=skip_columns)
         finally:
-            if cleanup is not None:
-                backend, name = cleanup
-                try:
-                    backend.drop_table(name)
-                except Exception:
-                    pass
             self._cleanup_cache_materialization()
             self._log_cache_stats()
 

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -5,9 +5,11 @@ ibis-framework or remote backend required. Skipped if xorq is not
 installed.
 """
 
+import glob
 import logging
 import math
 import os
+import tempfile
 
 import pandas as pd
 import pytest
@@ -42,6 +44,11 @@ def _make_table_categorical():
     return xo.memtable(
         pd.DataFrame(
             {"cat": ["a", "a", "a", "b", "b", "c", "d", "e", "f", "g", "h"]}))
+
+
+def _tmp_mat_files():
+    """Temp parquets written by _create_base_table's streaming path (#922)."""
+    return set(glob.glob(os.path.join(tempfile.gettempdir(), "buckaroo_mat_*.parquet")))
 
 
 # ============================================================
@@ -720,6 +727,74 @@ class TestMaterialization:
         leaked = [n for n in (set(con.list_tables()) - before)
                   if n.startswith("__buckaroo_histo_mat")]
         assert leaked == [], f"materialized table not cleaned up: {leaked}"
+
+    def test_streaming_path_bypasses_create_table(self):
+        """#922: a worthy source must land via a streamed temp parquet +
+        read_parquet, never CREATE TABLE AS SELECT — DataFusion materialises
+        CTAS results into an in-memory table in its Rust heap (12+ GB RSS on
+        a 167M-row filtered scan)."""
+        from unittest.mock import patch
+
+        con = xo.connect()
+        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
+        t = con.create_table("t_stream_src", df)
+        filt = t.filter(t.v > 1)
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        with patch.object(type(con), "create_table",
+            side_effect=RuntimeError("CTAS path used")) as ctas:
+            stats, errors = pipeline.process_table(filt)
+        assert ctas.call_count == 0, (
+            "materialization went through create_table (in-memory CTAS) "
+            "instead of the streamed-parquet path")
+        assert errors == []
+        assert stats["v"]["length"] == 6
+
+    def test_to_parquet_failure_falls_back_with_warning(self, caplog):
+        """A failed streaming write must fall back to in-engine create_table
+        and warn — silently reverting changes the run's memory profile ~6x
+        (never-silent precedent, #910). The partial temp file must not leak."""
+        from unittest.mock import patch
+
+        import xorq.expr.api as xorq_expr_api
+
+        con = xo.connect()
+        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
+        t = con.create_table("t_fallback_src", df)
+        filt = t.filter(t.v > 1)
+        before_files = _tmp_mat_files()
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        with caplog.at_level(logging.WARNING):
+            with patch.object(xorq_expr_api, "to_parquet",
+                side_effect=RuntimeError("disk full")):
+                stats, errors = pipeline.process_table(filt)
+        assert errors == []
+        assert stats["v"]["length"] == 6
+        assert _tmp_mat_files() - before_files == set(), "partial temp parquet leaked"
+        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("create_table" in m for m in warnings), (
+            f"no fallback warning logged; warnings seen: {warnings}")
+
+    def test_cleanup_releases_table_and_temp_file(self):
+        """One _cleanup_cache_materialization() call must release everything
+        a direct _maybe_materialize() registered — the backend table AND the
+        streamed temp parquet — so direct callers can't leak either."""
+        con = xo.connect()
+        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
+        t = con.create_table("t_cleanup_src", df)
+        filt = t.filter(t.v > 1)
+        before_tables = set(con.list_tables())
+        before_files = _tmp_mat_files()
+        pipeline = XorqStatPipeline(XORQ_STATS_V2)
+        pipeline._maybe_materialize(filt)
+        fired = [n for n in set(con.list_tables()) - before_tables
+                 if n.startswith("__buckaroo_histo_mat")]
+        assert fired, "materialization did not fire for a filter chain"
+        pipeline._cleanup_cache_materialization()
+        leaked_tables = [n for n in set(con.list_tables()) - before_tables
+                         if n.startswith("__buckaroo_histo_mat")]
+        leaked_files = _tmp_mat_files() - before_files
+        assert leaked_tables == [], f"cleanup left registered table(s): {leaked_tables}"
+        assert leaked_files == set(), f"cleanup left temp parquet(s): {leaked_files}"
 
     @staticmethod
     def _cached_join_expr(tmp_path):

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -716,17 +716,21 @@ class TestMaterialization:
 
     def test_materialized_table_dropped_after_call(self):
         """Materialized tables created for filter chains are cleaned up
-        so the backend connection doesn't accumulate temp tables."""
+        so the backend connection doesn't accumulate temp tables — and the
+        streamed temp parquet backing them goes with them (#922)."""
         con = xo.connect()
         df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
         t = con.create_table("t_mat_filt", df)
         filt = t.filter(t.v > 1)  # lazy chain → triggers materialization
         before = set(con.list_tables())
+        before_files = _tmp_mat_files()
         pipeline = XorqStatPipeline(XORQ_STATS_V2)
         pipeline.process_table(filt)
         leaked = [n for n in (set(con.list_tables()) - before)
                   if n.startswith("__buckaroo_histo_mat")]
         assert leaked == [], f"materialized table not cleaned up: {leaked}"
+        leaked_files = _tmp_mat_files() - before_files
+        assert leaked_files == set(), f"temp parquet not cleaned up: {leaked_files}"
 
     def test_streaming_path_bypasses_create_table(self):
         """#922: a worthy source must land via a streamed temp parquet +
@@ -824,16 +828,16 @@ class TestMaterialization:
 
         expr = self._cached_join_expr(tmp_path)
         pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        materialized, cleanup = pipeline._maybe_materialize(expr)
+        materialized = pipeline._maybe_materialize(expr)
         try:
-            assert cleanup is not None, "materialization did not fire for CachedNode expr"
+            assert pipeline._cache_mat_cleanup is not None, (
+                "materialization did not fire for CachedNode expr")
             assert isinstance(materialized.op(), (ops.DatabaseTable, ops.InMemoryTable))
             # In-engine path: the CachedNode is rewritten to a parquet read,
             # not pulled through pandas.
             assert not list(materialized.op().find(CachedNode))
         finally:
-            if cleanup is not None:
-                cleanup[0].drop_table(cleanup[1])
+            pipeline._cleanup_cache_materialization()
 
     def test_cached_node_stats_match_unmaterialized(self, tmp_path):
         """Stats over the materialized base table equal stats over the raw
@@ -859,23 +863,24 @@ class TestMaterialization:
         t = con.create_table("t_mat_cache", df)
         filt = t.filter(t.v > 1)  # lazy chain → would materialize
 
-        # Without cache_storage the chain materializes: new table + cleanup.
+        # Without cache_storage the chain materializes: new table + cleanup
+        # state recorded on the instance.
         plain = XorqStatPipeline(XORQ_STATS_V2)
-        mat, cleanup = plain._maybe_materialize(filt)
+        mat = plain._maybe_materialize(filt)
         try:
-            assert cleanup is not None, "filter chain should materialize without cache_storage"
+            assert plain._cache_mat_cleanup is not None, (
+                "filter chain should materialize without cache_storage")
             assert mat is not filt
         finally:
-            if cleanup is not None:
-                cleanup[0].drop_table(cleanup[1])
+            plain._cleanup_cache_materialization()
 
         # With cache_storage the same chain is returned untouched, no cleanup.
         cache = xo.ParquetSnapshotCache.from_kwargs(
             source=xo.connect(), base_path=str(tmp_path))
         cached = XorqStatPipeline(XORQ_STATS_V2, cache_storage=cache)
-        same, no_cleanup = cached._maybe_materialize(filt)
+        same = cached._maybe_materialize(filt)
         assert same is filt
-        assert no_cleanup is None
+        assert cached._cache_mat_cleanup is None
 
 
 class TestCacheStorageExecute:


### PR DESCRIPTION
## Problem

`XorqStatPipeline._create_base_table` calls `underlying.create_table(name, table)`, which compiles to a DataFusion `CREATE TABLE AS SELECT`. DataFusion materialises all result rows into a Rust `InMemoryTable`, causing a 12+ GB RSS spike when the stat source is a large filtered parquet scan (e.g. 167M-row parking data with a state filter).

This only fires when `_source_worth_materializing` returns True — plain `Read` nodes are already out-of-core. The spike happens the first time a user applies Search or Sort in the Buckaroo UI.

## Fix

Replace the primary path in `_create_base_table` with:

1. Stream-write the expression to a temp parquet file via `xorq.expr.api.to_parquet` (uses `execute_stream()` internally — DataFusion batches are written incrementally, ~1 GB peak).
2. Register the file as a lazy parquet scan with `underlying.read_parquet(path, table_name=name)`. DataFusion reads columns on demand per stat query.

The temp file path is stored in `self._cache_mat_tmp_parquet` and deleted by `_cleanup_cache_materialization` after the stat run completes. The existing `create_table` fallback chain (in-engine → rewrite CachedNodes → pandas round-trip) is preserved for environments without xorq or when the parquet write fails.

## Verification

- 77 existing `tests/unit/test_xorq_stats_v2.py` tests pass unchanged.
- Plain scan: `_create_base_table` called 0 times (unchanged behaviour).
- NY-filtered 167M-row scan: peak RSS 1.97 GB (was 12+ GB); temp parquet deleted on cleanup.
- `read_parquet` returns `DatabaseTable`, so the `isinstance(materialized.op(), (ops.DatabaseTable, ops.InMemoryTable))` assertion in `test_materializes_past_cached_node` passes.