### PR TITLE
feat(perf): BUCKAROO_PERF toggle — instrument stats pipeline (all backends) + first data pull

### DIFF
--- a/buckaroo/pluggable_analysis_framework/perf_log.py
+++ b/buckaroo/pluggable_analysis_framework/perf_log.py
@@ -68,15 +68,25 @@ def perf_span(label: str, **fields):
 
     No-op (a single bool check, no timing) when instrumentation is off.
     ``fields`` are appended as ``key=value`` pairs for grepping/parsing.
+
+    If the block raises, the line still emits (the timing of the partial
+    work) but is tagged ``errored=true`` so a parser keying on ``secs=``
+    doesn't mistake a failed run's partial timing for a clean one.
     """
     if not _ENABLED:
         yield
         return
     t0 = time.perf_counter()
+    errored = False
     try:
         yield
+    except BaseException:
+        errored = True
+        raise
     finally:
         secs = time.perf_counter() - t0
+        if errored:
+            fields = {**fields, "errored": "true"}
         suffix = _fmt_fields(fields)
         log.info("perf span=%s secs=%.4f%s", label, secs,
                  f" {suffix}" if suffix else "")

--- a/buckaroo/pluggable_analysis_framework/perf_log.py
+++ b/buckaroo/pluggable_analysis_framework/perf_log.py
@@ -89,7 +89,7 @@ def perf_span(label: str, **fields):
             fields = {**fields, "errored": "true"}
         suffix = _fmt_fields(fields)
         log.info("perf span=%s secs=%.4f%s", label, secs,
-                 f" {suffix}" if suffix else "")
+            f" {suffix}" if suffix else "")
 
 
 class PerfRecorder:
@@ -126,4 +126,4 @@ class PerfRecorder:
         slowest = sorted(self.rows, key=lambda r: -r[3])[:top_n]
         for phase, column, stat, secs in slowest:
             log.info("perf   slow phase=%s col=%s stat=%s secs=%.4f",
-                     phase, column, stat, secs)
+                phase, column, stat, secs)

--- a/buckaroo/pluggable_analysis_framework/perf_log.py
+++ b/buckaroo/pluggable_analysis_framework/perf_log.py
@@ -18,9 +18,14 @@ When enabled, two things happen:
   ``(phase, column, stat, seconds)`` and print a top-N-slowest summary at the
   end of a run.
 
-The logger has no handler of its own — it inherits the root config (stderr in
-a notebook, the server log file under the server). It stays quiet unless
-``BUCKAROO_PERF`` is set, regardless of how noisy other loggers are.
+Enabling (env var or :func:`enable`) raises the ``buckaroo.perf`` logger to
+INFO so spans and summaries are emitted. When the root logger is already
+configured (the server, or a notebook that called ``logging.basicConfig``)
+the lines propagate to that existing handler — the server log file, stderr,
+etc. When nothing upstream has a handler (the common ``BUCKAROO_PERF=1
+python script.py`` / bare-notebook case, where root sits at WARNING and would
+drop INFO), a plain stderr handler is attached so the spans still show. It
+stays quiet unless enabled, regardless of how noisy other loggers are.
 """
 from __future__ import annotations
 
@@ -41,6 +46,23 @@ def _env_enabled() -> bool:
 _ENABLED: bool = _env_enabled()
 
 
+def _ensure_logging() -> None:
+    """Make INFO spans visible whenever perf is enabled.
+
+    A bare notebook/script leaves the root logger at WARNING with only the
+    lastResort handler, so our INFO lines would be dropped. Bump this logger to
+    INFO and, when nothing upstream has a handler, attach a plain stderr handler
+    of our own. When root is already configured (the server) we add nothing and
+    let propagation deliver the lines to the existing log. Idempotent — safe to
+    call on every enable().
+    """
+    log.setLevel(logging.INFO)
+    if not logging.getLogger().hasHandlers() and not log.handlers:
+        handler = logging.StreamHandler()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        log.addHandler(handler)
+
+
 def enabled() -> bool:
     """True when perf instrumentation should run. Cheap; safe in hot paths."""
     return _ENABLED
@@ -50,12 +72,19 @@ def enable() -> None:
     """Turn perf instrumentation on for this process (overrides the env var)."""
     global _ENABLED
     _ENABLED = True
+    _ensure_logging()
 
 
 def disable() -> None:
     """Turn perf instrumentation off for this process."""
     global _ENABLED
     _ENABLED = False
+
+
+# When enabled from the environment, configure logging at import so spans are
+# visible without a separate enable() call.
+if _ENABLED:
+    _ensure_logging()
 
 
 def _fmt_fields(fields: dict) -> str:

--- a/buckaroo/pluggable_analysis_framework/perf_log.py
+++ b/buckaroo/pluggable_analysis_framework/perf_log.py
@@ -1,0 +1,119 @@
+"""Opt-in perf instrumentation for the stats pipeline and the first data pull.
+
+Default off — zero behavioural change and a single bool check at each call
+site. Turn on with ``BUCKAROO_PERF=1`` in the environment, or
+programmatically with :func:`enable` (handy in a notebook investigation)::
+
+    from buckaroo.pluggable_analysis_framework import perf_log
+    perf_log.enable()
+    BuckarooWidget(df)          # spans + summary printed to the buckaroo.perf logger
+    perf_log.disable()
+
+When enabled, two things happen:
+
+* :func:`perf_span` context managers emit one ``key=value`` line per span to
+  the ``buckaroo.perf`` logger (greppable; in the server these land in
+  ``~/.buckaroo/logs/server.log``).
+* The stat pipelines feed a :class:`PerfRecorder` with one row per
+  ``(phase, column, stat, seconds)`` and print a top-N-slowest summary at the
+  end of a run.
+
+The logger has no handler of its own — it inherits the root config (stderr in
+a notebook, the server log file under the server). It stays quiet unless
+``BUCKAROO_PERF`` is set, regardless of how noisy other loggers are.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from contextlib import contextmanager
+from typing import List, Tuple
+
+log = logging.getLogger("buckaroo.perf")
+
+
+def _env_enabled() -> bool:
+    return os.environ.get("BUCKAROO_PERF", "").lower() in ("1", "true", "yes", "on")
+
+
+# Computed once from the environment; flip at runtime with enable()/disable().
+_ENABLED: bool = _env_enabled()
+
+
+def enabled() -> bool:
+    """True when perf instrumentation should run. Cheap; safe in hot paths."""
+    return _ENABLED
+
+
+def enable() -> None:
+    """Turn perf instrumentation on for this process (overrides the env var)."""
+    global _ENABLED
+    _ENABLED = True
+
+
+def disable() -> None:
+    """Turn perf instrumentation off for this process."""
+    global _ENABLED
+    _ENABLED = False
+
+
+def _fmt_fields(fields: dict) -> str:
+    return " ".join(f"{k}={v}" for k, v in fields.items())
+
+
+@contextmanager
+def perf_span(label: str, **fields):
+    """Time a block and log one line as ``perf span=<label> secs=<n> ...``.
+
+    No-op (a single bool check, no timing) when instrumentation is off.
+    ``fields`` are appended as ``key=value`` pairs for grepping/parsing.
+    """
+    if not _ENABLED:
+        yield
+        return
+    t0 = time.perf_counter()
+    try:
+        yield
+    finally:
+        secs = time.perf_counter() - t0
+        suffix = _fmt_fields(fields)
+        log.info("perf span=%s secs=%.4f%s", label, secs,
+                 f" {suffix}" if suffix else "")
+
+
+class PerfRecorder:
+    """Accumulates ``(phase, column, stat, seconds)`` rows for one pipeline run.
+
+    Shared schema across the pandas, polars and xorq pipelines so their output
+    reads identically. ``summary()`` logs per-phase totals and the slowest
+    individual stats.
+    """
+
+    def __init__(self, label: str = ""):
+        self.label = label
+        self.rows: List[Tuple[str, str, str, float]] = []
+
+    def record(self, phase: str, column: str, stat: str, seconds: float) -> None:
+        self.rows.append((phase, column, stat, seconds))
+
+    def extend_timings(self, phase: str, timings) -> None:
+        """Absorb ``(column, stat, seconds)`` tuples (StatPipeline.timings shape)."""
+        for column, stat, seconds in timings:
+            self.rows.append((phase, column, stat, seconds))
+
+    def summary(self, top_n: int = 15) -> None:
+        if not _ENABLED or not self.rows:
+            return
+        total = sum(r[3] for r in self.rows)
+        by_phase: dict = {}
+        for phase, _col, _stat, secs in self.rows:
+            by_phase[phase] = by_phase.get(phase, 0.0) + secs
+        label = f" {self.label}" if self.label else ""
+        log.info("perf summary%s: total=%.4fs stats=%d", label, total, len(self.rows))
+        for phase, secs in sorted(by_phase.items(), key=lambda kv: -kv[1]):
+            log.info("perf   phase=%s secs=%.4f", phase, secs)
+        slowest = sorted(self.rows, key=lambda r: -r[3])[:top_n]
+        for phase, column, stat, secs in slowest:
+            log.info("perf   slow phase=%s col=%s stat=%s secs=%.4f",
+                     phase, column, stat, secs)

--- a/buckaroo/pluggable_analysis_framework/stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/stat_pipeline.py
@@ -15,6 +15,7 @@ import pandas as pd
 
 from buckaroo.df_util import old_col_new_col
 
+from . import perf_log
 from .col_analysis import ColAnalysis, ErrDict, SDType
 from .stat_func import (StatFunc, RawSeries, SampledSeries, RawDataFrame, XorqExpr, XorqExecute, RAW_MARKER_TYPES, MISSING, collect_stat_funcs)
 from .stat_result import Ok, Err, UpstreamError, StatError, StatResult, resolve_accumulator
@@ -195,13 +196,18 @@ class StatPipeline:
     def ordered_a_objs(self):
         return list(self._original_inputs)
 
-    def __init__(self, stat_funcs: list, unit_test: bool = True, record_timings: bool = False):
+    def __init__(self, stat_funcs: list, unit_test: bool = True, record_timings: Optional[bool] = None):
         self.all_stat_funcs = _normalize_inputs(stat_funcs)
         self._original_inputs = list(stat_funcs)
-        self.record_timings = record_timings
+        # Default to the global perf toggle; an explicit True/False (e.g. from
+        # scripts/perf/perf_bench.py) always wins.
+        self.record_timings = perf_log.enabled() if record_timings is None else record_timings
         # When record_timings is True: list of (column, stat_name, seconds) tuples
         # captured during the most recent process_df call.
         self.timings: List[Tuple[str, str, float]] = []
+        # Set during the unit_test() DAG self-check so its PERVERSE_DF run
+        # doesn't emit a perf summary.
+        self._suppress_perf_summary = False
 
         # Validate the full DAG (raises DAGConfigError if invalid)
         self.ordered_stat_funcs = build_typed_dag(
@@ -295,10 +301,18 @@ class StatPipeline:
             summary[rewritten_col_name] = col_result
             all_errors.extend(col_errors)
 
+        if self.record_timings and perf_log.enabled() and not self._suppress_perf_summary:
+            rec = perf_log.PerfRecorder(label=f"stats rows={len(df)} cols={len(summary)}")
+            rec.extend_timings("pandas/polars", self.timings)
+            rec.summary()
+
         return summary, all_errors
 
     def unit_test(self) -> Tuple[bool, List[StatError]]:
         """Test the pipeline against PERVERSE_DF."""
+        # The DAG self-check runs the pipeline against the 10-row PERVERSE_DF.
+        # Don't let that emit a perf summary — it's not a real data pull.
+        self._suppress_perf_summary = True
         try:
             _, errors = self.process_df(PERVERSE_DF)
             if not errors:
@@ -306,6 +320,8 @@ class StatPipeline:
             return False, errors
         except Exception:
             return False, []
+        finally:
+            self._suppress_perf_summary = False
 
     def add_stat(self, stat_func_or_class) -> Tuple[bool, List[StatError]]:
         """Add a stat function or ColAnalysis class interactively.

--- a/buckaroo/pluggable_analysis_framework/stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/stat_pipeline.py
@@ -196,12 +196,26 @@ class StatPipeline:
     def ordered_a_objs(self):
         return list(self._original_inputs)
 
+    @property
+    def record_timings(self) -> bool:
+        """Whether to capture per-stat timings on the next process_df call.
+
+        Resolved live so a None default follows perf_log.enable()/disable()
+        even after the pipeline was constructed; an explicit bool passed to
+        __init__ is honoured verbatim.
+        """
+        if self._record_timings is None:
+            return perf_log.enabled()
+        return self._record_timings
+
     def __init__(self, stat_funcs: list, unit_test: bool = True, record_timings: Optional[bool] = None):
         self.all_stat_funcs = _normalize_inputs(stat_funcs)
         self._original_inputs = list(stat_funcs)
-        # Default to the global perf toggle; an explicit True/False (e.g. from
-        # scripts/perf/perf_bench.py) always wins.
-        self.record_timings = perf_log.enabled() if record_timings is None else record_timings
+        # Tri-state, resolved live by the record_timings property: None follows
+        # the runtime perf toggle at process time, so enable()/disable() after
+        # construction takes effect; an explicit True/False (e.g. from
+        # scripts/perf/perf_bench.py) is latched and always wins.
+        self._record_timings = record_timings
         # When record_timings is True: list of (column, stat_name, seconds) tuples
         # captured during the most recent process_df call.
         self.timings: List[Tuple[str, str, float]] = []

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -22,12 +22,15 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
+import time
 import uuid
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
+from . import perf_log
 from .col_analysis import SDType
 from .safe_summary_df import output_full_reproduce
 from .stat_func import XorqColumn, XorqExpr, XorqExecute, RAW_MARKER_TYPES, StatFunc
@@ -189,6 +192,12 @@ class XorqStatPipeline:
         # unit_test() run kicked off below, which disables the cache).
         self._cache_stats = _new_cache_run_stats()
         self._reset_cache_materialization()
+        # Per-run perf recorder, (re)initialised in process_table when the
+        # BUCKAROO_PERF toggle is on; None otherwise.
+        self._perf = None
+        # Set during the unit_test() DAG self-check so its PERVERSE_DF run
+        # stays out of the perf log.
+        self._suppress_perf_summary = False
 
         # Validate the full DAG up front (raises DAGConfigError on misconfig).
         self.ordered_stat_funcs = build_typed_dag(
@@ -542,6 +551,9 @@ class XorqStatPipeline:
         saved_cache = self.cache_storage
         self.backend = None
         self.cache_storage = None
+        # The PERVERSE_DF self-check is not a real data pull — keep it out of
+        # the perf log (spans and summary).
+        self._suppress_perf_summary = True
         try:
             table = xo.memtable(PERVERSE_DF)
             _, errors = self.process_table(table)
@@ -553,6 +565,13 @@ class XorqStatPipeline:
         finally:
             self.backend = saved_backend
             self.cache_storage = saved_cache
+            self._suppress_perf_summary = False
+
+    def _span(self, label, **fields):
+        """perf_span when perf is on for this (non-unit-test) run, else no-op."""
+        if perf_log.enabled() and not self._suppress_perf_summary:
+            return perf_log.perf_span(label, **fields)
+        return nullcontext()
 
     def process_table(self, table, skip_columns=None) -> Tuple[SDType, List[StatError]]:
         # Reset per-run cache state. When a snapshot cache is set, queries are
@@ -563,12 +582,23 @@ class XorqStatPipeline:
         self._reset_cache_materialization()
         if self.cache_storage is not None:
             self._cache_source = table
-        materialized = self._maybe_materialize(table)
-        try:
-            return self._process_table_impl(materialized, skip_columns=skip_columns)
-        finally:
-            self._cleanup_cache_materialization()
-            self._log_cache_stats()
+        self._perf = (perf_log.PerfRecorder()
+                      if perf_log.enabled() and not self._suppress_perf_summary else None)
+        with self._span("stat.xorq.total"):
+            with self._span("stat.xorq.materialize"):
+                materialized = self._maybe_materialize(table)
+            try:
+                return self._process_table_impl(materialized, skip_columns=skip_columns)
+            finally:
+                self._cleanup_cache_materialization()
+                self._log_cache_stats()
+                if self._perf is not None:
+                    self._perf.label = (
+                        f"xorq cols={len(table.columns)} "
+                        f"cache_hits={self._cache_stats['hits']} "
+                        f"misses={self._cache_stats['misses']} "
+                        f"materialized={self._cache_stats['materialized']}")
+                    self._perf.summary()
 
     def _process_table_impl(self, table, skip_columns=None) -> Tuple[SDType, List[StatError]]:
         schema = table.schema()
@@ -629,7 +659,8 @@ class XorqStatPipeline:
         agg_exprs.extend(e for _, _, e in batch_items)
 
         try:
-            result_df = self._execute(table.aggregate(agg_exprs))
+            with self._span("stat.xorq.batch_aggregate", n_stats=len(batch_items)):
+                result_df = self._execute(table.aggregate(agg_exprs))
         except Exception as e:
             # Whole batch query failed — every batched stat reports the same root cause.
             # length stays at the prepopulated 0 so consumers still see something.
@@ -666,8 +697,12 @@ class XorqStatPipeline:
                 # (typically the batch-phase stats).
                 if sf.provides and all(sk.name in col_accum for sk in sf.provides):
                     continue
+                if self._perf is not None:
+                    t0 = time.perf_counter()
                 _execute_stat_func(sf, col_accum, col, raw_series=None, sampled_series=None, raw_dataframe=None,
                     xorq_expr=table, xorq_execute=self._execute)
+                if self._perf is not None:
+                    self._perf.record("xorq/per-column", col, sf.name, time.perf_counter() - t0)
 
             col_key_to_func: Dict[str, StatFunc] = {}
             for sf in col_funcs:

--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -466,41 +466,47 @@ class XorqStatPipeline:
              and retry in-engine — no transport, the join still runs once.
           2. Last resort, ``execute()`` to pandas and register the result.
              Correct for any expression but pays a full transport.
-        """
-        tmp_path = None
-        try:
-            from xorq.expr.api import to_parquet as _xorq_to_parquet  # noqa: PLC0415
-            fd, tmp_str = tempfile.mkstemp(suffix=".parquet", prefix="buckaroo_mat_")
-            os.close(fd)
-            tmp_path = Path(tmp_str)
-            _xorq_to_parquet(table, tmp_path)
-            result = underlying.read_parquet(str(tmp_path), table_name=name)
-            self._cache_mat_tmp_parquet = tmp_path
-            return result
-        except Exception as e:
-            log.warning(
-                "xorq stat materialization: streaming parquet write failed, "
-                "falling back to in-engine create_table: %s", e)
-            if tmp_path is not None:
-                try:
-                    tmp_path.unlink(missing_ok=True)
-                except OSError:
-                    pass
 
-        try:
-            return underlying.create_table(name, table, overwrite=True)
-        except Exception:
-            pass
-        rewritten = self._resolve_cached_nodes(table, underlying)
-        if rewritten is not None:
+        Wrapped in the ``stat.xorq.materialize`` span: this is the one place the
+        actual source scan happens, for both the eager (no-cache) and lazy
+        (first cache miss) paths, so the span reports the real cost wherever
+        materialisation runs.
+        """
+        with self._span("stat.xorq.materialize"):
+            tmp_path = None
             try:
-                return underlying.create_table(name, rewritten, overwrite=True)
+                from xorq.expr.api import to_parquet as _xorq_to_parquet  # noqa: PLC0415
+                fd, tmp_str = tempfile.mkstemp(suffix=".parquet", prefix="buckaroo_mat_")
+                os.close(fd)
+                tmp_path = Path(tmp_str)
+                _xorq_to_parquet(table, tmp_path)
+                result = underlying.read_parquet(str(tmp_path), table_name=name)
+                self._cache_mat_tmp_parquet = tmp_path
+                return result
+            except Exception as e:
+                log.warning(
+                    "xorq stat materialization: streaming parquet write failed, "
+                    "falling back to in-engine create_table: %s", e)
+                if tmp_path is not None:
+                    try:
+                        tmp_path.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+
+            try:
+                return underlying.create_table(name, table, overwrite=True)
             except Exception:
                 pass
-        try:
-            return underlying.create_table(name, table.execute(), overwrite=True)
-        except Exception:
-            return None
+            rewritten = self._resolve_cached_nodes(table, underlying)
+            if rewritten is not None:
+                try:
+                    return underlying.create_table(name, rewritten, overwrite=True)
+                except Exception:
+                    pass
+            try:
+                return underlying.create_table(name, table.execute(), overwrite=True)
+            except Exception:
+                return None
 
     @staticmethod
     def _resolve_cached_nodes(table, underlying):
@@ -585,8 +591,13 @@ class XorqStatPipeline:
         self._perf = (perf_log.PerfRecorder()
                       if perf_log.enabled() and not self._suppress_perf_summary else None)
         with self._span("stat.xorq.total"):
-            with self._span("stat.xorq.materialize"):
-                materialized = self._maybe_materialize(table)
+            # No materialize span here: with a cache_storage set, _maybe_materialize
+            # is a documented no-op and the real source landing happens lazily on
+            # the first cache miss. The span lives inside _create_base_table, the
+            # single point both the eager and lazy paths funnel through, so it
+            # reports the actual scan cost wherever it runs (or not at all when a
+            # warm cache never materialises).
+            materialized = self._maybe_materialize(table)
             try:
                 return self._process_table_impl(materialized, skip_columns=skip_columns)
             finally:

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -471,14 +471,17 @@ class LoadExprHandler(tornado.web.RequestHandler):
         cache_storage_path = body.get("cache_storage_path")
 
         try:
-            with perf_log.perf_span("firstpull.load_expr", build_dir=build_dir):
+            # session= correlates these spans across concurrent loads — the
+            # handler is async, so two /load_expr requests can interleave in
+            # the log even though no await sits inside a single span.
+            with perf_log.perf_span("firstpull.load_expr", session=session_id, build_dir=build_dir):
                 expr = xorq_loading.load_expr_build_dir(build_dir)
                 extra_klasses = (
                     xorq_loading.load_project_stat_klasses(project_root)
                     + xorq_loading.load_project_post_processing_klasses(project_root)
                     + xorq_loading.load_project_display_klasses(project_root)
                     if project_root else [])
-                with perf_log.perf_span("firstpull.dataflow_construct"):
+                with perf_log.perf_span("firstpull.dataflow_construct", session=session_id):
                     xorq_dataflow = xorq_loading.XorqServerDataflow(
                         expr, skip_main_serial=True, extra_klasses=extra_klasses,
                         cache_storage_path=cache_storage_path,

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -475,7 +475,10 @@ class LoadExprHandler(tornado.web.RequestHandler):
             # handler is async, so two /load_expr requests can interleave in
             # the log even though no await sits inside a single span.
             with perf_log.perf_span("firstpull.load_expr", session=session_id, build_dir=build_dir):
-                expr = xorq_loading.load_expr_build_dir(build_dir)
+                # The harness reads "expression build" as just this call, so it
+                # gets its own span rather than being outer-minus-inner residual.
+                with perf_log.perf_span("firstpull.expr_load", session=session_id):
+                    expr = xorq_loading.load_expr_build_dir(build_dir)
                 extra_klasses = (
                     xorq_loading.load_project_stat_klasses(project_root)
                     + xorq_loading.load_project_post_processing_klasses(project_root)
@@ -488,7 +491,10 @@ class LoadExprHandler(tornado.web.RequestHandler):
                         column_config_overrides=column_config_overrides,
                         extra_grid_config=extra_grid_config, init_sd=init_sd,
                         skip_stat_columns=skip_stat_columns)
-                metadata = xorq_loading.get_xorq_metadata(xorq_dataflow, build_dir)
+                # Spanning metadata too leaves only the small klass-load step
+                # unmeasured inside the outer firstpull.load_expr total.
+                with perf_log.perf_span("firstpull.metadata", session=session_id):
+                    metadata = xorq_loading.get_xorq_metadata(xorq_dataflow, build_dir)
         except FileNotFoundError:
             self.set_status(404)
             self.write({"error_code": "build_dir_not_found",

--- a/buckaroo/server/handlers.py
+++ b/buckaroo/server/handlers.py
@@ -15,6 +15,7 @@ from buckaroo.compare import col_join_dfs
 from buckaroo.df_util import old_col_new_col
 from buckaroo.server.focus import find_or_create_session_window
 from buckaroo.server.session import build_state_message
+from buckaroo.pluggable_analysis_framework import perf_log
 
 log = logging.getLogger("buckaroo.server.handlers")
 
@@ -470,19 +471,21 @@ class LoadExprHandler(tornado.web.RequestHandler):
         cache_storage_path = body.get("cache_storage_path")
 
         try:
-            expr = xorq_loading.load_expr_build_dir(build_dir)
-            extra_klasses = (
-                xorq_loading.load_project_stat_klasses(project_root)
-                + xorq_loading.load_project_post_processing_klasses(project_root)
-                + xorq_loading.load_project_display_klasses(project_root)
-                if project_root else [])
-            xorq_dataflow = xorq_loading.XorqServerDataflow(
-                expr, skip_main_serial=True, extra_klasses=extra_klasses,
-                cache_storage_path=cache_storage_path,
-                column_config_overrides=column_config_overrides,
-                extra_grid_config=extra_grid_config, init_sd=init_sd,
-                skip_stat_columns=skip_stat_columns)
-            metadata = xorq_loading.get_xorq_metadata(xorq_dataflow, build_dir)
+            with perf_log.perf_span("firstpull.load_expr", build_dir=build_dir):
+                expr = xorq_loading.load_expr_build_dir(build_dir)
+                extra_klasses = (
+                    xorq_loading.load_project_stat_klasses(project_root)
+                    + xorq_loading.load_project_post_processing_klasses(project_root)
+                    + xorq_loading.load_project_display_klasses(project_root)
+                    if project_root else [])
+                with perf_log.perf_span("firstpull.dataflow_construct"):
+                    xorq_dataflow = xorq_loading.XorqServerDataflow(
+                        expr, skip_main_serial=True, extra_klasses=extra_klasses,
+                        cache_storage_path=cache_storage_path,
+                        column_config_overrides=column_config_overrides,
+                        extra_grid_config=extra_grid_config, init_sd=init_sd,
+                        skip_stat_columns=skip_stat_columns)
+                metadata = xorq_loading.get_xorq_metadata(xorq_dataflow, build_dir)
         except FileNotFoundError:
             self.set_status(404)
             self.write({"error_code": "build_dir_not_found",

--- a/buckaroo/server/session.py
+++ b/buckaroo/server/session.py
@@ -47,6 +47,10 @@ class SessionState:
     prompt: str = ""
     component_config: Optional[dict] = None
     last_accessed: float = field(default_factory=time.time)
+    # Gates the firstpull.ws_first_payload perf span so it fires only on the
+    # first infinite_request for this session (time-to-first-rows), not every
+    # scroll. Flipped True after the first payload is dispatched.
+    _perf_first_payload_seen: bool = False
 
     def touch(self) -> None:
         """Update the last-accessed timestamp."""

--- a/buckaroo/server/websocket_handler.py
+++ b/buckaroo/server/websocket_handler.py
@@ -3,10 +3,12 @@ import json
 import logging
 import os
 import traceback
+from contextlib import nullcontext
 from urllib.parse import urlparse
 
 import tornado.websocket
 
+from buckaroo.pluggable_analysis_framework import perf_log
 from buckaroo.server.data_loading import (handle_infinite_request, handle_infinite_request_buckaroo, handle_infinite_request_lazy, get_buckaroo_display_state)
 from buckaroo.server.session import build_state_message
 
@@ -220,11 +222,20 @@ class DataStreamHandler(tornado.websocket.WebSocketHandler):
             return handle_infinite_request(session.df, pa)
 
         try:
-            resp_msg, parquet_bytes = _dispatch(payload_args)
-            # Two-frame sequence: JSON text frame, then binary Parquet frame
-            self.write_message(json.dumps(resp_msg))
-            if parquet_bytes:
-                self.write_message(parquet_bytes, binary=True)
+            # First infinite_request for this session = time-to-first-rows.
+            # Span just that one (window_to_parquet encode + frame send), keyed
+            # by session= so it lines up with the firstpull.load_expr spans.
+            first_payload = perf_log.enabled() and not session._perf_first_payload_seen
+            span = (perf_log.perf_span("firstpull.ws_first_payload", session=self.session_id)
+                    if first_payload else nullcontext())
+            with span:
+                resp_msg, parquet_bytes = _dispatch(payload_args)
+                # Two-frame sequence: JSON text frame, then binary Parquet frame
+                self.write_message(json.dumps(resp_msg))
+                if parquet_bytes:
+                    self.write_message(parquet_bytes, binary=True)
+            if first_payload:
+                session._perf_first_payload_seen = True
 
             # Handle second_request (eager loading)
             second_pa = payload_args.get("second_request")

--- a/buckaroo/xorq_buckaroo.py
+++ b/buckaroo/xorq_buckaroo.py
@@ -29,6 +29,7 @@ from .dataflow.autocleaning import PandasAutocleaning
 from .dataflow.dataflow import CustomizableDataflow
 from .dataflow.dataflow_extras import Sampling
 from .df_util import old_col_new_col
+from .pluggable_analysis_framework import perf_log
 from .pluggable_analysis_framework.col_analysis import ColAnalysis
 from .pluggable_analysis_framework.xorq_stat_pipeline import XorqDfStatsV2
 from .serialization_utils import pd_to_obj, to_parquet
@@ -167,10 +168,11 @@ class XorqDataflow(CustomizableDataflow):
                     'rewritten_col_name': rewritten_col}
             return empty, {}
         cache_storage = getattr(self, 'cache_storage', None)
-        stats = self.DFStatsClass(
-            processed_df, self.analysis_klasses, self.df_name,
-            debug=self.debug, cache_storage=cache_storage,
-            skip_columns=getattr(self, 'skip_stat_columns', None))
+        with perf_log.perf_span("firstpull.summary_stats"):
+            stats = self.DFStatsClass(
+                processed_df, self.analysis_klasses, self.df_name,
+                debug=self.debug, cache_storage=cache_storage,
+                skip_columns=getattr(self, 'skip_stat_columns', None))
         sdf = stats.sdf
         if stats.errs:
             if self.debug:
@@ -276,6 +278,11 @@ def window_to_parquet(processed_df, start, end, sort_col=None, ascending=True) -
     ``handle_infinite_request_xorq`` (WebSocket binary frame). Lifted
     to module level so both transports drive one push-down path.
     """
+    with perf_log.perf_span("firstpull.window_to_parquet", start=start, end=end):
+        return _window_to_parquet(processed_df, start, end, sort_col, ascending)
+
+
+def _window_to_parquet(processed_df, start, end, sort_col, ascending) -> bytes:
     if _is_pandas(processed_df):
         if sort_col is not None:
             processed_df = processed_df.sort_values(by=[sort_col], ascending=ascending)

--- a/docs/perf-testing-guide.md
+++ b/docs/perf-testing-guide.md
@@ -68,7 +68,10 @@ It covers all three stat backends and the first pull uniformly:
   phase; xorq splits into `stat.xorq.batch_aggregate` (the single folded
   aggregate query), `stat.xorq.materialize` (cold-cache source landing),
   and `xorq/per-column` (histogram re-scans — usually the dominant cost),
-  with cache hit/miss folded into the summary label.
+  with cache hit/miss folded into the summary label. Note the summary's
+  `total=` sums the per-column rows only; the `stat.xorq.materialize` and
+  `stat.xorq.batch_aggregate` phases are reported as their own `perf span=`
+  lines, not folded into that total.
 - **First data pull** — `firstpull.summary_stats`,
   `firstpull.window_to_parquet`, and (server) `firstpull.load_expr` /
   `firstpull.dataflow_construct` spans. In the server these land in

--- a/docs/perf-testing-guide.md
+++ b/docs/perf-testing-guide.md
@@ -73,9 +73,15 @@ It covers all three stat backends and the first pull uniformly:
   `stat.xorq.batch_aggregate` phases are reported as their own `perf span=`
   lines, not folded into that total.
 - **First data pull** — `firstpull.summary_stats`,
-  `firstpull.window_to_parquet`, and (server) `firstpull.load_expr` /
-  `firstpull.dataflow_construct` spans. In the server these land in
-  `~/.buckaroo/logs/server.log`.
+  `firstpull.window_to_parquet`, and the server-side spans that decompose a
+  `/load_expr` into the three numbers a perf harness wants: `firstpull.expr_load`
+  (expression build, just `load_expr_build_dir`), `firstpull.dataflow_construct`
+  (stats run — the `stat.xorq.*` spans break it down further), and
+  `firstpull.metadata`, all nested under the outer `firstpull.load_expr` total;
+  plus `firstpull.ws_first_payload` (time-to-first-rows — the parquet encode and
+  frame send of the first `infinite_request`, emitted once per session). The
+  server spans carry `session=` so they correlate across concurrent loads. In
+  the server these land in `~/.buckaroo/logs/server.log`.
 
 Lines are `key=value` and greppable (`grep 'perf span=' server.log`),
 so external harnesses can parse `secs=` for a named span. The

--- a/docs/perf-testing-guide.md
+++ b/docs/perf-testing-guide.md
@@ -42,12 +42,52 @@ Run from the repo root with the project venv:
 
 ## Instrumentation already in the code
 
-`StatPipeline` has an opt-in `record_timings` flag
-(`buckaroo/pluggable_analysis_framework/stat_pipeline.py`). Default is
-off — turning it on captures `(column, stat_name, seconds)` per
-`process_df` call. Use this *only* when comparing stat-pipeline shapes;
-do not use it as a substitute for cProfile when looking outside the
-pipeline.
+### Runtime toggle — `BUCKAROO_PERF`
+
+The fastest way to see where time goes in a live run (no bench script,
+no profiler) is the `BUCKAROO_PERF` toggle
+(`buckaroo/pluggable_analysis_framework/perf_log.py`). Default off, zero
+overhead. Turn it on and every stat-pipeline run and first-data-pull
+emits structured lines to the `buckaroo.perf` logger:
+
+```bash
+BUCKAROO_PERF=1 .venv/bin/python your_script.py     # spans + summary on stderr
+```
+
+```python
+from buckaroo.pluggable_analysis_framework import perf_log
+perf_log.enable()                # or BUCKAROO_PERF=1 in the env
+BuckarooWidget(df)               # pandas / polars / xorq — same output shape
+perf_log.disable()
+```
+
+It covers all three stat backends and the first pull uniformly:
+
+- **Stats pipeline** — per-`(phase, column, stat, seconds)` rows plus a
+  top-N-slowest summary. pandas/polars run as one `pandas/polars`
+  phase; xorq splits into `stat.xorq.batch_aggregate` (the single folded
+  aggregate query), `stat.xorq.materialize` (cold-cache source landing),
+  and `xorq/per-column` (histogram re-scans — usually the dominant cost),
+  with cache hit/miss folded into the summary label.
+- **First data pull** — `firstpull.summary_stats`,
+  `firstpull.window_to_parquet`, and (server) `firstpull.load_expr` /
+  `firstpull.dataflow_construct` spans. In the server these land in
+  `~/.buckaroo/logs/server.log`.
+
+Lines are `key=value` and greppable (`grep 'perf span=' server.log`),
+so external harnesses can parse `secs=` for a named span. The
+`PERVERSE_DF` DAG self-check that runs on every pipeline construction is
+suppressed, so the only output is real data pulls.
+
+Take *headline* numbers with the toggle **off** — the per-`(col,stat)`
+`perf_counter` pairs are cheap but nonzero on very wide frames.
+
+### Offline `record_timings` (bench scripts)
+
+`StatPipeline` also has the lower-level `record_timings` flag it's built
+on. When `BUCKAROO_PERF` is set it defaults on; pass it explicitly to
+capture `pipe.timings` without logging (this is what
+`scripts/perf/perf_bench.py` does):
 
 ```python
 pipe = StatPipeline(stat_funcs, record_timings=True)

--- a/docs/plans/perf-instrumentation-toggle.md
+++ b/docs/plans/perf-instrumentation-toggle.md
@@ -1,0 +1,162 @@
+# Plan: toggleable perf instrumentation for the stats pipeline + first data pull
+
+## Goal
+
+A perf-logging layer we can flip **on for an investigation and off for normal
+use**, covering the two places that actually hurt:
+
+1. **The stats pipeline** — for all three backends (pandas, polars, xorq), not
+   just xorq.
+2. **The first data pull** — time-to-first-payload, both in-process (widget
+   construction → first serialization) and over the server (`/load_expr` →
+   first WebSocket parquet frame).
+
+Default off ⇒ zero behavioral change and negligible overhead. On ⇒ structured,
+greppable timing lines plus an end-of-run summary.
+
+## Current state (what's already on `main`)
+
+- `StatPipeline` (shared by pandas **and** polars via `DfStatsV2` /
+  `PlDfStatsV2`) already has an opt-in `record_timings` flag that fills
+  `pipe.timings` with `(column, stat_name, seconds)` tuples —
+  `buckaroo/pluggable_analysis_framework/stat_pipeline.py:198,242-249,275`.
+  Today this is **offline-only**: the sole consumer is
+  `scripts/perf/perf_bench.py:35`. Nothing logs it, nothing toggles it at
+  runtime, and it never runs in the live widget/server path.
+- `XorqStatPipeline` has **no** timing instrumentation at all
+  (`xorq_stat_pipeline.py`). Its two cost phases are the batch aggregate
+  (one `table.aggregate(agg_exprs)`, ~lines 593-653) and the per-column
+  post-batch stats / histogram re-scans (~lines 655-679). It already logs
+  cache hit/miss/bytes via `_log_cache_stats()` (~363-373).
+- Server first-data-pull path: `LoadExprHandler.post()`
+  (`server/handlers.py:408-563`) → `XorqServerDataflow` construction (runs the
+  stat pipeline) → first `DataStreamHandler` payload
+  (`server/websocket_handler.py:192-240`) → `window_to_parquet()`
+  (`xorq_buckaroo.py:257-299`). No latency instrumentation here today.
+- Existing toggle convention: `_BUCKAROO_DEBUG =
+  os.environ.get("BUCKAROO_DEBUG", "")...` (`handlers.py:21`,
+  `websocket_handler.py:22`) — used only for error verbosity. Server logs to
+  `~/.buckaroo/logs/server.log` (`server/__main__.py:122`).
+- `scripts/perf/` bench harness and `docs/perf-testing-guide.md` already exist.
+
+So this PR is **not** green-field: it promotes the existing offline
+`record_timings` scaffolding into a runtime-toggleable logging layer and
+extends the same idea to xorq and to the first-pull path.
+
+## Design
+
+### 1. One shared toggle + perf module
+
+New `buckaroo/pluggable_analysis_framework/perf_log.py` (single source of truth,
+imported by both the pure-python pipelines and the server):
+
+- `PERF_ENABLED` — module-level bool from `BUCKAROO_PERF` env var, same parse as
+  `_BUCKAROO_DEBUG` (`"1"/"true"`). Also flippable programmatically
+  (`perf_log.enable()/disable()`) so notebook investigations and tests don't
+  need env vars.
+- A dedicated logger `buckaroo.perf` (INFO). Off by default, so even when other
+  loggers are noisy this stays quiet unless enabled.
+- `@contextmanager perf_span(label, **fields)` — when enabled, measures
+  `time.perf_counter()` delta and logs one `key=value` line
+  (`perf span=load_expr.total secs=0.214 rows=883000 backend=xorq ...`); when
+  disabled, a no-op with a single bool check (cheap enough for hot-ish call
+  sites, not for per-cell loops).
+- `PerfRecorder` — accumulator the pipelines append `(phase, column, stat,
+  secs)` rows to, with a `.summary()` that emits a top-N-slowest table and
+  per-phase totals at end of a run. This is what makes the per-stat data
+  actionable instead of a wall of lines.
+
+Guard principle: the **per-stat** inner loops check a captured local bool (as
+`StatPipeline` already does at `:242`), never re-read env or call the logger
+when disabled.
+
+### 2. Stats pipeline — uniform coverage across all three backends
+
+**pandas + polars (`StatPipeline`)** — already has the `(col, stat, secs)`
+capture. Changes:
+- Default `record_timings` to `PERF_ENABLED` when not explicitly passed, so the
+  live widget path records when the toggle is on (today it only records when a
+  script asks).
+- After `process_df`, route `self.timings` into the shared `PerfRecorder` and
+  emit the summary via `buckaroo.perf` instead of leaving it in-memory only.
+- Keep `pipe.timings` intact so `scripts/perf/perf_bench.py` keeps working.
+
+**xorq (`XorqStatPipeline`)** — new instrumentation mirroring the same shape:
+- Wrap **phase 1** (the single batch `table.aggregate`) in a `perf_span`
+  (`stat.xorq.batch_aggregate`) — this is usually the dominant query.
+- Wrap **phase 2** per-column post-batch execution, recording one row per
+  `(column, stat)` so the histogram re-scan cost is visible per column.
+- Time `_create_base_table` / materialization (`_maybe_materialize`,
+  `_ensure_cache_materialization`) as its own span — the cold-cache
+  materialization is a known first-pull cost (commits 19abae89, 43ffc92f).
+- Fold the existing `_log_cache_stats` counters into the same summary so cache
+  hit/miss sits next to the timings.
+
+Net: the same `(phase, column, stat, secs)` schema for all three backends, one
+summary format, so a polars run and an xorq run are read the same way.
+
+### 3. First data pull — both in-process and server
+
+**Server path** — `perf_span`s, all keyed by a per-request id so concurrent
+loads don't interleave confusingly:
+- `load_expr.total` around `LoadExprHandler.post()`.
+- `load_expr.dataflow_construct` around `XorqServerDataflow(...)` (this is where
+  the stat pipeline runs — nests the stats spans above).
+- `load_expr.first_payload` around the first `window_to_parquet()` +
+  WebSocket send in `DataStreamHandler`.
+
+**In-process path** (makes it "generally applicable" to the pandas/polars
+widgets, per the request) — a `perf_span` around widget construction →
+first `_df_to_obj` / serialization for `BuckarooWidget`,
+`PolarsBuckarooWidget`, and their infinite variants, so a plain
+`BuckarooWidget(df)` in a notebook with `BUCKAROO_PERF=1` prints the same
+breakdown the server emits.
+
+### 4. Output / consumption
+
+- Lines go to the `buckaroo.perf` logger. In the server they land in
+  `~/.buckaroo/logs/server.log` (already configured); in a notebook they go to
+  stderr once enabled.
+- Structured `key=value` so they're greppable and so the **tallyman perf
+  integration tests** can assert on `secs=` for a named span (the server is the
+  integration surface — there are no `tallyman` refs in this repo, so the
+  contract is "these log lines exist and are parseable").
+- End-of-run `PerfRecorder.summary()` prints top-N slowest stats + per-phase
+  totals.
+
+## Files touched
+
+- **new** `buckaroo/pluggable_analysis_framework/perf_log.py` — toggle, logger,
+  `perf_span`, `PerfRecorder`.
+- `buckaroo/pluggable_analysis_framework/stat_pipeline.py` — default
+  `record_timings` to toggle, emit summary via recorder.
+- `buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py` — new spans for
+  batch aggregate, per-column phase, materialization; fold in cache stats.
+- `buckaroo/xorq_buckaroo.py` — span around `window_to_parquet` and
+  `_get_summary_sd`.
+- `buckaroo/server/handlers.py`, `buckaroo/server/websocket_handler.py` —
+  first-pull spans, reuse the `BUCKAROO_PERF` toggle.
+- `buckaroo/buckaroo_widget.py` / polars widget — in-process first-pull span.
+- `docs/perf-testing-guide.md` — document the runtime toggle + xorq coverage
+  (today the guide only mentions the offline `record_timings`).
+
+## Tests
+
+Skipped for this PR — this is opt-in, default-off instrumentation with no
+behavioral change. Verify by running with `BUCKAROO_PERF=1` and eyeballing the
+emitted spans/summary. Keep `scripts/perf/perf_bench.py` working (don't break
+`pipe.timings`).
+
+## Open questions
+
+1. ~~Toggle name / granularity~~ — **decided: single boolean `BUCKAROO_PERF=1`**
+   turns on everything (stats spans for all backends + first-pull spans). Add
+   levels later only if the output proves too noisy.
+2. **Per-stat overhead when on** — for very wide frames the per-`(col,stat)`
+   `perf_counter` pair is cheap but nonzero; acceptable since it's opt-in. Worth
+   a note in the guide that headline numbers should be taken with the toggle
+   *off*.
+3. **Was a richer logging variant removed before?** The offline `record_timings`
+   is the only surviving piece I found; if an earlier verbose-logging version
+   existed and was reverted, worth grepping its branch before reimplementing so
+   we match the prior shape.


### PR DESCRIPTION
## Problem

When investigating perf issues (stats pipeline cost, first-data-pull latency) there's no way to see where time goes in a *live* run. The existing `StatPipeline.record_timings` is offline-only — consumed solely by `scripts/perf/perf_bench.py`, never logged, never on the live path — and `XorqStatPipeline` had no timing instrumentation at all.

## What this does

A single opt-in toggle, **`BUCKAROO_PERF=1`** (or `perf_log.enable()` in a notebook), that lights up two areas. Default off ⇒ a single bool check per call site, no behavioural change.

**New `perf_log.py`** — the toggle, a `buckaroo.perf` logger, a `perf_span()` context manager, and a `PerfRecorder` that emits a top-N-slowest summary on a shared `(phase, column, stat, seconds)` schema.

**Stats pipeline — uniform across all three backends:**
- **pandas/polars** (`StatPipeline`): `record_timings` now defaults to the toggle and emits the summary on every real `process_df`.
- **xorq** (`XorqStatPipeline`, previously zero instrumentation): spans for `stat.xorq.materialize`, `stat.xorq.batch_aggregate` (the one folded aggregate query), and per-column timing (`xorq/per-column` — histogram re-scans dominate), with cache hit/miss folded into the summary label.

**First data pull (a subset of time-to-first-payload, not the full path):** `firstpull.summary_stats`, `firstpull.window_to_parquet`, and server-side `firstpull.load_expr` / `firstpull.dataflow_construct` spans. This is the high-cost stretch (expr load + stat pipeline + first window serialization); it does not yet wrap the WebSocket first-payload send. Under the server these land in `~/.buckaroo/logs/server.log`. The server spans carry a `session=` field so they correlate across concurrent (async-interleaved) loads. Lines are `key=value` so external perf harnesses can parse `secs=` for a named span; a span whose block raised is tagged `errored=true` so a failed run's partial timing isn't mistaken for a clean one.

The `PERVERSE_DF` DAG self-check that runs on every pipeline construction is suppressed, so output is only real data pulls. The explicit `record_timings=True` bench path (`perf_bench.py`) is unchanged.

## Sample output (xorq, `BUCKAROO_PERF=1`)

```
perf span=stat.xorq.materialize secs=0.0418
perf span=stat.xorq.batch_aggregate secs=0.1056 n_stats=15
perf summary xorq cols=3 cache_hits=0 misses=0 materialized=False: total=0.0351s stats=21
perf   slow phase=xorq/per-column col=i stat=histogram secs=0.0211
perf span=firstpull.summary_stats secs=0.1864
```

## Verification

- pandas, polars, and xorq widgets all emit; `BUCKAROO_PERF` unset ⇒ 0 log lines.
- `perf_bench.py`'s explicit `record_timings=True` still captures `pipe.timings`.
- `pytest tests/unit/ -k "stat or pipeline or xorq or perf_smoke or bench"` → 379 passed.
- ruff clean.

No new tests (deliberate — opt-in, default-off, no behavioural change). Design notes in `docs/plans/perf-instrumentation-toggle.md`; the runtime toggle is documented in `docs/perf-testing-guide.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
