### PR TITLE
fix(ci): isolate pytest-check-links so Max Versions matrix can collect

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -328,7 +328,7 @@ jobs:
         run: |
           rm -f uv.lock
           sed -i 's/\[tool\.uv\]/[tool.uv]\noverride-dependencies = ["pandas"]/' pyproject.toml
-          uv sync --resolution=highest --all-extras --dev --no-group datacompy
+          uv sync --resolution=highest --all-extras --dev --no-group datacompy --no-group linkcheck
           uv pip list | grep -i pandas
       - name: Run tests
         # Tolerant of the post-summary polars-stream / pyo3 SIGABRT — see scripts/run_pytest_tolerant.sh.
@@ -664,7 +664,7 @@ jobs:
         with:
           packages: pandoc graphviz
       - name: Install the project
-        run: uv sync --locked --all-extras --dev
+        run: uv sync --locked --all-extras --dev --group linkcheck
       - name: Check docs build and links
         run: |
           mkdir -p docs/build/html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,12 +68,10 @@ dev = [
     "solara[pytest]; python_version < '3.14'",
     "sphinx>=1.5",
     "graphviz>=0.20.1",
-    "pytest-check-links",
     "pytest",
     "toml",
     "watchfiles",
     "graphviz>=0.20.1",
-    "pytest-check-links",
     "toml",
     "mistune<3.1",
     "pl-series-hash==0.2.1",
@@ -311,6 +309,21 @@ datacompy = [
     "datacompy>=0.15.0",
 ]
 
+# Docs link-checking only. pytest-check-links declares its pytest_collect_file
+# hook with the legacy `path` argument that pytest 9 removed from the hookspec,
+# so under pytest >= 9 it raises PluginValidationError at startup and aborts
+# collection for the *whole* suite. Version 0.10.1 caps pytest < 9 in its own
+# metadata; 0.9.1 does not, so an unconstrained resolve against pytest 9 (the
+# Max Versions matrix) backtracks to 0.9.1 and reintroduces the break. pytest-
+# check-links is not a buckaroo runtime dependency — only the CheckDocs job runs
+# `pytest --check-links` — so it lives in its own group (kept out of the shared
+# dev deps and the Max Versions matrix). Pin >= 0.10.1 plus an explicit
+# pytest < 9 belt to guard against a future release dropping the cap.
+linkcheck = [
+    "pytest-check-links>=0.10.1",
+    "pytest<9",
+]
+
 release = [
     "anthropic>=0.40.0",
 ]
@@ -333,11 +346,9 @@ dev = [
     "solara[pytest]; python_version < '3.14'",
     "sphinx>=1.5",
     "graphviz>=0.20.1",
-    "pytest-check-links",
     "toml",
     "watchfiles",
     "graphviz>=0.20.1",
-    "pytest-check-links",
     "toml",
     "marimo>=0.19.7"
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,6 @@ dev = [
     { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pydantic" },
     { name = "pytest" },
-    { name = "pytest-check-links" },
     { name = "pytest-playwright" },
     { name = "ruff" },
     { name = "solara", extra = ["pytest"], marker = "python_full_version < '3.14'" },
@@ -344,7 +343,6 @@ dev = [
     { name = "pyarrow", version = "21.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "pyarrow", version = "22.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
     { name = "pydantic" },
-    { name = "pytest-check-links" },
     { name = "pytest-playwright" },
     { name = "ruff" },
     { name = "solara", extra = ["pytest"], marker = "python_full_version < '3.14'" },
@@ -352,6 +350,10 @@ dev = [
     { name = "toml" },
     { name = "watchfiles", version = "1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14'" },
     { name = "watchfiles", version = "1.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14'" },
+]
+linkcheck = [
+    { name = "pytest" },
+    { name = "pytest-check-links" },
 ]
 release = [
     { name = "anthropic" },
@@ -411,7 +413,6 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'test'", specifier = ">=2.5.2" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=6" },
-    { name = "pytest-check-links", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=3" },
     { name = "pytest-playwright", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.6.2" },
@@ -446,7 +447,6 @@ dev = [
     { name = "polars", extras = ["timezone"] },
     { name = "pyarrow" },
     { name = "pydantic", specifier = ">=2.5.2" },
-    { name = "pytest-check-links" },
     { name = "pytest-playwright" },
     { name = "ruff", specifier = ">=0.6.2" },
     { name = "solara", marker = "python_full_version < '3.14'" },
@@ -454,6 +454,10 @@ dev = [
     { name = "sphinx", specifier = ">=1.5" },
     { name = "toml" },
     { name = "watchfiles" },
+]
+linkcheck = [
+    { name = "pytest", specifier = "<9" },
+    { name = "pytest-check-links", specifier = ">=0.10.1" },
 ]
 release = [{ name = "anthropic", specifier = ">=0.40.0" }]
 


### PR DESCRIPTION
## Problem

The **Python / Test (Max Versions)** matrix fails at "Run tests" with exit code 1, before any test runs:

```
pluggy._manager.PluginValidationError: Plugin 'check-links' for hook 'pytest_collect_file'
hookimpl definition: pytest_collect_file(path: 'Any', parent: 'pytest.Collector') -> 'CheckLinks | None'
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
```

Seen on run [27550697421](https://github.com/buckaroo-data/buckaroo/actions/runs/27550697421/job/81435856849?pr=926) (hit while another PR was open; fixing it properly here).

## Cause

Fully deterministic in the pytest version:

- Max Versions installs with `uv sync --resolution=highest`, pulling **pytest 9.1.0**.
- pytest 9.0 removed the legacy `path` (py.path) argument from the `pytest_collect_file` hookspec.
- `pytest-check-links` **0.10.1** caps `pytest<9` in its own metadata, so the max-versions resolve can't use it and backtracks to **0.9.1** (no cap), installing it next to pytest 9.1.
- 0.9.1's hookimpl still declares `path`, so pluggy's startup validation raises `PluginValidationError` and aborts collection for the entire unit suite.

This is unrelated to test content and distinct from the post-summary polars/pyo3 SIGABRT (exit 134) that `scripts/run_pytest_tolerant.sh` handles — this is exit 1 during collection. It only hits Max Versions; the locked matrices use an older pytest where the plugin loads fine.

`pytest-check-links` is docs tooling, not a buckaroo runtime dependency — only the **CheckDocs** job runs `pytest --check-links` (checks.yml). It has no business in the Max Versions matrix.

## Fix

- Move `pytest-check-links` out of the shared `dev` deps into a dedicated `linkcheck` dependency-group, pinned `>=0.10.1` with an explicit `pytest<9` belt.
- Install `linkcheck` only in **CheckDocs** (`--group linkcheck`).
- Exclude it from **Max Versions** with `--no-group linkcheck`, mirroring the existing `--no-group datacompy`.

## Verification

- Reproduced locally: pytest 9.1.0 + pytest-check-links 0.9.1 → `PluginValidationError`; pytest 8.4.2 → loads fine.
- Faithful max-versions resolve (`--resolution=highest ... --no-group linkcheck`): pytest-check-links **absent**, all 1212 unit tests collect with no error.
- CheckDocs env (`--group linkcheck`): pytest-check-links 0.10.1 under pytest<9, `--check-links` option registered, plugin loads cleanly.
- Unit suite passes locally (2 unrelated `artifact_test` failures are pre-existing in this checkout — they need a built dist artifact and fail identically on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)