### PR TITLE
refactor(stats): remove buckaroo-managed source materialization

### DIFF
--- a/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
+++ b/buckaroo/pluggable_analysis_framework/xorq_stat_pipeline.py
@@ -21,11 +21,8 @@ from __future__ import annotations
 
 import logging
 import os
-import tempfile
 import time
-import uuid
 from contextlib import nullcontext
-from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
 import pandas as pd
@@ -57,11 +54,9 @@ def _new_cache_run_stats() -> Dict[str, Any]:
     """Per-``process_table``-run counters for the snapshot cache.
 
     Reset at the start of every run and summarised in one log line at the
-    end (see ``_log_cache_stats``). ``materialized`` records whether the
-    source filter chain was landed as an in-memory base table to amortise
-    the per-column histogram scans (#910)."""
+    end (see ``_log_cache_stats``)."""
     return {"hits": 0, "misses": 0, "snapshots": 0, "bytes": 0,
-        "write_errors": 0, "materialized": False}
+        "write_errors": 0}
 
 
 def _to_python_scalar(val):
@@ -105,49 +100,6 @@ def _is_batch_func(sf: StatFunc) -> bool:
     return True
 
 
-# Relational ops whose result a per-column re-scan recomputes expensively, so
-# materialising the source once amortises across the per-column histogram
-# queries. Everything else — scans, projections, unions, limits — streams
-# cheaply via predicate + projection pushdown, so materialising it is pure
-# overhead, and multi-GB of resident overhead on a wide or tall source (#915).
-# ``Sample`` is here for correctness, not just cost: an unseeded sample
-# re-drawn per query would compute length/min/max/histogram over different row
-# sets, so the run must share a single materialised sample.
-# Resolved by name so an op renamed/absent across ibis versions is skipped
-# rather than raising.
-_MATERIALIZE_WORTHY_OP_NAMES = (
-    "Filter", "Aggregate", "JoinChain", "JoinLink", "Distinct", "Sort", "DropNull", "Sample")
-
-
-def _materialize_worthy_ops():
-    if not HAS_XORQ:
-        return ()
-    from xorq.vendor.ibis.expr import operations as ops  # noqa: PLC0415
-    return tuple(getattr(ops, n) for n in _MATERIALIZE_WORTHY_OP_NAMES if hasattr(ops, n))
-
-
-def _source_worth_materializing(source) -> bool:
-    """True if the source op tree carries a chain — filter / aggregate / join /
-    distinct / sort / drop_null / sample — whose re-execution per per-column
-    query materialising the source once would avoid (and, for an unseeded
-    sample, must avoid so every stat sees the same rows).
-
-    A source built only from scans, projections, unions and limits streams
-    cheaply, so materialising it is pure overhead (#915). The check is op-tree
-    based, hence independent of how the expression was spelled (``.filter`` vs
-    ``[bool]``, ``group_by().agg`` vs ``.agg`` vs ``.count``, any ``*_join``).
-
-    Conservative: a classification failure returns False (stream). Streaming is
-    memory-safe; the unbounded in-memory copy is the failure mode we avoid."""
-    worthy = _materialize_worthy_ops()
-    if not worthy:
-        return False
-    try:
-        return bool(list(source.op().find(worthy)))
-    except Exception:
-        return False
-
-
 class XorqStatPipeline:
     """v2 stat pipeline for ``ibis.Table`` inputs.
 
@@ -187,11 +139,10 @@ class XorqStatPipeline:
         self.backend = backend
         self.cache_storage = cache_storage
 
-        # Per-run snapshot-cache state, (re)initialised in process_table.
-        # Defaults set here so the attributes always exist (e.g. for the
-        # unit_test() run kicked off below, which disables the cache).
+        # Per-run snapshot-cache counters, (re)initialised in process_table.
+        # Set here so the attribute always exists (e.g. for the unit_test()
+        # run kicked off below, which disables the cache).
         self._cache_stats = _new_cache_run_stats()
-        self._reset_cache_materialization()
         # Per-run perf recorder, (re)initialised in process_table when the
         # BUCKAROO_PERF toggle is on; None otherwise.
         self._perf = None
@@ -236,15 +187,12 @@ class XorqStatPipeline:
         read the result parquet. The win compounds across the per-column
         histogram queries.
 
-        MISS: execute and write the snapshot ourselves. The cache key is
-        content-addressed on ``query`` as built against the *original* source
-        expression (the same key the next process gets), so warm loads stay
-        portable. For execution only, ``_rewrite_to_materialized`` swaps the
-        source leaf for an in-memory base table so the filter chain is scanned
-        once instead of once per per-column query (#910) — that rewrite never
-        touches the cache key. The result is written with pandas (the same
-        reader the HIT path uses); these stat-result snapshots are read back
-        only via ``pd.read_parquet`` here, never through xorq's cache layer.
+        MISS: execute ``query`` and write the snapshot ourselves. The cache key
+        is content-addressed on ``query`` as built against the source expression
+        (the same key the next process gets), so warm loads stay portable. The
+        result is written with pandas (the same reader the HIT path uses); these
+        stat-result snapshots are read back only via ``pd.read_parquet`` here,
+        never through xorq's cache layer.
         """
         key = self.cache_storage.calc_key(query)
         path = self.cache_storage.storage.get_path(key)
@@ -256,7 +204,7 @@ class XorqStatPipeline:
             except Exception:
                 pass  # corrupt/partial cache file — fall back to recompute
         self._cache_stats["misses"] += 1
-        result = self._rewrite_to_materialized(query).execute()
+        result = query.execute()
         self._write_snapshot(path, result)
         return result
 
@@ -277,98 +225,6 @@ class XorqStatPipeline:
             self._cache_stats["write_errors"] += 1
             log.warning("xorq stat snapshot write failed for %s: %s", path, e)
 
-    def _rewrite_to_materialized(self, query):
-        """Rewrite ``query``'s source leaf to the materialized base table.
-
-        Lazily materialises the post-filter source once (on the first miss),
-        then substitutes that base table for the source op in each query so the
-        filter/clean chain is scanned a single time rather than re-evaluated by
-        every per-column histogram. Best-effort: any failure to materialise or
-        rewrite falls back to executing ``query`` against the original source."""
-        subs = self._ensure_cache_materialization()
-        if not subs:
-            return query
-        try:
-            return query.op().replace(subs).to_expr()
-        except Exception:
-            return query
-
-    def _ensure_cache_materialization(self):
-        """Materialise the cache source once; return the substitution map.
-
-        Returns ``{source_op: materialized_op}`` for ``_rewrite_to_materialized``
-        to splice in, or ``None`` when materialisation doesn't apply (no source,
-        non-datafusion backend, source already a base table, no per-column work
-        to amortise, or a failed create_table). Mirrors the guards in
-        ``_maybe_materialize`` — that path handles the no-cache case eagerly;
-        this one handles the cache case lazily so a fully-warm load (all hits)
-        never scans the source at all."""
-        if self._cache_mat_attempted:
-            return self._cache_mat_subs
-        self._cache_mat_attempted = True
-
-        source = self._cache_source
-        if source is None:
-            return None
-        # Only in-process datafusion — a remote backend would pull all data
-        # over the wire just to land the base table.
-        try:
-            underlying = source._find_backend()
-        except Exception:
-            return None
-        if "xorq_datafusion" not in type(underlying).__module__:
-            return None
-        # Already a base table → no filter chain to amortise; the per-column
-        # queries already scan it directly.
-        try:
-            from xorq.vendor.ibis.expr import operations as _ibis_ops
-            if isinstance(source.op(), (_ibis_ops.DatabaseTable, _ibis_ops.InMemoryTable)):
-                return None
-        except Exception:
-            pass
-        # Nothing re-executes the filter chain (only batched stats) → a single
-        # materialisation scan would be pure overhead.
-        if not any(not _is_batch_func(sf) for sf in self.ordered_stat_funcs):
-            return None
-        # Only worth materialising when re-scanning would recompute an expensive
-        # chain (filter / aggregate / join / …). A scan / projection / union
-        # streams cheaply; materialising a wide or tall one is multi-GB of pure
-        # overhead (#915).
-        if not _source_worth_materializing(source):
-            return None
-
-        name = f"__buckaroo_histo_mat_{uuid.uuid4().hex[:12]}"
-        mat = self._create_base_table(underlying, name, source)
-        if mat is None:
-            return None
-        self._cache_mat_cleanup = (underlying, name)
-        self._cache_mat_subs = {source.op(): mat.op()}
-        self._cache_stats["materialized"] = True
-        return self._cache_mat_subs
-
-    def _reset_cache_materialization(self):
-        self._cache_source = None
-        self._cache_mat_subs = None
-        self._cache_mat_cleanup = None
-        self._cache_mat_attempted = False
-        self._cache_mat_tmp_parquet = None
-
-    def _cleanup_cache_materialization(self):
-        cleanup = self._cache_mat_cleanup
-        tmp_parquet = self._cache_mat_tmp_parquet
-        self._reset_cache_materialization()
-        if cleanup is not None:
-            backend, name = cleanup
-            try:
-                backend.drop_table(name)
-            except Exception:
-                pass
-        if tmp_parquet is not None:
-            try:
-                tmp_parquet.unlink(missing_ok=True)
-            except Exception:
-                pass
-
     def _log_cache_stats(self):
         """One summary line per run when a snapshot cache is in play (#910)."""
         if self.cache_storage is None:
@@ -377,169 +233,9 @@ class XorqStatPipeline:
         base_path = getattr(getattr(self.cache_storage, "storage", None), "base_path", "?")
         log.info(
             "xorq stat cache [%s]: %d hit(s), %d miss(es), %d snapshot(s) "
-            "written (%d bytes), %d write error(s), source materialized=%s",
+            "written (%d bytes), %d write error(s)",
             base_path, s["hits"], s["misses"], s["snapshots"], s["bytes"],
-            s["write_errors"], s["materialized"])
-
-    def _maybe_materialize(self, table):
-        """Materialize a lazy expression to a fresh base table.
-
-        Lazy filter/clean chains (filt/clean scopes in the buckaroo
-        dataflow) re-execute on every per-column query. With N columns
-        and a histogram per column, that's N+1 filter evaluations.
-        Materializing once turns each subsequent query into a simple
-        table scan against an in-memory base table.
-
-        Only runs for in-process xorq-datafusion backends. Remote
-        backends would pay the cost of pulling all data over the wire.
-        Returns the table to use. When materialization fires, the
-        registered table name (and any streamed temp parquet) is recorded
-        on the instance and released by ``_cleanup_cache_materialization``
-        — one lifecycle for both resources, so a direct caller can't drop
-        the table yet leak the file.
-
-        Skipped (no-op) when a ``cache_storage`` is set: the cache path keys
-        each stat query against the *original* ``table`` so the content-
-        addressed snapshot key is stable across loads, and materialises lazily
-        inside ``_execute_cached`` (only on a miss, as an execution-only
-        rewrite) so a fully-warm load never scans the source. Materialising
-        here instead would inject a per-load ``__buckaroo_histo_mat_<uuid>``
-        table name into the query token and break the cache key on every load.
-        """
-        if self.cache_storage is not None:
-            return table
-        try:
-            underlying = table._find_backend()
-        except Exception:
-            return table
-        if "xorq_datafusion" not in type(underlying).__module__:
-            return table
-        # Skip when the table is already a base table on the backend —
-        # materializing it again is pure overhead (full table read +
-        # re-register) with no filter chain to amortize.
-        try:
-            from xorq.vendor.ibis.expr import operations as _ibis_ops
-            if isinstance(table.op(), (_ibis_ops.DatabaseTable, _ibis_ops.InMemoryTable)):
-                return table
-        except Exception:
-            pass
-        # If no per-column work follows the batch aggregate (i.e. nothing
-        # would re-execute the filter chain), materialization is just
-        # wasted work — skip it.
-        if not any(not _is_batch_func(sf) for sf in self.ordered_stat_funcs):
-            return table
-        # Only worth materialising when the source carries an expensive chain
-        # (filter / aggregate / join / …) a per-column re-scan would recompute;
-        # a scan / projection / union streams cheaply (#915).
-        if not _source_worth_materializing(table):
-            return table
-        name = f"__buckaroo_histo_mat_{uuid.uuid4().hex[:12]}"
-        new_table = self._create_base_table(underlying, name, table)
-        if new_table is None:
-            return table
-        self._cache_mat_cleanup = (underlying, name)
-        return new_table
-
-    def _create_base_table(self, underlying, name, table):
-        """Land ``table`` as a base table on ``underlying``, or None on failure.
-
-        Primary: stream-write the expression to a temp parquet file and
-        register it as a lazy DataFusion parquet scan (table_name=``name``).
-        This is fully out-of-core — DataFusion never holds all rows in its
-        Rust heap at once (~1 GB peak for a 167M-row scan vs 12+ GB for
-        ``CREATE TABLE AS SELECT``). The temp file is tracked in
-        ``self._cache_mat_tmp_parquet`` and deleted by
-        ``_cleanup_cache_materialization``. It lands in the system temp dir
-        (honours ``TMPDIR``) and duplicates the result on disk for the run's
-        duration — on hosts where /tmp is RAM-backed tmpfs, point ``TMPDIR``
-        at real disk to keep the out-of-core win.
-
-        Falls back (with a logged warning) to the in-engine
-        ``create_table(expr)`` path when this xorq has no
-        ``xorq.expr.api.to_parquet`` or the parquet write fails — xorq
-        itself is guaranteed by ``__init__``. That path compiles the
-        expression to SQL, so an op with no translation rule — notably
-        ``CachedNode`` from ``expr.cache()`` (the shape every catalog-diff
-        comparison carries) — makes it raise. Two further fallbacks recover that:
-
-          1. Rewrite each ``CachedNode`` to a read of its on-disk cache file
-             and retry in-engine — no transport, the join still runs once.
-          2. Last resort, ``execute()`` to pandas and register the result.
-             Correct for any expression but pays a full transport.
-
-        Wrapped in the ``stat.xorq.materialize`` span: this is the one place the
-        actual source scan happens, for both the eager (no-cache) and lazy
-        (first cache miss) paths, so the span reports the real cost wherever
-        materialisation runs.
-        """
-        with self._span("stat.xorq.materialize"):
-            tmp_path = None
-            try:
-                from xorq.expr.api import to_parquet as _xorq_to_parquet  # noqa: PLC0415
-                fd, tmp_str = tempfile.mkstemp(suffix=".parquet", prefix="buckaroo_mat_")
-                os.close(fd)
-                tmp_path = Path(tmp_str)
-                _xorq_to_parquet(table, tmp_path)
-                result = underlying.read_parquet(str(tmp_path), table_name=name)
-                self._cache_mat_tmp_parquet = tmp_path
-                return result
-            except Exception as e:
-                log.warning(
-                    "xorq stat materialization: streaming parquet write failed, "
-                    "falling back to in-engine create_table: %s", e)
-                if tmp_path is not None:
-                    try:
-                        tmp_path.unlink(missing_ok=True)
-                    except OSError:
-                        pass
-
-            try:
-                return underlying.create_table(name, table, overwrite=True)
-            except Exception:
-                pass
-            rewritten = self._resolve_cached_nodes(table, underlying)
-            if rewritten is not None:
-                try:
-                    return underlying.create_table(name, rewritten, overwrite=True)
-                except Exception:
-                    pass
-            try:
-                return underlying.create_table(name, table.execute(), overwrite=True)
-            except Exception:
-                return None
-
-    @staticmethod
-    def _resolve_cached_nodes(table, underlying):
-        """Rewrite ``CachedNode``s in ``table`` to reads of their cache files.
-
-        ``CachedNode`` has no SQL translation, but its cached result is a
-        parquet on disk once materialised. Swapping each node for a
-        ``read_parquet`` of that file yields an equivalent expression the SQL
-        compiler can handle, keeping materialisation in-engine. Returns the
-        rewritten expression, or None if there are no cached nodes or any
-        cache file is missing (so the caller falls back to ``execute()``,
-        which populates the cache).
-        """
-        try:
-            from xorq.expr.relations import CachedNode
-        except Exception:
-            return None
-        nodes = list(table.op().find(CachedNode))
-        if not nodes:
-            return None
-        subs = {}
-        for cn in nodes:
-            try:
-                path = cn.cache.storage.get_path(cn.cache.calc_key(cn.parent))
-                if not Path(path).exists():
-                    return None
-                subs[cn] = underlying.read_parquet(str(path)).op()
-            except Exception:
-                return None
-        try:
-            return table.op().replace(subs).to_expr()
-        except Exception:
-            return None
+            s["write_errors"])
 
     def unit_test(self) -> Tuple[bool, List[StatError]]:
         """Run pipeline against PERVERSE_DF wrapped as a xorq memtable.
@@ -580,35 +276,24 @@ class XorqStatPipeline:
         return nullcontext()
 
     def process_table(self, table, skip_columns=None) -> Tuple[SDType, List[StatError]]:
-        # Reset per-run cache state. When a snapshot cache is set, queries are
-        # keyed against this original ``table`` (stable across processes) while
-        # ``_execute_cached`` materialises it lazily for execution — so
-        # _maybe_materialize stays a no-op for the cache path.
+        # Each per-column query runs directly against ``table`` (the source
+        # expression). When a snapshot cache is set, queries are keyed against
+        # that source so the content-addressed key is stable across processes;
+        # ``_execute_cached`` serves a hit from the snapshot parquet or executes
+        # and writes one on a miss.
         self._cache_stats = _new_cache_run_stats()
-        self._reset_cache_materialization()
-        if self.cache_storage is not None:
-            self._cache_source = table
         self._perf = (perf_log.PerfRecorder()
                       if perf_log.enabled() and not self._suppress_perf_summary else None)
         with self._span("stat.xorq.total"):
-            # No materialize span here: with a cache_storage set, _maybe_materialize
-            # is a documented no-op and the real source landing happens lazily on
-            # the first cache miss. The span lives inside _create_base_table, the
-            # single point both the eager and lazy paths funnel through, so it
-            # reports the actual scan cost wherever it runs (or not at all when a
-            # warm cache never materialises).
-            materialized = self._maybe_materialize(table)
             try:
-                return self._process_table_impl(materialized, skip_columns=skip_columns)
+                return self._process_table_impl(table, skip_columns=skip_columns)
             finally:
-                self._cleanup_cache_materialization()
                 self._log_cache_stats()
                 if self._perf is not None:
                     self._perf.label = (
                         f"xorq cols={len(table.columns)} "
                         f"cache_hits={self._cache_stats['hits']} "
-                        f"misses={self._cache_stats['misses']} "
-                        f"materialized={self._cache_stats['materialized']}")
+                        f"misses={self._cache_stats['misses']}")
                     self._perf.summary()
 
     def _process_table_impl(self, table, skip_columns=None) -> Tuple[SDType, List[StatError]]:

--- a/tests/unit/test_xorq_stats_v2.py
+++ b/tests/unit/test_xorq_stats_v2.py
@@ -5,11 +5,9 @@ ibis-framework or remote backend required. Skipped if xorq is not
 installed.
 """
 
-import glob
 import logging
 import math
 import os
-import tempfile
 
 import pandas as pd
 import pytest
@@ -44,11 +42,6 @@ def _make_table_categorical():
     return xo.memtable(
         pd.DataFrame(
             {"cat": ["a", "a", "a", "b", "b", "c", "d", "e", "f", "g", "h"]}))
-
-
-def _tmp_mat_files():
-    """Temp parquets written by _create_base_table's streaming path (#922)."""
-    return set(glob.glob(os.path.join(tempfile.gettempdir(), "buckaroo_mat_*.parquet")))
 
 
 # ============================================================
@@ -697,192 +690,6 @@ class TestBackendThreading:
         ), f"histogram is recomputing min/max; saw {backend.calls} queries"
 
 
-class TestMaterialization:
-    """Lazy filter/clean chains get materialized to a fresh DataFusion table
-    so per-column histogram queries don't re-execute the chain N times."""
-
-    def test_skipped_for_base_tables(self):
-        """A registered base table shouldn't be re-materialized — that's
-        pure overhead with no filter chain to amortize."""
-        con = xo.connect()
-        df = pd.DataFrame({"x": [1, 2, 3, 4, 5, 6, 7], "y": list("abcdefg")})
-        t = con.create_table("t_mat_skip", df)
-        before = set(con.list_tables())
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        pipeline.process_table(t)
-        new = set(con.list_tables()) - before
-        leaked = [n for n in new if n.startswith("__buckaroo_histo_mat")]
-        assert leaked == [], f"materialization fired for a base table: {leaked}"
-
-    def test_materialized_table_dropped_after_call(self):
-        """Materialized tables created for filter chains are cleaned up
-        so the backend connection doesn't accumulate temp tables — and the
-        streamed temp parquet backing them goes with them (#922)."""
-        con = xo.connect()
-        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
-        t = con.create_table("t_mat_filt", df)
-        filt = t.filter(t.v > 1)  # lazy chain → triggers materialization
-        before = set(con.list_tables())
-        before_files = _tmp_mat_files()
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        pipeline.process_table(filt)
-        leaked = [n for n in (set(con.list_tables()) - before)
-                  if n.startswith("__buckaroo_histo_mat")]
-        assert leaked == [], f"materialized table not cleaned up: {leaked}"
-        leaked_files = _tmp_mat_files() - before_files
-        assert leaked_files == set(), f"temp parquet not cleaned up: {leaked_files}"
-
-    def test_streaming_path_bypasses_create_table(self):
-        """#922: a worthy source must land via a streamed temp parquet +
-        read_parquet, never CREATE TABLE AS SELECT — DataFusion materialises
-        CTAS results into an in-memory table in its Rust heap (12+ GB RSS on
-        a 167M-row filtered scan)."""
-        from unittest.mock import patch
-
-        con = xo.connect()
-        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
-        t = con.create_table("t_stream_src", df)
-        filt = t.filter(t.v > 1)
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        with patch.object(type(con), "create_table",
-            side_effect=RuntimeError("CTAS path used")) as ctas:
-            stats, errors = pipeline.process_table(filt)
-        assert ctas.call_count == 0, (
-            "materialization went through create_table (in-memory CTAS) "
-            "instead of the streamed-parquet path")
-        assert errors == []
-        assert stats["v"]["length"] == 6
-
-    def test_to_parquet_failure_falls_back_with_warning(self, caplog):
-        """A failed streaming write must fall back to in-engine create_table
-        and warn — silently reverting changes the run's memory profile ~6x
-        (never-silent precedent, #910). The partial temp file must not leak."""
-        from unittest.mock import patch
-
-        import xorq.expr.api as xorq_expr_api
-
-        con = xo.connect()
-        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
-        t = con.create_table("t_fallback_src", df)
-        filt = t.filter(t.v > 1)
-        before_files = _tmp_mat_files()
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        with caplog.at_level(logging.WARNING):
-            with patch.object(xorq_expr_api, "to_parquet",
-                side_effect=RuntimeError("disk full")):
-                stats, errors = pipeline.process_table(filt)
-        assert errors == []
-        assert stats["v"]["length"] == 6
-        assert _tmp_mat_files() - before_files == set(), "partial temp parquet leaked"
-        warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
-        assert any("create_table" in m for m in warnings), (
-            f"no fallback warning logged; warnings seen: {warnings}")
-
-    def test_cleanup_releases_table_and_temp_file(self):
-        """One _cleanup_cache_materialization() call must release everything
-        a direct _maybe_materialize() registered — the backend table AND the
-        streamed temp parquet — so direct callers can't leak either."""
-        con = xo.connect()
-        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
-        t = con.create_table("t_cleanup_src", df)
-        filt = t.filter(t.v > 1)
-        before_tables = set(con.list_tables())
-        before_files = _tmp_mat_files()
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        pipeline._maybe_materialize(filt)
-        fired = [n for n in set(con.list_tables()) - before_tables
-                 if n.startswith("__buckaroo_histo_mat")]
-        assert fired, "materialization did not fire for a filter chain"
-        pipeline._cleanup_cache_materialization()
-        leaked_tables = [n for n in set(con.list_tables()) - before_tables
-                         if n.startswith("__buckaroo_histo_mat")]
-        leaked_files = _tmp_mat_files() - before_files
-        assert leaked_tables == [], f"cleanup left registered table(s): {leaked_tables}"
-        assert leaked_files == set(), f"cleanup left temp parquet(s): {leaked_files}"
-
-    @staticmethod
-    def _cached_join_expr(tmp_path):
-        """A cache()+join expression — the shape every catalog-diff
-        comparison carries. The cache() wrapper inserts a CachedNode, which
-        has no SQL translation, so the plain create_table(expr) materialize
-        path raises on it."""
-        cache = xo.ParquetSnapshotCache.from_kwargs(
-            source=xo.connect(), base_path=str(tmp_path))
-        df = pd.DataFrame({"k": range(20), "v": [float(i % 7) for i in range(20)]})
-        con = xo.connect()
-        a = con.create_table("cn_a", df).cache(cache=cache)
-        b = (con.create_table("cn_b", df.assign(v=df.v + 1))
-             .cache(cache=cache).rename({"v_v2": "v"}))
-        expr = a.join(b, "k").select("k", "v", "v_v2")
-        expr.execute()  # populate the on-disk cache files
-        return expr
-
-    def test_materializes_past_cached_node(self, tmp_path):
-        """A CachedNode-bearing expr (the diff shape) still materializes:
-        create_table(expr) can't compile CachedNode, so the fallback rewrites
-        each node to a read of its cache file and retries in-engine. Without
-        the fallback, materialization silently no-ops and every per-column
-        histogram re-runs the join."""
-        from xorq.expr.relations import CachedNode
-        from xorq.vendor.ibis.expr import operations as ops
-
-        expr = self._cached_join_expr(tmp_path)
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        materialized = pipeline._maybe_materialize(expr)
-        try:
-            assert pipeline._cache_mat_cleanup is not None, (
-                "materialization did not fire for CachedNode expr")
-            assert isinstance(materialized.op(), (ops.DatabaseTable, ops.InMemoryTable))
-            # In-engine path: the CachedNode is rewritten to a parquet read,
-            # not pulled through pandas.
-            assert not list(materialized.op().find(CachedNode))
-        finally:
-            pipeline._cleanup_cache_materialization()
-
-    def test_cached_node_stats_match_unmaterialized(self, tmp_path):
-        """Stats over the materialized base table equal stats over the raw
-        CachedNode expr — materialization is a perf optimization, not a
-        semantic change."""
-        expr = self._cached_join_expr(tmp_path)
-        pipeline = XorqStatPipeline(XORQ_STATS_V2)
-        raw, _ = pipeline._process_table_impl(expr)
-        mat, _ = pipeline.process_table(expr)
-        for col in raw:
-            for key in ("min", "max", "mean", "null_count", "distinct_count"):
-                assert raw[col].get(key) == mat[col].get(key), (col, key)
-            assert len(raw[col].get("histogram", [])) == len(mat[col].get("histogram", []))
-
-    def test_skipped_when_cache_storage_set(self, tmp_path):
-        """With cache_storage set, _maybe_materialize must NOT inject a
-        __buckaroo_histo_mat_<uuid> base table — that name lands in the
-        expression token and would break the content-addressed cache key on
-        every load. A lazy filter chain that materializes without cache_storage
-        is returned untouched once cache_storage is set."""
-        con = xo.connect()
-        df = pd.DataFrame({"v": [1.0, 2, 3, 4, 5, 6, 7], "c": list("abcdefg")})
-        t = con.create_table("t_mat_cache", df)
-        filt = t.filter(t.v > 1)  # lazy chain → would materialize
-
-        # Without cache_storage the chain materializes: new table + cleanup
-        # state recorded on the instance.
-        plain = XorqStatPipeline(XORQ_STATS_V2)
-        mat = plain._maybe_materialize(filt)
-        try:
-            assert plain._cache_mat_cleanup is not None, (
-                "filter chain should materialize without cache_storage")
-            assert mat is not filt
-        finally:
-            plain._cleanup_cache_materialization()
-
-        # With cache_storage the same chain is returned untouched, no cleanup.
-        cache = xo.ParquetSnapshotCache.from_kwargs(
-            source=xo.connect(), base_path=str(tmp_path))
-        cached = XorqStatPipeline(XORQ_STATS_V2, cache_storage=cache)
-        same = cached._maybe_materialize(filt)
-        assert same is filt
-        assert cached._cache_mat_cleanup is None
-
-
 class TestCacheStorageExecute:
     """_execute serves a cache HIT by reading the snapshot parquet directly
     rather than re-planning the expression through cache().execute()."""
@@ -922,8 +729,8 @@ class TestCacheStorageExecute:
 class TestSnapshotCacheRun:
     """Per-run snapshot-cache behaviour (#910).
 
-    A cold run materializes the source filter chain once and writes one
-    snapshot per stat query; a fully-warm run reads those snapshots without
+    A cold run computes each stat query against the source and writes one
+    snapshot per query; a fully-warm run reads those snapshots without
     re-scanning the source; every run with a cache configured logs a single
     summary line carrying the hit/miss/snapshot/byte/error counts."""
 
@@ -936,16 +743,16 @@ class TestSnapshotCacheRun:
 
     @staticmethod
     def _filter_chain_table():
-        # Lazy filter chain (re-scanned per query unless materialized) with a
-        # numeric column (numeric histogram) and a string column (categorical
-        # histogram), so both per-column query shapes run through the cache.
+        # Lazy filter chain with a numeric column (numeric histogram) and a
+        # string column (categorical histogram), so both per-column query
+        # shapes run through the cache.
         con = xo.connect()
         df = pd.DataFrame(
             {"n": list(range(40)), "cat": [c for c in "abcdefgh" for _ in range(5)]})
         t = con.create_table("snap_src", df)
         return t.filter(t.n > 1)
 
-    def test_cold_run_materializes_and_writes_snapshots(self, tmp_path):
+    def test_cold_run_writes_snapshots(self, tmp_path):
         pipeline = XorqStatPipeline(
             XORQ_STATS_V2, unit_test=False, cache_storage=self._cache(tmp_path))
         pipeline.process_table(self._filter_chain_table())
@@ -953,12 +760,10 @@ class TestSnapshotCacheRun:
         assert s["misses"] > 0 and s["hits"] == 0, f"cold run should miss the cache: {s}"
         assert s["snapshots"] == s["misses"], "each miss should write exactly one snapshot"
         assert s["bytes"] > 0 and s["write_errors"] == 0
-        assert s["materialized"] is True, (
-            "a cold run over a filter chain must materialize the source once (#910)")
         files = [f for _, _, fs in os.walk(tmp_path) for f in fs if f.endswith(".parquet")]
         assert files, "expected snapshot parquet files under the cache dir"
 
-    def test_warm_run_hits_without_materializing(self, tmp_path):
+    def test_warm_run_hits_cache(self, tmp_path):
         cache = self._cache(tmp_path)
         XorqStatPipeline(XORQ_STATS_V2, unit_test=False,
             cache_storage=cache).process_table(self._filter_chain_table())
@@ -967,8 +772,6 @@ class TestSnapshotCacheRun:
         s = warm._cache_stats
         assert s["hits"] > 0 and s["misses"] == 0, f"warm run should hit the cache: {s}"
         assert s["snapshots"] == 0, "a fully-warm run should write nothing"
-        assert s["materialized"] is False, (
-            "a fully-warm run serves every query from a snapshot — no source scan (#910)")
 
     def test_run_logs_one_cache_summary_line(self, tmp_path, caplog):
         pipeline = XorqStatPipeline(
@@ -981,8 +784,8 @@ class TestSnapshotCacheRun:
         assert "miss(es)" in lines[0] and "snapshot(s) written" in lines[0]
 
     def test_cached_stats_match_uncached(self, tmp_path):
-        """The materialized cold path and the snapshot-read warm path produce
-        the same stats as a plain uncached run — materialization is a perf
+        """The cold (compute + write) and warm (snapshot-read) cache paths
+        produce the same stats as a plain uncached run — the cache is a perf
         optimization, not a semantic change."""
         cache = self._cache(tmp_path)
         plain, _ = XorqStatPipeline(
@@ -996,64 +799,7 @@ class TestSnapshotCacheRun:
         # The warm run reads the exact parquet the cold run wrote, so its whole
         # SD (histogram row order included) must reproduce the cold run's.
         assert cold == warm, "warm run must reproduce the cold run's snapshot exactly"
-        # Histogram tie-order can differ between materialized and unmaterialized
-        # execution, so compare the tie-independent stats against the plain run.
+        # Compare the tie-independent stats against the plain run.
         for col in plain:
             for key in ("length", "min", "max", "mean", "null_count", "distinct_count"):
                 assert cold[col].get(key) == plain[col].get(key), (col, key)
-
-
-class TestMaterializeHeuristic:
-    """#915: materialize the source only when its op tree carries an expensive
-    chain (filter / aggregate / join / distinct / sort / drop_null) worth
-    amortising across the per-column queries. A scan / projection / union /
-    limit streams cheaply via predicate + projection pushdown, so materialising
-    it is pure overhead — and multi-GB of resident overhead on a wide or tall
-    source (#915, e.g. a 131M-row union or a 24M×20 read landing 25GB in RAM).
-
-    The decision is op-tree based, so it is independent of how the expression
-    was spelled — hence the parametrised formation styles below."""
-
-    @staticmethod
-    def _cache(tmp_path):
-        return xo.ParquetSnapshotCache.from_kwargs(
-            source=xo.connect(), base_path=str(tmp_path))
-
-    @staticmethod
-    def _base():
-        con = xo.connect()
-        df = pd.DataFrame(
-            {"n": list(range(40)), "cat": [c for c in "abcdefgh" for _ in range(5)]})
-        return con.create_table("heur_src", df)
-
-    def _run(self, src, tmp_path):
-        p = XorqStatPipeline(
-            XORQ_STATS_V2, unit_test=False, cache_storage=self._cache(tmp_path))
-        summary, _ = p.process_table(src)
-        return p._cache_stats, summary
-
-    @pytest.mark.parametrize("shape", ["union", "projection", "column-list", "limit"])
-    def test_cheap_source_streams_not_materialized(self, shape, tmp_path):
-        t = self._base()
-        src = {"union": t.select("n", "cat").union(t.select("n", "cat")), "projection": t.select("n", "cat"),
-            "column-list": t[["n", "cat"]], "limit": t.limit(30)}[shape]
-        stats, summary = self._run(src, tmp_path)
-        assert stats["materialized"] is False, (
-            f"a {shape} source has no chain to amortise — must stream, not "
-            f"materialize into RAM (#915)")
-        # still a real cold run: stats computed and snapshots written
-        assert stats["misses"] > 0 and stats["snapshots"] == stats["misses"]
-        assert {"n", "cat"} <= set(summary)
-
-    @pytest.mark.parametrize("shape", ["filter", "aggregate", "agg-shorthand", "distinct", "sample"])
-    def test_chain_source_is_materialized(self, shape, tmp_path):
-        t = self._base()
-        src = {"filter": t.filter(t.n > 1), "aggregate": t.group_by("cat").aggregate(c=t.count()),
-            "agg-shorthand": t.group_by("cat").count(), "distinct": t.select("cat").distinct(),
-            # A sample source MUST materialize: an unseeded sample re-drawn per
-            # per-column query would compute length/min/max/histogram over
-            # different rows (Codex review on #916).
-            "sample": t.sample(0.5)}[shape]
-        stats, _ = self._run(src, tmp_path)
-        assert stats["materialized"] is True, (
-            f"a {shape} source carries an expensive chain — materialize once (#915)")


### PR DESCRIPTION
## Problem

Across #910/#915/#916/#922 the xorq stat pipeline grew a "materialize the source once" optimization: on a cache miss it streamed the post-filter source to a temp parquet (the `stat.xorq.materialize` span) so the per-column histogram queries scanned that copy instead of re-executing the source chain N times. It carried a lot of machinery — a worthiness heuristic (`_source_worth_materializing`), a streamed-temp-parquet writer with `create_table` fallbacks (`_create_base_table`), a CachedNode rewrite path (`_rewrite_to_materialized` / `_resolve_cached_nodes`), plus ensure/reset/cleanup state — and made the pipeline hard to reason about.

## What this does

Removes it. Per-column queries now run directly against the source via `query.execute()`. `process_table` drops the maybe-materialize / cleanup / reset calls, and `_execute_cached`'s miss path is just `query.execute()`.

Measured cold runs over the common filter-over-base-table shape are faster without it — median total ≈68% lower at 1M rows (211.6ms → 67.6ms) and ≈84% at 5M (810.3ms → 129.4ms) — because DataFusion pushes the filter into each per-column scan, so N direct scans beat {full read + full temp write + N temp scans}. With the snapshot cache that cold cost is one-time per entry anyway (warm runs never materialized). Not measured: an expensive multi-op chain over raw, multi-file sources re-scanned once per column — the narrow case materialize targeted; re-add if that shows up.

The CachedNode catalog-diff shape needs no special handling: `.execute()` reads the on-disk cache natively — the SQL-compilation problem only existed in the removed `create_table` path.

Removed: `_maybe_materialize`, `_create_base_table`, `_rewrite_to_materialized`, `_resolve_cached_nodes`, `_ensure/_reset/_cleanup_cache_materialization`, the `_source_worth_materializing` / `_materialize_worthy_ops` heuristic, and the `_cache_mat_*` state / `materialized` cache stat. Materialize-specific tests deleted with the code. Net `+31 / -600`.

## Known limitation

An unseeded `Sample` source is now re-drawn per per-column query, so its stats can disagree across columns. Rare in practice; re-add a guard or targeted materialization if measurements show it matters.

## Verification

- `tests/unit/test_xorq_stats_v2.py`: 63 passed.
- Full `tests/unit`: 1187 passed, 6 skipped. The 3 failures seen locally are pre-existing and unrelated — `artifact_test.py` / `test_mcp_uvx_install.py` require the `standalone.js` / `static-embed.css` build outputs, which are gitignored and absent in a Python-only tree (CI builds JS first).
- `ruff check` clean; no dangling references to any removed symbol across `buckaroo/` and `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)