### PR TITLE
fix(ci): exclude slow MCP tests from dependency-check workflow

### DIFF
--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -45,7 +45,11 @@ jobs:
             echo '```'
           } >> "$GITHUB_STEP_SUMMARY"
       - name: Run tests
-        run: .venv/bin/python -m pytest ./tests/unit --color=yes
+        # Exclude slow MCP/uvx network tests: they install Buckaroo from
+        # test.pypi (no JS built in) and assert on bundled assets, which is
+        # unrelated to dependency compatibility. Matches the -m "not slow"
+        # filter used by every unit-test job in checks.yml.
+        run: .venv/bin/python -m pytest ./tests/unit -m "not slow" --color=yes
 
   notify-on-failure:
     name: Create Issue on Failure


### PR DESCRIPTION
## Problem

The scheduled **Dependency Compatibility Check** workflow fails on all four Python versions (3.11–3.14) with:

```
AssertionError: Critical static file 'standalone.js' is empty: {'exists': True, 'size_bytes': 0}
tests/unit/server/test_mcp_uvx_install.py:388
```

This is unrelated to dependency compatibility, the workflow's actual purpose.

## Root cause

`dependency-check.yml` ran `pytest ./tests/unit` with **no marker filter**, while every unit-test job in `checks.yml` runs `-m "not slow"` (lines 308, 336, 354). So this is the only workflow that picks up the `@slow`-marked `TestMcpInstall` network tests.

Because the workflow never sets `BUCKAROO_MCP_CMD`, `test_view_data_call` drops into uvx mode (`test_mcp_uvx_install.py:48-56`) and installs `buckaroo[mcp]` from test.pypi. That artifact has no JS toolchain at build time, so `hatch_build.py:55-58` writes an empty 0-byte `standalone.js` stub. The test then asserts the bundled asset is non-empty and fails.

The main CI runs this same test correctly in `checks.yml:213-220`: it builds the wheel *with real JS*, sets `BUCKAROO_MCP_CMD` to the local `buckaroo-table`, and runs `-m slow` — so it validates a real artifact.

## Fix

Add `-m "not slow"` to the dependency-check pytest invocation, matching the rest of the suite. Verified locally that this deselects `test_view_data_call` (and the 7 other slow tests in that file).

## Context

Found while addressing failures on run 27968740157. A separate fix already landed on `main` (7f4b4fd9) for the earlier TOML duplicate-`[tool.uv]` parse error in the same workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)