### PR TITLE
feat(duckdb-node): DuckDB backend for buckaroo-js-core (#930)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,6 +57,11 @@ jobs:
           cd packages/buckaroo-js-core
           pnpm install && pnpm run build
           pnpm run test
+      - name: Build and test buckaroo-duckdb-node
+        run: |
+          cd packages/buckaroo-duckdb-node
+          pnpm run build
+          SKIP_DUCKDB=1 pnpm run test
 
   BuildWheel:
     name: Build JS + Python Wheel

--- a/.github/workflows/release-buckaroo-duckdb-node.yml
+++ b/.github/workflows/release-buckaroo-duckdb-node.yml
@@ -1,0 +1,125 @@
+name: Release npm (buckaroo-duckdb-node)
+
+# Standalone, manually-triggered publish for buckaroo-duckdb-node.
+#
+# While the package is new it is published on its own from here, NOT folded
+# into the automatic release-npm job in release.yml. Version is coupled to the
+# buckaroo release by convention: pass the same version the Python/PyPI release
+# used (the same number buckaroo-js-core publishes at). Once the package and its
+# Trusted Publisher are established, this can be merged into release.yml so it
+# publishes automatically alongside buckaroo-js-core.
+#
+# BOOTSTRAP (one-time, before the first automated run can succeed):
+#   1. The package does not yet exist on npm; Trusted Publishing cannot be
+#      configured on a package that does not exist. Do one manual publish to
+#      create it at the release version (the first will be 0.15.2):
+#        cd packages/buckaroo-duckdb-node && pnpm run build
+#        npm version 0.15.2 --no-git-tag-version --allow-same-version
+#        npm publish --access public
+#   2. Register the npm Trusted Publisher for buckaroo-duckdb-node, matching
+#      this workflow exactly:
+#        https://www.npmjs.com/package/buckaroo-duckdb-node/access
+#        Owner: buckaroo-data  Repository: buckaroo
+#        Workflow: release-buckaroo-duckdb-node.yml  Environment: npm
+#   After that, dispatching this workflow publishes via OIDC with no token.
+#
+# Auth: npm Trusted Publishing via OIDC (no NPM_TOKEN secret).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish as (must match the buckaroo release, e.g. 0.15.2)"
+        required: true
+        type: string
+      dry_run:
+        description: "Run npm publish with --dry-run (no actual publish)"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  release-npm-duckdb-node:
+    name: Publish buckaroo-duckdb-node to npm
+    # GitHub-hosted runner required: npm Trusted Publishing OIDC is only
+    # supported on github-hosted runners (Depot's depot-ubuntu-latest is
+    # treated as self-hosted and won't receive npm OIDC credentials).
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9.10.0
+
+      - name: Setup Node.js with npm registry
+        uses: actions/setup-node@v6
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'pnpm'
+          cache-dependency-path: 'packages/pnpm-lock.yaml'
+
+      - name: Install pnpm dependencies
+        working-directory: packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Upgrade npm to a Trusted-Publishing-capable version
+        # Trusted Publishing requires npm >= 11.5.1. The global npm dir
+        # on github-hosted runners is root-owned, so sudo is needed.
+        run: sudo npm install -g npm@11.5.1
+
+      - name: OIDC diagnostics (compare against npm Trusted Publisher config)
+        # Prints the values npm checks against the Trusted Publisher config on
+        # the package. Compare these to what's registered at
+        # https://www.npmjs.com/package/buckaroo-duckdb-node/access
+        run: |
+          echo "npm version:              $(npm --version)"
+          echo "GITHUB_REPOSITORY:        ${GITHUB_REPOSITORY}"
+          echo "GITHUB_WORKFLOW_REF:      ${GITHUB_WORKFLOW_REF}"
+          echo "GITHUB_REF:               ${GITHUB_REF}"
+          echo "GITHUB_REF_NAME:          ${GITHUB_REF_NAME}"
+          echo "GITHUB_JOB:               ${GITHUB_JOB}"
+          echo "Job environment (yaml):   npm"
+          echo
+          echo "On npmjs.com the Trusted Publisher must match:"
+          echo "  Owner:        $(echo "${GITHUB_REPOSITORY}" | cut -d/ -f1)"
+          echo "  Repository:   $(echo "${GITHUB_REPOSITORY}" | cut -d/ -f2)"
+          echo "  Workflow:     $(basename "${GITHUB_WORKFLOW_REF%@*}")"
+          echo "  Environment:  npm  (or leave blank if no environment configured)"
+
+      - name: Set buckaroo-duckdb-node version to ${{ inputs.version }}
+        working-directory: packages/buckaroo-duckdb-node
+        run: npm version "${{ inputs.version }}" --no-git-tag-version --allow-same-version
+
+      - name: Build buckaroo-duckdb-node
+        working-directory: packages/buckaroo-duckdb-node
+        run: pnpm run build
+
+      - name: Check if version already published
+        id: check
+        run: |
+          VERSION="${{ inputs.version }}"
+          if npm view "buckaroo-duckdb-node@${VERSION}" version >/dev/null 2>&1; then
+            echo "buckaroo-duckdb-node@${VERSION} already on npm — skipping publish."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm (Trusted Publishing + provenance)
+        if: steps.check.outputs.skip != 'true'
+        working-directory: packages/buckaroo-duckdb-node
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            npm publish --access public --provenance --dry-run --loglevel=verbose
+          else
+            npm publish --access public --provenance --loglevel=verbose
+          fi

--- a/packages/buckaroo-duckdb-node/LICENSE
+++ b/packages/buckaroo-duckdb-node/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) Paddy Mullen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/packages/buckaroo-duckdb-node/README.md
+++ b/packages/buckaroo-duckdb-node/README.md
@@ -16,8 +16,8 @@ pnpm demo         # builds, then serves a live DuckDB-backed viewer
 ```
 
 Open http://localhost:8780/ — a 250k-row DuckDB table with infinite scroll,
-sort, and summary stats, no Python. It renders against today's browser bundle
-via the legacy binary-frame protocol (no #933 needed); details in
+sort, and summary stats, no Python. It renders against the browser bundle over
+`WebSocketModel`'s binary-frame path; details in
 `examples/duckdb-ws-server/README.md`.
 
 ## Status (v1)
@@ -34,15 +34,12 @@ Implemented and tested:
 - **Serialization** — the `COPY → tempfile parquet` no-coercion path, plus a
   batteries-included `@duckdb/node-api` adapter.
 - **Transport** — an `IModel`-over-IPC adapter for Electron (renderer ⇄ main).
+  The renderer decodes the inline `parquet_b64` `infinite_resp` payload through
+  `buckaroo-js-core`'s `decodeDFData(msg.payload, buffers)` (#933), so the
+  single-JSON-message reply renders end-to-end with no binary frame.
 
-### Blocked / fast-follow
+### Fast-follow
 
-- **End-to-end rendering is partially blocked on #933.** The producer side here
-  is complete, but the renderer decodes the inline `parquet_b64` row payload via
-  `decodeDFData` from #933 (unified DF transport). Until that lands in
-  `buckaroo-js-core`, the infinite path still does `parquetRead(buffers[0])` and
-  cannot consume a single-JSON-message inline-parquet reply. Don't ship the
-  renderer integration before #933.
 - **Histograms / quantiles, search, quick commands, exact DECIMAL** — designed
   for (the effective-query seam is in place) but not built. See the plan.
 
@@ -96,7 +93,8 @@ ipcMain.handle('buckaroo:msg', makeIpcMainHandler(backend));
 // renderer process
 import { IpcDuckModel } from 'buckaroo-duckdb-node';
 const model = new IpcDuckModel((channel, msg) => ipcRenderer.invoke(channel, msg));
-// hand `model` to the buckaroo-js-core viewer (post-#933)
+// hand `model` to the buckaroo-js-core viewer; it decodes the parquet_b64
+// payload via decodeDFData(msg.payload, buffers) (#933)
 ```
 
 ## Serialization fidelity (spike findings)

--- a/packages/buckaroo-duckdb-node/README.md
+++ b/packages/buckaroo-duckdb-node/README.md
@@ -8,6 +8,18 @@ so the viewer renders behind DuckDB exactly as it does behind pandas/polars.
 Tracks [#930](https://github.com/buckaroo-data/buckaroo/issues/930). See
 `docs/plans/930-duckdb-node-backend.md`.
 
+## See it running
+
+```bash
+pnpm install      # from packages/
+pnpm demo         # builds, then serves a live DuckDB-backed viewer
+```
+
+Open http://localhost:8780/ — a 250k-row DuckDB table with infinite scroll,
+sort, and summary stats, no Python. It renders against today's browser bundle
+via the legacy binary-frame protocol (no #933 needed); details in
+`examples/duckdb-ws-server/README.md`.
+
 ## Status (v1)
 
 Implemented and tested:

--- a/packages/buckaroo-duckdb-node/README.md
+++ b/packages/buckaroo-duckdb-node/README.md
@@ -1,0 +1,112 @@
+# buckaroo-duckdb-node
+
+A DuckDB-backed buckaroo backend for pure Node / Electron hosts — no Python
+kernel. It produces the same wire payloads (`initial_state`, `infinite_resp`,
+wide summary stats) that `buckaroo-js-core`'s `DFViewerInfinite` already speaks,
+so the viewer renders behind DuckDB exactly as it does behind pandas/polars.
+
+Tracks [#930](https://github.com/buckaroo-data/buckaroo/issues/930). See
+`docs/plans/930-duckdb-node-backend.md`.
+
+## Status (v1)
+
+Implemented and tested:
+
+- **Column rename** — `DESCRIBE` → buckaroo's `a, b, c…` space + a synthesized
+  `index` (base-26 scheme matching `df_util.py:to_chars`). Removes the
+  `index`-collision, dotted-name, and duplicate-name foot-guns.
+- **Windowed rows** — `infinite_request` → sorted, windowed, renamed SQL.
+- **Summary stats** — `SUMMARIZE` → `SDType` → the pinned stat rows the viewer
+  consumes (dtype, null_count, distinct_count, mean, std, min, q25/q50/q75, max).
+- **Type → displayer** config with `DefaultMainStyling` parity.
+- **Serialization** — the `COPY → tempfile parquet` no-coercion path, plus a
+  batteries-included `@duckdb/node-api` adapter.
+- **Transport** — an `IModel`-over-IPC adapter for Electron (renderer ⇄ main).
+
+### Blocked / fast-follow
+
+- **End-to-end rendering is partially blocked on #933.** The producer side here
+  is complete, but the renderer decodes the inline `parquet_b64` row payload via
+  `decodeDFData` from #933 (unified DF transport). Until that lands in
+  `buckaroo-js-core`, the infinite path still does `parquetRead(buffers[0])` and
+  cannot consume a single-JSON-message inline-parquet reply. Don't ship the
+  renderer integration before #933.
+- **Histograms / quantiles, search, quick commands, exact DECIMAL** — designed
+  for (the effective-query seam is in place) but not built. See the plan.
+
+## Architecture
+
+```
+DuckSource (injected connection)
+   describe(stmt)        DESCRIBE → (name, type)[]
+   summarize(stmt)       SUMMARIZE → SummarizeRow[]
+   copyToParquet(query)  COPY … TO tmpfile (FORMAT PARQUET) → bytes
+        │
+        ▼
+DuckBackend (transport-agnostic)
+   initialState()              → initial_state message
+   handleInfiniteRequest(args) → infinite_resp { payload: parquet_b64 }
+        │
+        ▼
+IpcDuckModel / makeIpcMainHandler   (Electron IModel-over-IPC)
+```
+
+Core imports zero native bindings. Embedders inject a `DuckSource` bound to
+*their* live connection (so attached DBs / registered files / temp views
+resolve), or use the bundled adapter.
+
+## Usage
+
+```ts
+import { DuckBackend } from 'buckaroo-duckdb-node';
+import { createNodeApiDuckSource } from 'buckaroo-duckdb-node/node-api';
+import { DuckDBInstance } from '@duckdb/node-api';
+
+const instance = await DuckDBInstance.create(':memory:');
+const connection = await instance.connect();
+const source = createNodeApiDuckSource(connection);
+
+const backend = new DuckBackend(source, 'SELECT * FROM my_table');
+const initial = await backend.initialState();
+const window = await backend.handleInfiniteRequest({
+  sourceName: 'main', start: 0, end: 100, origEnd: 100,
+});
+```
+
+### Electron
+
+```ts
+// main process
+import { ipcMain } from 'electron';
+import { makeIpcMainHandler } from 'buckaroo-duckdb-node';
+ipcMain.handle('buckaroo:msg', makeIpcMainHandler(backend));
+
+// renderer process
+import { IpcDuckModel } from 'buckaroo-duckdb-node';
+const model = new IpcDuckModel((channel, msg) => ipcRenderer.invoke(channel, msg));
+// hand `model` to the buckaroo-js-core viewer (post-#933)
+```
+
+## Serialization fidelity (spike findings)
+
+From `test/spike.duckdb.test.ts` (per-101-row window: COPY ≈ 3 ms, read ≈ 5 ms —
+temp-file latency is negligible, no ramdisk needed):
+
+| DuckDB type | parquet | hyparquet decode | v1 fidelity |
+|---|---|---|---|
+| `BIGINT` (incl. > 2^53) | INT64 | `bigint` | exact |
+| `DATE` / `TIMESTAMP` | INT32 / INT64 | `Date` | exact instant |
+| `VARCHAR`, `NULL` | — | `string` / `null` | exact |
+| `DECIMAL(38,9)` | DECIMAL | `number` (double) | lossy — `#934` |
+| `HUGEINT` | DOUBLE | `number` | lossy > 2^53 |
+
+## Develop
+
+```bash
+pnpm install          # from packages/
+pnpm test             # vitest (pure-logic + DuckDB spike)
+pnpm build            # tsc → dist/
+```
+
+The DuckDB spike requires the optional `@duckdb/node-api` peer; set
+`SKIP_DUCKDB=1` to skip it.

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/README.md
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/README.md
@@ -1,0 +1,62 @@
+# DuckDB WebSocket demo server
+
+A runnable demo that stands the `buckaroo-duckdb-node` backend behind a live
+browser viewer — infinite scroll, sort, and summary stats over a 250k-row DuckDB
+table, no Python kernel.
+
+## Run it
+
+From `packages/buckaroo-duckdb-node`:
+
+```bash
+pnpm install          # once, from packages/
+pnpm demo             # builds the package, then starts the server
+```
+
+Then open **http://localhost:8780/**.
+
+Scroll the grid (rows stream in on demand), click a column header to sort, and
+read the pinned summary-stats rows (dtype, null_count, distinct_count, mean,
+std, min, q25/q50/q75, max).
+
+Knobs (env vars):
+
+| var | default | meaning |
+|---|---|---|
+| `PORT` | `8780` | HTTP + WS port |
+| `ROWS` | `250000` | synthetic table size |
+| `BUCKAROO_STATIC` | `../../../../buckaroo/static` | dir holding the browser bundle |
+
+## Prerequisite: the browser bundle
+
+The demo reuses buckaroo's existing browser bundle (`standalone.js` + CSS),
+which the Python package builds into `buckaroo/static/`. If `pnpm demo` reports
+it's missing, build it from the repo root:
+
+```bash
+cd packages/js && pnpm build:standalone
+# (or ./scripts/full_build.sh)
+```
+
+## How it renders today (without #933)
+
+The viewer's transport (`WebSocketModel`) delivers each row window as a **binary
+parquet frame** paired with an `infinite_resp` JSON frame, then decodes it via
+`parquetRead(buffers[0])`. So this server sends the raw bytes from
+`DuckSource.copyToParquet` as that binary frame — the exact wire today's
+buckaroo-js-core already speaks. No `decodeDFData` (#933) needed.
+
+The backend logic is identical to the production IPC transport
+(`src/transport.ts`); only the framing differs. Post-#933, the same
+`DuckBackend.handleInfiniteRequest` answer (a single JSON message with an inline
+`parquet_b64` payload) flows straight through over Electron IPC with no
+re-framing.
+
+## What it exercises
+
+- `DESCRIBE` → `a,b,c…` rename + synthesized `index`
+- `SUMMARIZE` → `SDType` → pinned stat rows
+- `infinite_request` → sorted/windowed/renamed SQL → `COPY` → parquet
+- Serialization fidelity: a `BIGINT > 2^53` column (`big_id`) round-trips
+  exactly; `DATE`/`TIMESTAMP`/`NULL` preserved; `DECIMAL` shown as double (the
+  documented v1 limitation).

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/README.md
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/README.md
@@ -38,19 +38,20 @@ cd packages/js && pnpm build:standalone
 # (or ./scripts/full_build.sh)
 ```
 
-## How it renders today (without #933)
+## How it renders (legacy binary-frame path)
 
-The viewer's transport (`WebSocketModel`) delivers each row window as a **binary
-parquet frame** paired with an `infinite_resp` JSON frame, then decodes it via
+This demo deliberately uses `WebSocketModel`'s binary-frame path rather than
+#933's `decodeDFData`. `WebSocketModel` delivers each row window as a **binary
+parquet frame** paired with an `infinite_resp` JSON frame and decodes it via
 `parquetRead(buffers[0])`. So this server sends the raw bytes from
-`DuckSource.copyToParquet` as that binary frame — the exact wire today's
-buckaroo-js-core already speaks. No `decodeDFData` (#933) needed.
+`DuckSource.copyToParquet` as that binary frame — a wire buckaroo-js-core has
+always spoken — which keeps the demo self-contained over a plain WebSocket.
 
 The backend logic is identical to the production IPC transport
-(`src/transport.ts`); only the framing differs. Post-#933, the same
+(`src/transport.ts`); only the framing differs. Over Electron IPC the same
 `DuckBackend.handleInfiniteRequest` answer (a single JSON message with an inline
-`parquet_b64` payload) flows straight through over Electron IPC with no
-re-framing.
+`parquet_b64` payload) flows straight through, decoded by
+`decodeDFData(msg.payload, buffers)` (#933) with no re-framing.
 
 ## What it exercises
 

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
@@ -2,18 +2,18 @@
  * DuckDB WebSocket demo server.
  *
  * Stands the new `buckaroo-duckdb-node` backend behind the EXISTING buckaroo
- * server protocol so today's browser bundle (`buckaroo/static/standalone.js`)
+ * server protocol so the browser bundle (`buckaroo/static/standalone.js`)
  * renders a live, DuckDB-backed viewer — infinite scroll, sort, summary stats —
- * with no Python kernel and WITHOUT waiting on #933.
+ * with no Python kernel, over a plain WebSocket.
  *
- * Why this works pre-#933: the legacy protocol delivers each row window as a
- * binary parquet frame paired with an `infinite_resp` JSON frame, which
- * `WebSocketModel` already pairs into a `msg:custom` event and decodes via
- * `parquetRead(buffers[0])`. So the demo sends the raw parquet bytes from
- * `DuckSource.copyToParquet` as that binary frame. (Post-#933 the same backend
- * answers a single JSON message with an inline `parquet_b64` payload over IPC —
- * see ../../src/transport.ts. The backend logic is identical; only the framing
- * differs.)
+ * Why the legacy framing: `WebSocketModel` delivers each row window as a binary
+ * parquet frame paired with an `infinite_resp` JSON frame, pairs them into a
+ * `msg:custom` event, and decodes via `parquetRead(buffers[0])`. So the demo
+ * sends the raw parquet bytes from `DuckSource.copyToParquet` as that binary
+ * frame, which keeps it self-contained. (The production IPC transport instead
+ * answers a single JSON message with an inline `parquet_b64` payload, decoded by
+ * `decodeDFData(msg.payload, buffers)` from #933 — see ../../src/transport.ts.
+ * The backend logic is identical; only the framing differs.)
  *
  * Run:  pnpm demo        (from packages/buckaroo-duckdb-node)
  * Then open the printed http://localhost:8780/ URL.

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
@@ -1,0 +1,257 @@
+/**
+ * DuckDB WebSocket demo server.
+ *
+ * Stands the new `buckaroo-duckdb-node` backend behind the EXISTING buckaroo
+ * server protocol so today's browser bundle (`buckaroo/static/standalone.js`)
+ * renders a live, DuckDB-backed viewer — infinite scroll, sort, summary stats —
+ * with no Python kernel and WITHOUT waiting on #933.
+ *
+ * Why this works pre-#933: the legacy protocol delivers each row window as a
+ * binary parquet frame paired with an `infinite_resp` JSON frame, which
+ * `WebSocketModel` already pairs into a `msg:custom` event and decodes via
+ * `parquetRead(buffers[0])`. So the demo sends the raw parquet bytes from
+ * `DuckSource.copyToParquet` as that binary frame. (Post-#933 the same backend
+ * answers a single JSON message with an inline `parquet_b64` payload over IPC —
+ * see ../../src/transport.ts. The backend logic is identical; only the framing
+ * differs.)
+ *
+ * Run:  pnpm demo        (from packages/buckaroo-duckdb-node)
+ * Then open the printed http://localhost:8780/ URL.
+ */
+
+import http from 'node:http';
+import { readFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { WebSocketServer } from 'ws';
+import { DuckDBInstance } from '@duckdb/node-api';
+
+import { DuckBackend } from '../../dist/index.js';
+import { createNodeApiDuckSource } from '../../dist/adapters/nodeApiDuckSource.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PORT = Number(process.env.PORT ?? 8780);
+
+// The browser bundle + CSS the buckaroo Python package builds into buckaroo/static.
+const STATIC_DIR =
+  process.env.BUCKAROO_STATIC ??
+  resolve(__dirname, '../../../../buckaroo/static');
+
+const STATIC_FILES = {
+  'standalone.js': 'text/javascript',
+  'standalone.css': 'text/css',
+  'compiled.css': 'text/css',
+};
+
+// ---------------------------------------------------------------------------
+// Demo dataset — a synthetic table exercising the fidelity-critical types.
+// ---------------------------------------------------------------------------
+
+const TABLE = 'demo';
+const ROWS = Number(process.env.ROWS ?? 250_000);
+
+const CREATE_SQL = `
+  CREATE TABLE ${TABLE} AS
+  SELECT
+    i                                              AS row_id,
+    (9007199254740993 + i)::BIGINT                 AS big_id,        -- BIGINT > 2^53
+    (random() * 1000)::DOUBLE                       AS price,
+    ((random() * 100) - 50)::DECIMAL(12,4)          AS pnl,
+    DATE '2020-01-01' + (i % 1460)::INTEGER         AS trade_date,
+    TIMESTAMP '2020-01-01' + to_minutes((i * 7) % 525600) AS ts,
+    ['alpha','bravo','charlie','delta','echo'][(i % 5) + 1] AS bucket,
+    CASE WHEN i % 11 = 0 THEN NULL
+         ELSE 'order-' || lpad(i::VARCHAR, 7, '0') END    AS order_ref,
+    (i % 2 = 0)                                     AS is_active
+  FROM range(0, ${ROWS}) t(i)
+`;
+
+// The statement the backend renders. Any SQL the connection can resolve works.
+const BASE_STMT = `SELECT * FROM ${TABLE}`;
+
+// ---------------------------------------------------------------------------
+// Legacy-wire adaptation of the backend's transport-agnostic output.
+// ---------------------------------------------------------------------------
+
+/** Unwrap a `{format:'json', data}` envelope to a plain array (legacy df_data_dict). */
+function unwrapJsonEnvelope(value) {
+  if (value && typeof value === 'object' && value.format === 'json') {
+    return value.data;
+  }
+  return value;
+}
+
+function toLegacyInitialState(msg) {
+  const df_data_dict = {};
+  for (const [k, v] of Object.entries(msg.df_data_dict)) {
+    df_data_dict[k] = unwrapJsonEnvelope(v);
+  }
+  return {
+    type: 'initial_state',
+    protocol_version: 1,
+    mode: 'viewer',
+    prompt: '',
+    metadata: { path: `duckdb://${TABLE}`, rows: msg.df_meta.total_rows },
+    df_meta: msg.df_meta,
+    df_data_dict,
+    df_display_args: msg.df_display_args,
+    buckaroo_state: msg.buckaroo_state,
+    buckaroo_options: msg.buckaroo_options,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// HTTP: session page + static assets.
+// ---------------------------------------------------------------------------
+
+function sessionHtml(sessionId) {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Buckaroo (DuckDB) — ${sessionId}</title>
+  <link rel="stylesheet" href="/static/compiled.css">
+  <link rel="stylesheet" href="/static/standalone.css">
+  <style>
+    html, body { margin: 0; padding: 0; width: 100%; height: 100vh; background: #181d1f; }
+    body { display: flex; flex-direction: column; }
+    #filename-bar { padding: 4px 10px; font-family: sans-serif; font-size: 13px; color: #ccc; background: #222; border-bottom: 1px solid #333; flex-shrink: 0; }
+    #filename-bar:empty { display: none; }
+    #prompt-bar { padding: 4px 10px; font-family: sans-serif; font-size: 12px; color: #999; background: #222; border-bottom: 1px solid #333; flex-shrink: 0; }
+    #prompt-bar:empty { display: none; }
+    #root { flex: 1; display: flex; flex-direction: column; min-height: 0; margin-bottom: 20px; }
+    .buckaroo_anywidget, .dcf-root, .orig-df, .df-viewer { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+    .df-viewer .theme-hanger { flex: 1 !important; overflow: hidden; }
+    .flex { display: flex; } .flex-col { flex-direction: column; }
+    .orig-df.flex-row { flex-direction: column; }
+    .status-bar, .status-bar .theme-hanger { margin-bottom: 0; }
+    .df-viewer, .df-viewer .theme-hanger, .df-viewer .ag-root-wrapper { margin-top: 0; }
+  </style>
+</head>
+<body>
+  <div id="filename-bar"></div>
+  <div id="prompt-bar"></div>
+  <div id="root"></div>
+  <script type="module" src="/static/standalone.js"></script>
+</body>
+</html>`;
+}
+
+async function serveStatic(req, res, file) {
+  const path = join(STATIC_DIR, file);
+  if (!existsSync(path)) {
+    res.writeHead(404).end(`missing static asset: ${file}`);
+    return;
+  }
+  const body = await readFile(path);
+  res.writeHead(200, { 'content-type': STATIC_FILES[file] }).end(body);
+}
+
+// ---------------------------------------------------------------------------
+// Boot.
+// ---------------------------------------------------------------------------
+
+async function main() {
+  if (!existsSync(join(STATIC_DIR, 'standalone.js'))) {
+    console.error(
+      `\n  Browser bundle not found at ${STATIC_DIR}\n` +
+        `  Build it first (from the repo root):\n` +
+        `    cd packages/js && pnpm build:standalone\n` +
+        `  or set BUCKAROO_STATIC to a directory containing standalone.js.\n`,
+    );
+    process.exit(1);
+  }
+
+  // One in-memory DuckDB, one connection, shared by every WS client — the
+  // injected-connection model the backend is designed around.
+  const instance = await DuckDBInstance.create(':memory:');
+  const connection = await instance.connect();
+  console.log(`Creating demo table (${ROWS.toLocaleString()} rows)…`);
+  await connection.run(CREATE_SQL);
+  const source = createNodeApiDuckSource(connection);
+
+  const server = http.createServer(async (req, res) => {
+    try {
+      const url = new URL(req.url, `http://localhost:${PORT}`);
+      if (url.pathname === '/') {
+        res.writeHead(302, { location: '/s/demo' }).end();
+      } else if (url.pathname.startsWith('/s/')) {
+        res
+          .writeHead(200, { 'content-type': 'text/html' })
+          .end(sessionHtml(decodeURIComponent(url.pathname.slice(3))));
+      } else if (url.pathname.startsWith('/static/')) {
+        await serveStatic(req, res, url.pathname.slice('/static/'.length));
+      } else {
+        res.writeHead(404).end('not found');
+      }
+    } catch (err) {
+      res.writeHead(500).end(String(err));
+    }
+  });
+
+  const wss = new WebSocketServer({ server, path: undefined });
+  wss.on('connection', async (ws, req) => {
+    if (!req.url?.startsWith('/ws/')) {
+      ws.close();
+      return;
+    }
+    // Each client gets its own backend instance over the shared connection.
+    const backend = new DuckBackend(source, BASE_STMT);
+
+    try {
+      const initial = await backend.initialState();
+      ws.send(JSON.stringify(toLegacyInitialState(initial)));
+    } catch (err) {
+      console.error('initial_state failed:', err);
+      ws.close();
+      return;
+    }
+
+    ws.on('message', async (raw) => {
+      let msg;
+      try {
+        msg = JSON.parse(raw.toString());
+      } catch {
+        return;
+      }
+      if (msg.type !== 'infinite_request') return; // read-only viewer: ignore the rest
+
+      const args = msg.payload_args ?? {};
+      try {
+        const resp = await backend.handleInfiniteRequest(args);
+        // Re-frame the inline parquet_b64 envelope as the legacy two-frame wire.
+        const bytes = Buffer.from(resp.payload.data, 'base64');
+        ws.send(
+          JSON.stringify({
+            type: 'infinite_resp',
+            key: resp.key,
+            data: [],
+            length: resp.length,
+          }),
+        );
+        ws.send(bytes, { binary: true });
+      } catch (err) {
+        console.error('infinite_request failed:', err);
+        ws.send(
+          JSON.stringify({
+            type: 'infinite_resp',
+            key: args,
+            data: [],
+            length: 0,
+            error_info: String(err),
+          }),
+        );
+      }
+    });
+  });
+
+  server.listen(PORT, () => {
+    console.log(`\n  DuckDB buckaroo demo →  http://localhost:${PORT}/\n`);
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/packages/buckaroo-duckdb-node/package.json
+++ b/packages/buckaroo-duckdb-node/package.json
@@ -49,6 +49,7 @@
     "build": "tsc -p tsconfig.json",
     "test": "vitest run",
     "test:watch": "vitest",
+    "demo": "pnpm run build && node examples/duckdb-ws-server/server.mjs",
     "prepublishOnly": "pnpm run build"
   },
   "files": [
@@ -71,6 +72,7 @@
     "@duckdb/node-api": "1.4.4-r.3",
     "@types/node": "^22.15.3",
     "typescript": "~5.6.2",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "ws": "^8.18.0"
   }
 }

--- a/packages/buckaroo-duckdb-node/package.json
+++ b/packages/buckaroo-duckdb-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buckaroo-duckdb-node",
-  "version": "0.12.0",
+  "version": "0.15.2",
   "description": "DuckDB-backed buckaroo backend for pure Node/Electron hosts. Produces the same wire payloads (initial_state, infinite_resp, wide summary stats) that buckaroo-js-core's DFViewerInfinite already speaks, with no Python kernel.",
   "keywords": [
     "buckaroo",

--- a/packages/buckaroo-duckdb-node/package.json
+++ b/packages/buckaroo-duckdb-node/package.json
@@ -1,0 +1,76 @@
+{
+  "name": "buckaroo-duckdb-node",
+  "version": "0.12.0",
+  "description": "DuckDB-backed buckaroo backend for pure Node/Electron hosts. Produces the same wire payloads (initial_state, infinite_resp, wide summary stats) that buckaroo-js-core's DFViewerInfinite already speaks, with no Python kernel.",
+  "keywords": [
+    "buckaroo",
+    "duckdb",
+    "dataframe",
+    "data-viewer",
+    "electron",
+    "node"
+  ],
+  "license": "BSD-3-Clause",
+  "author": "Paddy Mullen",
+  "homepage": "https://github.com/buckaroo-data/buckaroo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/buckaroo-data/buckaroo.git",
+    "directory": "packages/buckaroo-duckdb-node"
+  },
+  "bugs": {
+    "url": "https://github.com/buckaroo-data/buckaroo/issues"
+  },
+  "packageManager": "pnpm@9.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "module": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./node-api": {
+      "types": "./dist/adapters/nodeApiDuckSource.d.ts",
+      "import": "./dist/adapters/nodeApiDuckSource.js",
+      "default": "./dist/adapters/nodeApiDuckSource.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "prepublishOnly": "pnpm run build"
+  },
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "dependencies": {
+    "hyparquet": "^1.8.2"
+  },
+  "peerDependencies": {
+    "@duckdb/node-api": ">=1.4.0"
+  },
+  "peerDependenciesMeta": {
+    "@duckdb/node-api": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@duckdb/node-api": "1.4.4-r.3",
+    "@types/node": "^22.15.3",
+    "typescript": "~5.6.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/buckaroo-duckdb-node/src/DuckSource.ts
+++ b/packages/buckaroo-duckdb-node/src/DuckSource.ts
@@ -1,0 +1,65 @@
+/**
+ * The injected connection seam.
+ *
+ * The core owns zero native bindings. An embedder hands in a `DuckSource`
+ * bound to *their* live connection (with their attached databases, registered
+ * files and temp views), because the stats/rows queries
+ * (`COPY (SELECT … FROM (<stmt>))`) only resolve in that same catalog. A
+ * self-owned connection would be a different database that can't see the
+ * user's tables.
+ *
+ * A batteries-included `@duckdb/node-api` adapter ships alongside
+ * (`buckaroo-duckdb-node/node-api`) for embedders who just want a connection.
+ */
+export interface DuckSource {
+  /** `DESCRIBE (<stmt>)` → ordered (name, type) pairs, in select order. */
+  describe(stmt: string): Promise<DescribeRow[]>;
+
+  /** `SUMMARIZE (<stmt>)` → one row per column. */
+  summarize(stmt: string): Promise<SummarizeRow[]>;
+
+  /**
+   * `COPY (<query>) TO '<tmpfile>' (FORMAT PARQUET)` → the file bytes.
+   *
+   * This is the only no-coercion serialization path with node-api@1.4.x
+   * (no Arrow output, no in-memory parquet): DuckDB serializes every type
+   * natively and the caller never touches a `DuckDBValue`.
+   */
+  copyToParquet(query: string): Promise<Uint8Array>;
+}
+
+/** One row of `DESCRIBE (<stmt>)`. DuckDB returns more columns; we use these. */
+export interface DescribeRow {
+  /** `column_name` */
+  name: string;
+  /** `column_type`, e.g. `BIGINT`, `DECIMAL(38,9)`, `VARCHAR`, `TIMESTAMP`. */
+  type: string;
+}
+
+/**
+ * One row of `SUMMARIZE (<stmt>)`. Field names match DuckDB's SUMMARIZE output.
+ * Numeric fields arrive as strings from `getRowObjectsJson()`; the stats layer
+ * keeps them verbatim (no coercion).
+ */
+export interface SummarizeRow {
+  column_name: string;
+  column_type: string;
+  min: string | null;
+  max: string | null;
+  approx_unique: number | string | null;
+  avg: string | null;
+  std: string | null;
+  q25: string | null;
+  q50: string | null;
+  q75: string | null;
+  count: number | string | null;
+  null_percentage: number | string | null;
+}
+
+/**
+ * Summary-stats dict: `Dict[col, Dict[stat, val]]`.
+ * Mirrors Python `SDType` (col_analysis.py:7-13). Serialized to the wide
+ * `{col}__{stat}` parquet shape for the `layout:'wide'` envelope.
+ */
+export type SDVal = string | number | boolean | null | SDVal[];
+export type SDType = Record<string, Record<string, SDVal>>;

--- a/packages/buckaroo-duckdb-node/src/adapters/nodeApiDuckSource.ts
+++ b/packages/buckaroo-duckdb-node/src/adapters/nodeApiDuckSource.ts
@@ -15,7 +15,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
-import type { DescribeRow, DuckSource, SummarizeRow } from '../DuckSource';
+import type { DescribeRow, DuckSource, SummarizeRow } from '../DuckSource.js';
 
 /**
  * The slice of `@duckdb/node-api`'s `DuckDBConnection` this adapter uses.

--- a/packages/buckaroo-duckdb-node/src/adapters/nodeApiDuckSource.ts
+++ b/packages/buckaroo-duckdb-node/src/adapters/nodeApiDuckSource.ts
@@ -1,0 +1,78 @@
+/**
+ * Batteries-included `DuckSource` over a `@duckdb/node-api` connection.
+ *
+ * Optional: the core package imports zero native bindings. Embedders who just
+ * want a connection import this entry (`buckaroo-duckdb-node/node-api`) and pass
+ * their live `DuckDBConnection`; aistudio-style hosts implement `DuckSource`
+ * directly against their own connection in the Electron main process.
+ *
+ * Serialization is the COPY → tempfile parquet path (the only no-coercion path
+ * with node-api@1.4.x: no Arrow output, no in-memory parquet). DuckDB serializes
+ * every type natively; we never touch a `DuckDBValue`.
+ */
+
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { DescribeRow, DuckSource, SummarizeRow } from '../DuckSource';
+
+/**
+ * The slice of `@duckdb/node-api`'s `DuckDBConnection` this adapter uses.
+ * Declared structurally so the core never imports the native module and the
+ * adapter stays decoupled from node-api's (pre-stable) exact class.
+ */
+export interface DuckDBConnectionLike {
+  run(sql: string): Promise<unknown>;
+  runAndReadAll(sql: string): Promise<DuckDBReaderLike>;
+}
+
+export interface DuckDBReaderLike {
+  getRowObjectsJson(): Array<Record<string, unknown>>;
+}
+
+export interface NodeApiDuckSourceOptions {
+  /** Directory for the per-window temp parquet files. Defaults to the OS tmpdir. */
+  tmpDir?: string;
+}
+
+/** Escape a single-quoted SQL string literal (for the COPY target path). */
+function sqlString(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+export function createNodeApiDuckSource(
+  connection: DuckDBConnectionLike,
+  opts: NodeApiDuckSourceOptions = {},
+): DuckSource {
+  const baseTmp = opts.tmpDir ?? tmpdir();
+
+  return {
+    async describe(stmt: string): Promise<DescribeRow[]> {
+      const reader = await connection.runAndReadAll(`DESCRIBE (${stmt})`);
+      return reader.getRowObjectsJson().map((r) => ({
+        name: String(r.column_name),
+        type: String(r.column_type),
+      }));
+    },
+
+    async summarize(stmt: string): Promise<SummarizeRow[]> {
+      const reader = await connection.runAndReadAll(`SUMMARIZE (${stmt})`);
+      return reader.getRowObjectsJson() as unknown as SummarizeRow[];
+    },
+
+    async copyToParquet(query: string): Promise<Uint8Array> {
+      const dir = await mkdtemp(join(baseTmp, 'buckaroo-duck-'));
+      const file = join(dir, `${randomUUID()}.parquet`);
+      try {
+        await connection.run(
+          `COPY (${query}) TO ${sqlString(file)} (FORMAT PARQUET)`,
+        );
+        return await readFile(file);
+      } finally {
+        // best-effort cleanup; a leaked temp dir must not fail the request
+        await rm(dir, { recursive: true, force: true }).catch(() => {});
+      }
+    },
+  };
+}

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -1,0 +1,154 @@
+/**
+ * The transport-agnostic backend. Composes rename + query + stats + config into
+ * the two messages a read-only viewer needs:
+ *
+ *   - `initialState()`     → the `initial_state` message.
+ *   - `handleInfiniteRequest(args)` → the `infinite_resp` message for one window.
+ *
+ * It owns the buckaroo-specific logic aistudio should not reinvent: the
+ * DESCRIBE→a,b,c+index rename, the SUMMARIZE→SDType stats, the
+ * infinite_request→windowed-SQL translation, and the type→displayer config.
+ *
+ * It is deliberately ignorant of *how* messages reach the renderer — wrap it in
+ * an IModel-over-IPC adapter (transport.ts) or any other transport.
+ */
+
+import type { DuckSource } from './DuckSource';
+import { buildRenamePlan, INDEX_COL, type RenamePlan } from './rename';
+import { effectiveQuery, windowedQuery, type QueryTransform } from './query';
+import { buildDfViewerConfig } from './columnConfig';
+import { summarizeToSDType, sdTypeToStatRows } from './stats';
+import type {
+  BuckarooOptions,
+  BuckarooState,
+  DFEnvelope,
+  InitialStateMessage,
+  PayloadArgs,
+  PayloadResponse,
+} from './wireTypes';
+
+export interface DuckBackendOptions {
+  /** display name / data key for the single source. Defaults to `'main'`. */
+  dataKey?: string;
+  /** summary-stats key. Defaults to `'all_stats'`. */
+  summaryStatsKey?: string;
+  /** v1: empty. Reserved for search (`+ WHERE`) and quick-command transforms. */
+  transforms?: QueryTransform[];
+}
+
+const READONLY_STATE: BuckarooState = {
+  sampled: false,
+  cleaning_method: false,
+  quick_command_args: {},
+  post_processing: false,
+  df_display: 'main',
+  show_commands: false,
+};
+
+const READONLY_OPTIONS: BuckarooOptions = {
+  sampled: [],
+  cleaning_method: [],
+  post_processing: [],
+  df_display: ['main'],
+  show_commands: [],
+};
+
+function toBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+export class DuckBackend {
+  private readonly source: DuckSource;
+  private readonly baseStmt: string;
+  private readonly dataKey: string;
+  private readonly summaryStatsKey: string;
+  private readonly transforms: QueryTransform[];
+
+  private plan?: RenamePlan;
+  private totalRows = 0;
+
+  constructor(source: DuckSource, baseStmt: string, opts: DuckBackendOptions = {}) {
+    this.source = source;
+    this.baseStmt = baseStmt;
+    this.dataKey = opts.dataKey ?? 'main';
+    this.summaryStatsKey = opts.summaryStatsKey ?? 'all_stats';
+    this.transforms = opts.transforms ?? [];
+  }
+
+  private get effectiveSql(): string {
+    return effectiveQuery(this.baseStmt, this.transforms);
+  }
+
+  /** Describe the (renamed) relation and cache the rename plan. */
+  private async ensurePlan(): Promise<RenamePlan> {
+    if (!this.plan) {
+      const describeRows = await this.source.describe(this.effectiveSql);
+      this.plan = buildRenamePlan(describeRows);
+    }
+    return this.plan;
+  }
+
+  async initialState(): Promise<InitialStateMessage> {
+    const plan = await this.ensurePlan();
+
+    // Stats over the renamed relation; column names come back as aliases. The
+    // relation includes the synthesized, non-null `index` column, so its
+    // SUMMARIZE count is the total row count — no extra count query needed.
+    const summarizeRows = await this.source.summarize(plan.renamedRelation(this.effectiveSql));
+    const indexRow = summarizeRows.find((r) => r.column_name === INDEX_COL);
+    this.totalRows = indexRow ? Number(indexRow.count) : 0;
+
+    const sd = summarizeToSDType(summarizeRows);
+    const statRows = sdTypeToStatRows(sd);
+
+    const dfViewerConfig = buildDfViewerConfig(plan);
+
+    return {
+      type: 'initial_state',
+      df_meta: {
+        total_rows: this.totalRows,
+        columns: plan.columns.length,
+        filtered_rows: this.totalRows,
+        rows_shown: this.totalRows,
+      },
+      df_data_dict: {
+        // main rows arrive on demand via infinite_request
+        [this.dataKey]: [],
+        // stats are small scalar aggregates — emitted pre-pivoted as json
+        [this.summaryStatsKey]: { format: 'json', data: statRows },
+      },
+      df_display_args: {
+        main: {
+          data_key: this.dataKey,
+          df_viewer_config: dfViewerConfig,
+          summary_stats_key: this.summaryStatsKey,
+        },
+      },
+      buckaroo_state: READONLY_STATE,
+      buckaroo_options: READONLY_OPTIONS,
+    };
+  }
+
+  /**
+   * Answer one `infinite_request`. The window is serialized through the
+   * COPY→parquet no-coercion path and returned inline as a `parquet_b64`
+   * envelope (single JSON message, no binary side-channel frame).
+   */
+  async handleInfiniteRequest(args: PayloadArgs): Promise<PayloadResponse> {
+    const plan = await this.ensurePlan();
+    const sql = windowedQuery(this.effectiveSql, plan, {
+      start: args.start,
+      end: args.end,
+      sort: args.sort,
+      sort_direction: args.sort_direction,
+    });
+    const bytes = await this.source.copyToParquet(sql);
+    const payload: DFEnvelope = { format: 'parquet_b64', data: toBase64(bytes) };
+    return {
+      type: 'infinite_resp',
+      key: args,
+      length: this.totalRows,
+      payload,
+    };
+  }
+}

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -28,13 +28,20 @@ import type {
 } from './wireTypes.js';
 
 export interface DuckBackendOptions {
-  /** display name / data key for the single source. Defaults to `'main'`. */
-  dataKey?: string;
   /** summary-stats key. Defaults to `'all_stats'`. */
   summaryStatsKey?: string;
   /** v1: empty. Reserved for search (`+ WHERE`) and quick-command transforms. */
   transforms?: QueryTransform[];
 }
+
+/**
+ * The live infinite source MUST be keyed `'main'`: the viewer
+ * (`BuckarooWidgetInfinite.getDataWrapper`) only wires the on-demand datasource
+ * when `data_key === 'main'`. Any other key is read as a preloaded static
+ * array out of `df_data_dict`, which we leave empty — so the grid would render
+ * empty and never issue `infinite_request`s. Not configurable for that reason.
+ */
+const MAIN_DATA_KEY = 'main';
 
 const READONLY_STATE: BuckarooState = {
   sampled: false,
@@ -60,7 +67,6 @@ function toBase64(bytes: Uint8Array): string {
 export class DuckBackend {
   private readonly source: DuckSource;
   private readonly baseStmt: string;
-  private readonly dataKey: string;
   private readonly summaryStatsKey: string;
   private readonly transforms: QueryTransform[];
 
@@ -70,7 +76,6 @@ export class DuckBackend {
   constructor(source: DuckSource, baseStmt: string, opts: DuckBackendOptions = {}) {
     this.source = source;
     this.baseStmt = baseStmt;
-    this.dataKey = opts.dataKey ?? 'main';
     this.summaryStatsKey = opts.summaryStatsKey ?? 'all_stats';
     this.transforms = opts.transforms ?? [];
   }
@@ -113,13 +118,13 @@ export class DuckBackend {
       },
       df_data_dict: {
         // main rows arrive on demand via infinite_request
-        [this.dataKey]: [],
+        [MAIN_DATA_KEY]: [],
         // stats are small scalar aggregates — emitted pre-pivoted as json
         [this.summaryStatsKey]: { format: 'json', data: statRows },
       },
       df_display_args: {
         main: {
-          data_key: this.dataKey,
+          data_key: MAIN_DATA_KEY,
           df_viewer_config: dfViewerConfig,
           summary_stats_key: this.summaryStatsKey,
         },

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -13,11 +13,11 @@
  * an IModel-over-IPC adapter (transport.ts) or any other transport.
  */
 
-import type { DuckSource } from './DuckSource';
-import { buildRenamePlan, INDEX_COL, type RenamePlan } from './rename';
-import { effectiveQuery, windowedQuery, type QueryTransform } from './query';
-import { buildDfViewerConfig } from './columnConfig';
-import { summarizeToSDType, sdTypeToStatRows } from './stats';
+import type { DuckSource } from './DuckSource.js';
+import { buildRenamePlan, INDEX_COL, type RenamePlan } from './rename.js';
+import { effectiveQuery, windowedQuery, type QueryTransform } from './query.js';
+import { buildDfViewerConfig } from './columnConfig.js';
+import { summarizeToSDType, sdTypeToStatRows } from './stats.js';
 import type {
   BuckarooOptions,
   BuckarooState,
@@ -25,7 +25,7 @@ import type {
   InitialStateMessage,
   PayloadArgs,
   PayloadResponse,
-} from './wireTypes';
+} from './wireTypes.js';
 
 export interface DuckBackendOptions {
   /** display name / data key for the single source. Defaults to `'main'`. */

--- a/packages/buckaroo-duckdb-node/src/columnConfig.ts
+++ b/packages/buckaroo-duckdb-node/src/columnConfig.ts
@@ -1,0 +1,74 @@
+/**
+ * Build the `df_viewer_config` (column_config + pinned_rows + left_col_configs)
+ * from the rename plan.
+ *
+ * Pinned rows reference only the v1 stats this backend actually computes from
+ * `SUMMARIZE` (see stats.ts) so no pinned row renders empty. Histogram rows are
+ * a fast-follow once the histogram SQL lands.
+ */
+
+import type { RenamePlan } from './rename';
+import { INDEX_COL } from './rename';
+import { duckTypeToColType, displayerForColType } from './duckTypes';
+import type { ColumnConfig, DFViewerConfig, PinnedRowConfig } from './wireTypes';
+
+/**
+ * The stat keys pinned in v1, in display order. Each must match a stat name
+ * produced by stats.ts (and therefore a wide `{col}__{stat}` column).
+ * `dtype` renders via `obj`; the rest `inherit` the column's own displayer
+ * (styling_helpers.py: obj_/inherit_).
+ */
+export const V1_PINNED_STATS: ReadonlyArray<{ stat: string; inherit: boolean }> = [
+  { stat: 'dtype', inherit: false },
+  { stat: 'null_count', inherit: true },
+  { stat: 'distinct_count', inherit: true },
+  { stat: 'mean', inherit: true },
+  { stat: 'std', inherit: true },
+  { stat: 'min', inherit: true },
+  { stat: 'q25', inherit: true },
+  { stat: 'q50', inherit: true },
+  { stat: 'q75', inherit: true },
+  { stat: 'max', inherit: true },
+];
+
+export function buildPinnedRows(): PinnedRowConfig[] {
+  return V1_PINNED_STATS.map(({ stat, inherit }) => ({
+    primary_key_val: stat,
+    displayer_args: inherit ? { displayer: 'inherit' } : { displayer: 'obj' },
+  }));
+}
+
+export function buildColumnConfig(plan: RenamePlan): ColumnConfig[] {
+  return plan.columns.map((c) => {
+    const colType = duckTypeToColType(c.type);
+    const cc: ColumnConfig = {
+      col_name: c.alias,
+      header_name: c.origName,
+      displayer_args: displayerForColType(colType),
+    };
+    if (colType === 'string') {
+      // DefaultMainStyling attaches a simple tooltip to string columns.
+      cc.tooltip_config = { tooltip_type: 'simple', val_column: c.alias };
+    }
+    return cc;
+  });
+}
+
+/** The leftmost (index) column config. */
+export function buildLeftColConfigs(): ColumnConfig[] {
+  return [
+    {
+      col_name: INDEX_COL,
+      header_name: INDEX_COL,
+      displayer_args: { displayer: 'obj' },
+    },
+  ];
+}
+
+export function buildDfViewerConfig(plan: RenamePlan): DFViewerConfig {
+  return {
+    pinned_rows: buildPinnedRows(),
+    column_config: buildColumnConfig(plan),
+    left_col_configs: buildLeftColConfigs(),
+  };
+}

--- a/packages/buckaroo-duckdb-node/src/columnConfig.ts
+++ b/packages/buckaroo-duckdb-node/src/columnConfig.ts
@@ -7,10 +7,10 @@
  * a fast-follow once the histogram SQL lands.
  */
 
-import type { RenamePlan } from './rename';
-import { INDEX_COL } from './rename';
-import { duckTypeToColType, displayerForColType } from './duckTypes';
-import type { ColumnConfig, DFViewerConfig, PinnedRowConfig } from './wireTypes';
+import type { RenamePlan } from './rename.js';
+import { INDEX_COL } from './rename.js';
+import { duckTypeToColType, displayerForColType } from './duckTypes.js';
+import type { ColumnConfig, DFViewerConfig, PinnedRowConfig } from './wireTypes.js';
 
 /**
  * The stat keys pinned in v1, in display order. Each must match a stat name

--- a/packages/buckaroo-duckdb-node/src/duckTypes.ts
+++ b/packages/buckaroo-duckdb-node/src/duckTypes.ts
@@ -1,0 +1,76 @@
+/**
+ * DuckDB type string → buckaroo column category → displayer args.
+ *
+ * The category mapping follows the plan's type map:
+ *   INT / BIGINT / etc -> integer, DOUBLE / REAL / DECIMAL -> float,
+ *   VARCHAR -> string, BOOLEAN -> string, DATE / TIMESTAMP / TIME -> datetime,
+ *   everything else -> obj.
+ *
+ * The displayer *args* mirror `DefaultMainStyling.style_column`
+ * (customizations/styling.py:70-142) so a column renders identically to the
+ * pandas/polars backends — notably buckaroo renders integers through the
+ * `float` displayer with zero fraction digits, not the `integer` displayer.
+ */
+
+import type { DisplayerArgs } from './wireTypes';
+
+export type ColType = 'integer' | 'float' | 'datetime' | 'string' | 'obj';
+
+/** Strip the parameter list: `DECIMAL(38,9)` → `DECIMAL`. */
+function baseType(duckType: string): string {
+  return duckType
+    .trim()
+    .toUpperCase()
+    .replace(/\(.*$/, '')
+    .trim();
+}
+
+const INTEGER_TYPES = new Set([
+  'TINYINT',
+  'SMALLINT',
+  'INTEGER',
+  'BIGINT',
+  'HUGEINT',
+  'UTINYINT',
+  'USMALLINT',
+  'UINTEGER',
+  'UBIGINT',
+  'UHUGEINT',
+  'INT',
+  'INT1',
+  'INT2',
+  'INT4',
+  'INT8',
+]);
+
+const FLOAT_TYPES = new Set(['DOUBLE', 'REAL', 'FLOAT', 'FLOAT4', 'FLOAT8', 'DECIMAL', 'NUMERIC']);
+
+export function duckTypeToColType(duckType: string): ColType {
+  // Array / nested types render as object cells, not scalars.
+  if (/[\[\]]/.test(duckType)) return 'obj';
+  const t = baseType(duckType);
+  if (t === 'STRUCT' || t === 'MAP' || t === 'LIST' || t === 'UNION') return 'obj';
+  if (INTEGER_TYPES.has(t)) return 'integer';
+  if (FLOAT_TYPES.has(t)) return 'float';
+  if (t === 'VARCHAR' || t === 'CHAR' || t === 'TEXT' || t === 'STRING' || t === 'UUID')
+    return 'string';
+  if (t === 'BOOLEAN' || t === 'BOOL') return 'string'; // plan: BOOLEAN → string
+  if (t === 'DATE' || t === 'TIME' || t.startsWith('TIMESTAMP')) return 'datetime';
+  return 'obj';
+}
+
+/** The displayer args for a column category (DefaultMainStyling parity). */
+export function displayerForColType(colType: ColType): DisplayerArgs {
+  switch (colType) {
+    case 'integer':
+      return { displayer: 'float', min_fraction_digits: 0, max_fraction_digits: 0 };
+    case 'float':
+      return { displayer: 'float', min_fraction_digits: 3, max_fraction_digits: 3 };
+    case 'datetime':
+      return { displayer: 'datetimeLocaleString', locale: 'en-US', args: {} };
+    case 'string':
+      return { displayer: 'string', max_length: 35 };
+    case 'obj':
+      return { displayer: 'obj' };
+  }
+}

--- a/packages/buckaroo-duckdb-node/src/duckTypes.ts
+++ b/packages/buckaroo-duckdb-node/src/duckTypes.ts
@@ -12,7 +12,7 @@
  * `float` displayer with zero fraction digits, not the `integer` displayer.
  */
 
-import type { DisplayerArgs } from './wireTypes';
+import type { DisplayerArgs } from './wireTypes.js';
 
 export type ColType = 'integer' | 'float' | 'datetime' | 'string' | 'obj';
 

--- a/packages/buckaroo-duckdb-node/src/index.ts
+++ b/packages/buckaroo-duckdb-node/src/index.ts
@@ -1,8 +1,8 @@
 // Copyright (c) Paddy Mullen
 // Distributed under the terms of the Modified BSD License.
 
-export { DuckBackend } from './backend';
-export type { DuckBackendOptions } from './backend';
+export { DuckBackend } from './backend.js';
+export type { DuckBackendOptions } from './backend.js';
 
 export type {
   DuckSource,
@@ -10,25 +10,25 @@ export type {
   SummarizeRow,
   SDType,
   SDVal,
-} from './DuckSource';
+} from './DuckSource.js';
 
 export {
   buildRenamePlan,
   colAlias,
   quoteIdent,
   INDEX_COL,
-} from './rename';
-export type { RenamePlan } from './rename';
+} from './rename.js';
+export type { RenamePlan } from './rename.js';
 
 export {
   effectiveQuery,
   windowedQuery,
   countQuery,
-} from './query';
-export type { QueryTransform, WindowParams } from './query';
+} from './query.js';
+export type { QueryTransform, WindowParams } from './query.js';
 
-export { duckTypeToColType, displayerForColType } from './duckTypes';
-export type { ColType } from './duckTypes';
+export { duckTypeToColType, displayerForColType } from './duckTypes.js';
+export type { ColType } from './duckTypes.js';
 
 export {
   buildColumnConfig,
@@ -36,19 +36,19 @@ export {
   buildPinnedRows,
   buildLeftColConfigs,
   V1_PINNED_STATS,
-} from './columnConfig';
+} from './columnConfig.js';
 
 export {
   summarizeToSDType,
   sdTypeToStatRows,
   sdTypeToWideRow,
   V1_STAT_NAMES,
-} from './stats';
+} from './stats.js';
 
-export { IpcDuckModel, makeIpcMainHandler } from './transport';
-export type { IModel, IpcInvoke } from './transport';
+export { IpcDuckModel, makeIpcMainHandler } from './transport.js';
+export type { IModel, IpcInvoke } from './transport.js';
 
-export type * from './wireTypes';
+export type * from './wireTypes.js';
 
 // The @duckdb/node-api adapter is a separate entry point so the core imports
 // zero native bindings: import from 'buckaroo-duckdb-node/node-api'.

--- a/packages/buckaroo-duckdb-node/src/index.ts
+++ b/packages/buckaroo-duckdb-node/src/index.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Paddy Mullen
+// Distributed under the terms of the Modified BSD License.
+
+export { DuckBackend } from './backend';
+export type { DuckBackendOptions } from './backend';
+
+export type {
+  DuckSource,
+  DescribeRow,
+  SummarizeRow,
+  SDType,
+  SDVal,
+} from './DuckSource';
+
+export {
+  buildRenamePlan,
+  colAlias,
+  quoteIdent,
+  INDEX_COL,
+} from './rename';
+export type { RenamePlan } from './rename';
+
+export {
+  effectiveQuery,
+  windowedQuery,
+  countQuery,
+} from './query';
+export type { QueryTransform, WindowParams } from './query';
+
+export { duckTypeToColType, displayerForColType } from './duckTypes';
+export type { ColType } from './duckTypes';
+
+export {
+  buildColumnConfig,
+  buildDfViewerConfig,
+  buildPinnedRows,
+  buildLeftColConfigs,
+  V1_PINNED_STATS,
+} from './columnConfig';
+
+export {
+  summarizeToSDType,
+  sdTypeToStatRows,
+  sdTypeToWideRow,
+  V1_STAT_NAMES,
+} from './stats';
+
+export { IpcDuckModel, makeIpcMainHandler } from './transport';
+export type { IModel, IpcInvoke } from './transport';
+
+export type * from './wireTypes';
+
+// The @duckdb/node-api adapter is a separate entry point so the core imports
+// zero native bindings: import from 'buckaroo-duckdb-node/node-api'.

--- a/packages/buckaroo-duckdb-node/src/query.ts
+++ b/packages/buckaroo-duckdb-node/src/query.ts
@@ -9,8 +9,8 @@
  * rather than rewrites.
  */
 
-import type { RenamePlan } from './rename';
-import { INDEX_COL } from './rename';
+import type { RenamePlan } from './rename.js';
+import { INDEX_COL } from './rename.js';
 
 /**
  * A transform applied to the base statement before describe/stats/rows. v1

--- a/packages/buckaroo-duckdb-node/src/query.ts
+++ b/packages/buckaroo-duckdb-node/src/query.ts
@@ -1,0 +1,78 @@
+/**
+ * SQL translation: the effective-query seam plus `infinite_request` windowing.
+ *
+ * Everything routes through `effectiveQuery(baseStmt, transforms)` — never off
+ * the raw `stmt`. v1's transform list is empty (sort/paging are per-request
+ * window params, not transforms), but routing `DESCRIBE`, stats and row
+ * windowing through this one seam is what makes search (`+ WHERE`, re-run stats
+ * for `search_` keys) and shape-changing quick commands clean fast-follows
+ * rather than rewrites.
+ */
+
+import type { RenamePlan } from './rename';
+import { INDEX_COL } from './rename';
+
+/**
+ * A transform applied to the base statement before describe/stats/rows. v1
+ * defines none; the shape is fixed now so fast-follows (search WHERE, quick
+ * commands) slot in without changing call sites.
+ */
+export interface QueryTransform {
+  kind: string;
+  /** wrap the incoming SQL and return the transformed SQL. */
+  apply(sql: string): string;
+}
+
+/** Compose the base statement with the (v1: empty) transform list. */
+export function effectiveQuery(
+  baseStmt: string,
+  transforms: QueryTransform[] = [],
+): string {
+  return transforms.reduce((sql, t) => t.apply(sql), baseStmt);
+}
+
+export interface WindowParams {
+  start: number;
+  end: number;
+  /** renamed sort column (`a`), as it arrives from the client. */
+  sort?: string;
+  sort_direction?: string;
+}
+
+/** SELECT `count(*)` over the effective query — the `length` for infinite_resp. */
+export function countQuery(effectiveSql: string): string {
+  return `SELECT count(*) AS n FROM (${effectiveSql}) AS _buckaroo_count`;
+}
+
+/**
+ * Build the windowed, sorted, renamed query for one `infinite_request`.
+ *
+ * Order of operations matters: the rename plan synthesizes `index` over the
+ * unsorted relation, so we wrap *that* in the ORDER BY / LIMIT / OFFSET. Each
+ * row therefore keeps its original `index` after sorting.
+ *
+ * The sort column arrives already renamed (`a`); we ORDER BY the alias directly
+ * against the renamed relation. An unknown/empty sort falls back to `index` for
+ * a stable window (DuckDB `ROW_NUMBER() OVER ()` order is otherwise unstable
+ * across LIMIT/OFFSET calls).
+ */
+export function windowedQuery(
+  effectiveSql: string,
+  plan: RenamePlan,
+  win: WindowParams,
+): string {
+  const inner = plan.renamedRelation(effectiveSql);
+  const limit = Math.max(0, win.end - win.start);
+  const offset = Math.max(0, win.start);
+
+  const orderCol =
+    win.sort && plan.aliases.includes(win.sort) ? win.sort : INDEX_COL;
+  const dir = win.sort_direction === 'desc' ? 'DESC' : 'ASC';
+  // tie-break on index so the window is deterministic when the sort col has ties
+  const orderBy =
+    orderCol === INDEX_COL
+      ? `${INDEX_COL} ${dir}`
+      : `${orderCol} ${dir}, ${INDEX_COL} ASC`;
+
+  return `SELECT * FROM (${inner}) AS _buckaroo_win ORDER BY ${orderBy} LIMIT ${limit} OFFSET ${offset}`;
+}

--- a/packages/buckaroo-duckdb-node/src/rename.ts
+++ b/packages/buckaroo-duckdb-node/src/rename.ts
@@ -1,0 +1,90 @@
+/**
+ * Column renaming: raw DuckDB columns → buckaroo's `a, b, c…` space, plus a
+ * synthesized `index`.
+ *
+ * Why rename at all (the JS core is agnostic to the `a,b,c` form, it only needs
+ * `column_config.col_name` to equal the row-object keys) — three failure modes
+ * that are *more* likely from user SQL than from a DataFrame:
+ *   1. A column literally named `index`/`level_0` collides with buckaroo's
+ *      reserved key (stat/pinned-row matching is by `{index: …}`). DuckDB has no
+ *      implicit index so we synthesize one; renaming every user column out of
+ *      the way removes the collision entirely.
+ *   2. Dotted names (`price.usd`) are an ag-grid `field` foot-gun.
+ *   3. Duplicate names from `SELECT * FROM a JOIN b` collapse to one JS key.
+ *
+ * The alias scheme is buckaroo's own (df_util.py:to_chars): base-26 with 'a' as
+ * the zero digit — a, b, …, z, ba, bb, … — so this backend renames into the
+ * exact same space the rest of buckaroo (e.g. xorq_buckaroo) uses.
+ */
+
+import type { DescribeRow } from './DuckSource';
+
+/** Reserved row-object key buckaroo uses for stat/pinned-row matching. */
+export const INDEX_COL = 'index';
+
+/** df_util.py:to_digits — positive integer → base-`b` digits, most significant first. */
+function toDigits(n: number, b: number): number[] {
+  if (n === 0) return [0];
+  const digits: number[] = [];
+  while (n > 0) {
+    digits.unshift(n % b);
+    n = Math.floor(n / b);
+  }
+  return digits;
+}
+
+/** df_util.py:to_chars — column index → `a, b, …, z, ba, bb, …`. */
+export function colAlias(i: number): string {
+  return toDigits(i, 26)
+    .map((d) => String.fromCharCode(d + 97))
+    .join('');
+}
+
+/** Quote a SQL identifier, doubling embedded double-quotes. */
+export function quoteIdent(name: string): string {
+  return `"${name.replace(/"/g, '""')}"`;
+}
+
+export interface RenamePlan {
+  /** alias (`a`) → original column name. For `header_name` + sort reversal. */
+  renameMap: Record<string, string>;
+  /** aliases in select order. */
+  aliases: string[];
+  /** the (alias, original DuckDB type) pairs in order. */
+  columns: Array<{ alias: string; origName: string; type: string }>;
+  /**
+   * The renamed relation: every source column projected to its alias, plus a
+   * synthesized 0-based `index` assigned in input-scan order (before any sort).
+   * Callers wrap this with ORDER BY / LIMIT / OFFSET.
+   */
+  renamedRelation(stmt: string): string;
+}
+
+/**
+ * Build the rename plan from `DESCRIBE (<stmt>)` output.
+ *
+ * `index` is computed with `(ROW_NUMBER() OVER ()) - 1` over the *unsorted*
+ * relation so each row keeps its original position when a sort is applied
+ * downstream (the outer ORDER BY sorts rows that already carry their index).
+ */
+export function buildRenamePlan(describeRows: DescribeRow[]): RenamePlan {
+  const columns = describeRows.map((row, i) => ({
+    alias: colAlias(i),
+    origName: row.name,
+    type: row.type,
+  }));
+
+  const renameMap: Record<string, string> = {};
+  for (const c of columns) renameMap[c.alias] = c.origName;
+  const aliases = columns.map((c) => c.alias);
+
+  const renamedRelation = (stmt: string): string => {
+    const projections = columns.map(
+      (c) => `${quoteIdent(c.origName)} AS ${c.alias}`,
+    );
+    projections.push(`(ROW_NUMBER() OVER ()) - 1 AS ${INDEX_COL}`);
+    return `SELECT ${projections.join(', ')} FROM (${stmt}) AS _buckaroo_src`;
+  };
+
+  return { renameMap, aliases, columns, renamedRelation };
+}

--- a/packages/buckaroo-duckdb-node/src/rename.ts
+++ b/packages/buckaroo-duckdb-node/src/rename.ts
@@ -17,7 +17,7 @@
  * exact same space the rest of buckaroo (e.g. xorq_buckaroo) uses.
  */
 
-import type { DescribeRow } from './DuckSource';
+import type { DescribeRow } from './DuckSource.js';
 
 /** Reserved row-object key buckaroo uses for stat/pinned-row matching. */
 export const INDEX_COL = 'index';

--- a/packages/buckaroo-duckdb-node/src/stats.ts
+++ b/packages/buckaroo-duckdb-node/src/stats.ts
@@ -23,6 +23,7 @@
 
 import type { SummarizeRow, SDType, SDVal } from './DuckSource.js';
 import { INDEX_COL } from './rename.js';
+import { duckTypeToColType } from './duckTypes.js';
 import type { DFData, DFDataRow } from './wireTypes.js';
 
 /** Stat names produced in v1, in the order they should appear as pinned rows. */
@@ -47,6 +48,20 @@ function maybeNumber(v: string | number | null): SDVal {
   if (trimmed === '') return null;
   const n = Number(trimmed);
   return Number.isFinite(n) ? n : v;
+}
+
+/**
+ * min/max coercion is type-aware: numeric columns get a real number, every
+ * other column keeps the raw string. A VARCHAR column whose min/max looks
+ * numeric (`'00123'` ZIP codes, IDs) must NOT be coerced — that would strip
+ * leading zeros and misrepresent the pinned stat. Likewise dates/booleans stay
+ * as their SUMMARIZE string form.
+ */
+function minMaxForColType(v: string | number | null, duckType: string): SDVal {
+  const colType = duckTypeToColType(duckType);
+  if (colType === 'integer' || colType === 'float') return maybeNumber(v);
+  if (v === null || v === undefined) return null;
+  return v;
 }
 
 /** count × null_percentage (a 0–100 percentage) → integer null count. */
@@ -77,11 +92,11 @@ export function summarizeToSDType(rows: SummarizeRow[]): SDType {
       distinct_count: maybeNumber(r.approx_unique as string | number | null),
       mean: maybeNumber(r.avg),
       std: maybeNumber(r.std),
-      min: maybeNumber(r.min),
+      min: minMaxForColType(r.min, r.column_type),
       q25: maybeNumber(r.q25),
       q50: maybeNumber(r.q50),
       q75: maybeNumber(r.q75),
-      max: maybeNumber(r.max),
+      max: minMaxForColType(r.max, r.column_type),
     };
   }
   return sd;

--- a/packages/buckaroo-duckdb-node/src/stats.ts
+++ b/packages/buckaroo-duckdb-node/src/stats.ts
@@ -1,0 +1,119 @@
+/**
+ * Summary stats: `SUMMARIZE` → `SDType` → the pivoted stat rows the viewer
+ * consumes.
+ *
+ * The plan's v1 SUMMARIZE → stat mapping:
+ *   dtype          ← column_type
+ *   min / max      ← min / max
+ *   distinct_count ← approx_unique
+ *   mean / std     ← avg / std
+ *   null_count     ← count × null_percentage (derived)
+ *   q25/q50/q75    ← q25 / q50 / q75 (approx)
+ *
+ * Histograms/quantile displayers are a fast-follow (not in SUMMARIZE).
+ *
+ * Note on serialization: these are computed aggregate scalars, not user row
+ * data, so the no-coercion rule (which exists to protect BigInt/DECIMAL/etc.
+ * fidelity on the *row* path) does not apply here. We emit the stats as already
+ * pivoted rows over the `json` envelope, so the payload never touches the
+ * fragile binary path. If wide-`{col}__{stat}` parquet is later preferred,
+ * `sdTypeToWideRow` produces that shape for a `copyToParquet`/`layout:'wide'`
+ * round-trip without changing the SDType producer.
+ */
+
+import type { SummarizeRow, SDType, SDVal } from './DuckSource';
+import { INDEX_COL } from './rename';
+import type { DFData, DFDataRow } from './wireTypes';
+
+/** Stat names produced in v1, in the order they should appear as pinned rows. */
+export const V1_STAT_NAMES = [
+  'dtype',
+  'null_count',
+  'distinct_count',
+  'mean',
+  'std',
+  'min',
+  'q25',
+  'q50',
+  'q75',
+  'max',
+] as const;
+
+/** Number if `v` is a finite numeric string/number, else the value unchanged. */
+function maybeNumber(v: string | number | null): SDVal {
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  const trimmed = v.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : v;
+}
+
+/** count × null_percentage (a 0–100 percentage) → integer null count. */
+function deriveNullCount(
+  count: number | string | null,
+  nullPct: number | string | null,
+): SDVal {
+  const c = typeof count === 'string' ? Number(count) : count;
+  const p = typeof nullPct === 'string' ? Number(nullPct) : nullPct;
+  if (c === null || p === null || !Number.isFinite(c) || !Number.isFinite(p)) {
+    return null;
+  }
+  return Math.round((c * p) / 100);
+}
+
+/**
+ * Map `SUMMARIZE` rows → `SDType` (keyed by the column name as SUMMARIZE
+ * reports it — the alias, when summarizing the renamed relation). The
+ * synthesized `index` column is skipped.
+ */
+export function summarizeToSDType(rows: SummarizeRow[]): SDType {
+  const sd: SDType = {};
+  for (const r of rows) {
+    if (r.column_name === INDEX_COL) continue;
+    sd[r.column_name] = {
+      dtype: r.column_type,
+      null_count: deriveNullCount(r.count, r.null_percentage),
+      distinct_count: maybeNumber(r.approx_unique as string | number | null),
+      mean: maybeNumber(r.avg),
+      std: maybeNumber(r.std),
+      min: maybeNumber(r.min),
+      q25: maybeNumber(r.q25),
+      q50: maybeNumber(r.q50),
+      q75: maybeNumber(r.q75),
+      max: maybeNumber(r.max),
+    };
+  }
+  return sd;
+}
+
+/**
+ * Pivot `SDType` into the row-per-stat form the viewer consumes directly:
+ * `[{index:'dtype', level_0:'dtype', a:'BIGINT', b:'VARCHAR'}, …]`.
+ * Mirrors serialization_utils.py:_pivot_wide_sd_row.
+ */
+export function sdTypeToStatRows(sd: SDType): DFData {
+  const cols = Object.keys(sd);
+  return V1_STAT_NAMES.map((stat) => {
+    const row: DFDataRow = { [INDEX_COL]: stat, level_0: stat };
+    for (const col of cols) {
+      row[col] = (sd[col]?.[stat] ?? null) as DFDataRow[string];
+    }
+    return row;
+  });
+}
+
+/**
+ * Build the single wide `{col}__{stat}` record (serialization_utils.py:
+ * sd_to_parquet_b64 naming). List/dict values are JSON-encoded the same way the
+ * Python producer does. Provided for a future `layout:'wide'` parquet path.
+ */
+export function sdTypeToWideRow(sd: SDType): Record<string, SDVal> {
+  const wide: Record<string, SDVal> = {};
+  for (const [col, stats] of Object.entries(sd)) {
+    for (const [stat, val] of Object.entries(stats)) {
+      wide[`${col}__${stat}`] = Array.isArray(val) ? JSON.stringify(val) : val;
+    }
+  }
+  return wide;
+}

--- a/packages/buckaroo-duckdb-node/src/stats.ts
+++ b/packages/buckaroo-duckdb-node/src/stats.ts
@@ -21,9 +21,9 @@
  * round-trip without changing the SDType producer.
  */
 
-import type { SummarizeRow, SDType, SDVal } from './DuckSource';
-import { INDEX_COL } from './rename';
-import type { DFData, DFDataRow } from './wireTypes';
+import type { SummarizeRow, SDType, SDVal } from './DuckSource.js';
+import { INDEX_COL } from './rename.js';
+import type { DFData, DFDataRow } from './wireTypes.js';
 
 /** Stat names produced in v1, in the order they should appear as pinned rows. */
 export const V1_STAT_NAMES = [

--- a/packages/buckaroo-duckdb-node/src/transport.ts
+++ b/packages/buckaroo-duckdb-node/src/transport.ts
@@ -26,8 +26,8 @@
  * is no binary frame and no `buffers` array.
  */
 
-import type { DuckBackend } from './backend';
-import type { InitialStateMessage, PayloadResponse } from './wireTypes';
+import type { DuckBackend } from './backend.js';
+import type { InitialStateMessage, PayloadResponse } from './wireTypes.js';
 
 /** The `ipcRenderer.invoke`-shaped function the renderer hands in. */
 export type IpcInvoke = (channel: string, msg: unknown) => Promise<unknown>;

--- a/packages/buckaroo-duckdb-node/src/transport.ts
+++ b/packages/buckaroo-duckdb-node/src/transport.ts
@@ -1,16 +1,13 @@
 /**
  * `IModel`-over-IPC transport adapter (renderer side).
  *
- * ┌──────────── PARTIALLY BLOCKED ON #933 ────────────────────────────────────┐
- * │ The PRODUCER side (this file + the backend) is complete and decoupled. The │
- * │ CONSUMER side — buckaroo-js-core decoding the `parquet_b64` payload on the  │
- * │ infinite path — requires #933's `decodeDFData(msg.payload, buffers)`.       │
- * │ Today the infinite handler does `parquetRead(buffers[0])` and crashes on a  │
- * │ single JSON message with inline parquet (BuckarooWidgetInfinite.tsx:122).   │
- * │ So this adapter is wired and unit-tested against the message contract, but  │
- * │ end-to-end rendering must wait for #933 to land in js-core. Do not ship the │
- * │ renderer integration before then.                                          │
- * └────────────────────────────────────────────────────────────────────────────┘
+ * Both sides of the wire are now in place. The PRODUCER (this file + the
+ * backend) emits a single JSON `infinite_resp` whose `payload` is a bare
+ * `parquet_b64` `DFEnvelope`. The CONSUMER — buckaroo-js-core's infinite
+ * handler — decodes it via #933's `decodeDFData(msg.payload, buffers)`
+ * (BuckarooWidgetInfinite.tsx:125), so an inline-parquet single-message reply
+ * (no binary side-channel frame) renders end-to-end. The pre-#933 handler did
+ * `parquetRead(buffers[0])` and could not consume this shape.
  *
  * aistudio has no Node webserver — it is Electron main + renderer over IPC
  * (`ipcMain.handle` / `ipcRenderer.invoke`). buckaroo-js-core runs in the
@@ -21,9 +18,9 @@
  *   adapter emits "msg:custom" with the reply.
  *
  * The "two frames" of `WebSocketModel` is a WebSocketModel implementation
- * detail; the React handler only needs the `"msg:custom"` event. Post-#933 the
- * reply is a single JSON object with an inline `parquet_b64` payload, so there
- * is no binary frame and no `buffers` array.
+ * detail; the React handler only needs the `"msg:custom"` event. The reply is
+ * a single JSON object with an inline `parquet_b64` payload, so there is no
+ * binary frame and no `buffers` array.
  */
 
 import type { DuckBackend } from './backend.js';

--- a/packages/buckaroo-duckdb-node/src/transport.ts
+++ b/packages/buckaroo-duckdb-node/src/transport.ts
@@ -1,0 +1,117 @@
+/**
+ * `IModel`-over-IPC transport adapter (renderer side).
+ *
+ * ┌──────────── PARTIALLY BLOCKED ON #933 ────────────────────────────────────┐
+ * │ The PRODUCER side (this file + the backend) is complete and decoupled. The │
+ * │ CONSUMER side — buckaroo-js-core decoding the `parquet_b64` payload on the  │
+ * │ infinite path — requires #933's `decodeDFData(msg.payload, buffers)`.       │
+ * │ Today the infinite handler does `parquetRead(buffers[0])` and crashes on a  │
+ * │ single JSON message with inline parquet (BuckarooWidgetInfinite.tsx:122).   │
+ * │ So this adapter is wired and unit-tested against the message contract, but  │
+ * │ end-to-end rendering must wait for #933 to land in js-core. Do not ship the │
+ * │ renderer integration before then.                                          │
+ * └────────────────────────────────────────────────────────────────────────────┘
+ *
+ * aistudio has no Node webserver — it is Electron main + renderer over IPC
+ * (`ipcMain.handle` / `ipcRenderer.invoke`). buckaroo-js-core runs in the
+ * renderer and can't call native DuckDB bindings (they live in main). This
+ * adapter implements the `IModel` seam the React tree already speaks:
+ *
+ *   model.send(msg)  →  invoke('buckaroo:msg', msg)  →  main answers  →
+ *   adapter emits "msg:custom" with the reply.
+ *
+ * The "two frames" of `WebSocketModel` is a WebSocketModel implementation
+ * detail; the React handler only needs the `"msg:custom"` event. Post-#933 the
+ * reply is a single JSON object with an inline `parquet_b64` payload, so there
+ * is no binary frame and no `buffers` array.
+ */
+
+import type { DuckBackend } from './backend';
+import type { InitialStateMessage, PayloadResponse } from './wireTypes';
+
+/** The `ipcRenderer.invoke`-shaped function the renderer hands in. */
+export type IpcInvoke = (channel: string, msg: unknown) => Promise<unknown>;
+
+/** Minimal structural copy of buckaroo-js-core's `IModel` (the only exported type). */
+export interface IModel {
+  send(msg: unknown): void;
+  get(key: string): unknown;
+  set(key: string, value: unknown): void;
+  save_changes(): void;
+  on(event: string, handler: (...args: unknown[]) => void): void;
+  off(event: string, handler: (...args: unknown[]) => void): void;
+}
+
+type Handler = (...args: unknown[]) => void;
+
+/**
+ * Renderer-side `IModel`. Outgoing `infinite_request` messages are forwarded
+ * over IPC; the main-process reply is re-emitted as a `"msg:custom"` event,
+ * which is what `getKeySmartRowCache` listens for.
+ */
+export class IpcDuckModel implements IModel {
+  private readonly invoke: IpcInvoke;
+  private readonly channel: string;
+  private readonly listeners = new Map<string, Set<Handler>>();
+  private readonly state = new Map<string, unknown>();
+
+  constructor(invoke: IpcInvoke, opts: { channel?: string } = {}) {
+    this.invoke = invoke;
+    this.channel = opts.channel ?? 'buckaroo:msg';
+  }
+
+  send(msg: unknown): void {
+    void this.invoke(this.channel, msg).then((reply) => {
+      if (reply !== undefined && reply !== null) {
+        this.emit('msg:custom', reply);
+      }
+    });
+  }
+
+  get(key: string): unknown {
+    return this.state.get(key);
+  }
+  set(key: string, value: unknown): void {
+    this.state.set(key, value);
+    this.emit('change:' + key, value);
+  }
+  save_changes(): void {
+    /* no-op: read-only viewer, no state to persist upstream */
+  }
+
+  on(event: string, handler: Handler): void {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(handler);
+  }
+  off(event: string, handler: Handler): void {
+    this.listeners.get(event)?.delete(handler);
+  }
+  private emit(event: string, ...args: unknown[]): void {
+    for (const h of this.listeners.get(event) ?? []) h(...args);
+  }
+}
+
+/**
+ * The main-process handler. Register with
+ * `ipcMain.handle('buckaroo:msg', makeIpcMainHandler(backend))`.
+ *
+ * Returns the reply object the renderer re-emits as `"msg:custom"`. Unknown
+ * message types (e.g. `buckaroo_state_change` quick commands) are no-ops in v1.
+ */
+export function makeIpcMainHandler(
+  backend: DuckBackend,
+): (event: unknown, msg: { type?: string; payload_args?: unknown }) => Promise<
+  InitialStateMessage | PayloadResponse | null
+> {
+  return async (_event, msg) => {
+    switch (msg?.type) {
+      case 'initial_state':
+        return backend.initialState();
+      case 'infinite_request':
+        return backend.handleInfiniteRequest(msg.payload_args as never);
+      default:
+        // viewer mode is read-only: buckaroo_state_change et al. are no-ops
+        return null;
+    }
+  };
+}

--- a/packages/buckaroo-duckdb-node/src/wireTypes.ts
+++ b/packages/buckaroo-duckdb-node/src/wireTypes.ts
@@ -124,16 +124,22 @@ export type DFDataRow = Record<
 export type DFData = DFDataRow[];
 
 /**
- * Transport envelope. This is the post-#933 unified `DFEnvelope` shape
- * (docs/plans/unified-df-transport.md). The DuckDB backend only ever emits
- * `parquet_b64` (inline base64 parquet) — the no-coercion path. The other
- * variants are declared for completeness so this type matches the js-core
- * `decodeDFData` input once #933 lands.
+ * Transport envelope — the unified `DFEnvelope` from #933 (DFWhole.ts:258-261,
+ * docs/plans/unified-df-transport.md). js-core's
+ * `decodeDFData(envelope, buffers)` is the matching consumer. The DuckDB
+ * backend only ever emits `parquet_b64` (inline base64 parquet, the
+ * no-coercion path) for rows and `json` for the pre-pivoted stats; the
+ * `parquet_buffer` variant is declared so this type stays structurally
+ * identical to the js-core source of truth.
+ *
+ * `layout` is orthogonal to transport: `'wide'` marks the single-row
+ * `{col}__{stat}` summary-stats shape the decoder pivots; `'row'` (or absent)
+ * is ordinary row-layout parquet, JSON-parsed per cell.
  */
 export type DFEnvelope =
-  | { format: 'parquet_buffer'; buffer_index: number; layout?: 'wide' }
-  | { format: 'parquet_b64'; data: string; layout?: 'wide' }
-  | { format: 'json'; data: DFData; layout?: 'wide' };
+  | { format: 'parquet_buffer'; buffer_index: number; layout?: 'wide' | 'row' }
+  | { format: 'parquet_b64'; data: string; layout?: 'wide' | 'row' }
+  | { format: 'json'; data: DFData; layout?: 'wide' | 'row' };
 
 // ---------------------------------------------------------------------------
 // Widget state  (WidgetTypes.tsx)
@@ -179,8 +185,9 @@ export interface PayloadArgs {
 }
 
 /**
- * The `infinite_resp` message. Post-#933 the parquet bytes ride in `payload`
- * as a bare `DFEnvelope` rather than via the untagged `buffers[0]` convention.
+ * The `infinite_resp` message. Per #933 the parquet bytes ride in `payload` as
+ * a bare `DFEnvelope` (decoded by `decodeDFData(msg.payload, buffers)`) rather
+ * than via the untagged `buffers[0]` convention.
  */
 export interface PayloadResponse {
   type: 'infinite_resp';

--- a/packages/buckaroo-duckdb-node/src/wireTypes.ts
+++ b/packages/buckaroo-duckdb-node/src/wireTypes.ts
@@ -1,0 +1,201 @@
+/**
+ * Wire-contract types for the buckaroo viewer protocol.
+ *
+ * These mirror the structural shapes that `buckaroo-js-core` already speaks.
+ * buckaroo-js-core does not export its config/data types from its public entry
+ * (only `IModel` is exported), so this backend re-declares the protocol it
+ * produces. They are structurally compatible by design — the citations below
+ * point at the source of truth in buckaroo-js-core; keep them in sync.
+ *
+ * Source of truth:
+ *   - components/DFViewerParts/DFWhole.ts  (DisplayerArgs, ColumnConfig, DFData, DFEnvelope)
+ *   - components/DFViewerParts/gridUtils.ts (IDisplayArgs)
+ *   - components/DFViewerParts/SmartRowCache.ts (PayloadArgs)
+ *   - components/WidgetTypes.tsx (DFMeta, BuckarooState, BuckarooOptions)
+ */
+
+// ---------------------------------------------------------------------------
+// Displayer args  (DFWhole.ts:9-108)
+// ---------------------------------------------------------------------------
+
+export interface ObjDisplayerA {
+  displayer: 'obj';
+  max_length?: number;
+}
+
+export interface StringDisplayerA {
+  displayer: 'string';
+  max_length?: number;
+}
+
+export interface FloatDisplayerA {
+  displayer: 'float';
+  min_fraction_digits: number;
+  max_fraction_digits: number;
+}
+
+export interface IntegerDisplayerA {
+  displayer: 'integer';
+  min_digits: number;
+  max_digits: number;
+}
+
+export interface DatetimeLocaleDisplayerA {
+  displayer: 'datetimeLocaleString';
+  locale: 'en-US' | 'en-GB' | 'en-CA' | 'fr-FR' | 'es-ES' | 'de-DE' | 'ja-JP';
+  args: Record<string, unknown>;
+}
+
+export interface DatetimeDefaultDisplayerA {
+  displayer: 'datetimeDefault';
+}
+
+export interface BooleanDisplayerA {
+  displayer: 'boolean';
+}
+
+export interface HistogramDisplayerA {
+  displayer: 'histogram';
+}
+
+export interface InheritDisplayerA {
+  displayer: 'inherit';
+}
+
+export type DisplayerArgs =
+  | ObjDisplayerA
+  | StringDisplayerA
+  | FloatDisplayerA
+  | IntegerDisplayerA
+  | DatetimeLocaleDisplayerA
+  | DatetimeDefaultDisplayerA
+  | BooleanDisplayerA
+  | HistogramDisplayerA
+  | InheritDisplayerA;
+
+// ---------------------------------------------------------------------------
+// Column / viewer config  (DFWhole.ts:170-242, styling_core.py:143-178)
+// ---------------------------------------------------------------------------
+
+export interface TooltipConfig {
+  tooltip_type: 'simple';
+  val_column: string;
+}
+
+export interface NormalColumnConfig {
+  col_name: string;
+  header_name: string;
+  displayer_args: DisplayerArgs;
+  tooltip_config?: TooltipConfig;
+  ag_grid_specs?: Record<string, unknown>;
+}
+
+export type ColumnConfig = NormalColumnConfig;
+
+export interface PinnedRowConfig {
+  primary_key_val: string;
+  displayer_args: DisplayerArgs;
+  default_renderer_columns?: string[];
+}
+
+export interface DFViewerConfig {
+  pinned_rows: PinnedRowConfig[];
+  column_config: ColumnConfig[];
+  left_col_configs: ColumnConfig[];
+  extra_grid_config?: Record<string, unknown>;
+  component_config?: Record<string, unknown>;
+}
+
+/** gridUtils.ts:411-415 / styling_core.py:180-183 */
+export interface IDisplayArgs {
+  data_key: string;
+  df_viewer_config: DFViewerConfig;
+  summary_stats_key: string;
+}
+
+// ---------------------------------------------------------------------------
+// Data + transport envelope
+// ---------------------------------------------------------------------------
+
+export type DFDataRow = Record<
+  string,
+  string | number | boolean | unknown[] | Record<string, unknown> | null
+>;
+export type DFData = DFDataRow[];
+
+/**
+ * Transport envelope. This is the post-#933 unified `DFEnvelope` shape
+ * (docs/plans/unified-df-transport.md). The DuckDB backend only ever emits
+ * `parquet_b64` (inline base64 parquet) — the no-coercion path. The other
+ * variants are declared for completeness so this type matches the js-core
+ * `decodeDFData` input once #933 lands.
+ */
+export type DFEnvelope =
+  | { format: 'parquet_buffer'; buffer_index: number; layout?: 'wide' }
+  | { format: 'parquet_b64'; data: string; layout?: 'wide' }
+  | { format: 'json'; data: DFData; layout?: 'wide' };
+
+// ---------------------------------------------------------------------------
+// Widget state  (WidgetTypes.tsx)
+// ---------------------------------------------------------------------------
+
+export interface DFMeta {
+  total_rows: number;
+  columns: number;
+  filtered_rows: number;
+  rows_shown: number;
+}
+
+export interface BuckarooState {
+  sampled: string | false;
+  cleaning_method: string | false;
+  quick_command_args: Record<string, (number | string)[]>;
+  post_processing: string | false;
+  df_display: string;
+  show_commands: string | false;
+}
+
+export interface BuckarooOptions {
+  sampled: string[];
+  cleaning_method: string[];
+  post_processing: string[];
+  df_display: string[];
+  show_commands: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Infinite-scroll request/response  (SmartRowCache.ts:17-33)
+// ---------------------------------------------------------------------------
+
+export interface PayloadArgs {
+  sourceName: string;
+  start: number;
+  end: number;
+  origEnd: number;
+  sort?: string;
+  sort_direction?: string;
+  request_time?: number;
+  second_request?: PayloadArgs;
+}
+
+/**
+ * The `infinite_resp` message. Post-#933 the parquet bytes ride in `payload`
+ * as a bare `DFEnvelope` rather than via the untagged `buffers[0]` convention.
+ */
+export interface PayloadResponse {
+  type: 'infinite_resp';
+  key: PayloadArgs;
+  length: number;
+  payload: DFEnvelope;
+  error_info?: string;
+}
+
+/** The `initial_state` message for a read-only viewer. */
+export interface InitialStateMessage {
+  type: 'initial_state';
+  df_meta: DFMeta;
+  df_data_dict: Record<string, DFEnvelope | DFData>;
+  df_display_args: Record<string, IDisplayArgs>;
+  buckaroo_state: BuckarooState;
+  buckaroo_options: BuckarooOptions;
+}

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -83,6 +83,9 @@ describe('DuckBackend.initialState', () => {
     expect(cfg.column_config.map((c) => c.col_name)).toEqual(['a', 'b']);
     expect(cfg.column_config[0].header_name).toBe('price');
 
+    // the live infinite source MUST be keyed 'main' — the viewer only wires the
+    // on-demand datasource for that exact key; any other key renders empty.
+    expect(msg.df_display_args.main.data_key).toBe('main');
     // main rows are empty (delivered via infinite_request); stats are inline json
     expect(msg.df_data_dict.main).toEqual([]);
     const stats = msg.df_data_dict.all_stats as { format: string; data: unknown[] };

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import { DuckBackend } from '../src/backend';
+import type { DuckSource, DescribeRow, SummarizeRow } from '../src/DuckSource';
+
+/**
+ * A fake DuckSource — exercises the orchestrator (rename → stats → config →
+ * windowed-SQL → envelope) without a native DuckDB. The real round-trip is
+ * covered by spike.duckdb.test.ts.
+ */
+function fakeSource(): DuckSource & { lastCopyQuery?: string } {
+  const src: DuckSource & { lastCopyQuery?: string } = {
+    async describe(): Promise<DescribeRow[]> {
+      return [
+        { name: 'price', type: 'DOUBLE' },
+        { name: 'name', type: 'VARCHAR' },
+      ];
+    },
+    async summarize(): Promise<SummarizeRow[]> {
+      return [
+        {
+          column_name: 'a',
+          column_type: 'DOUBLE',
+          min: '1.5',
+          max: '9.5',
+          approx_unique: 5,
+          avg: '5.0',
+          std: '2.0',
+          q25: '2',
+          q50: '5',
+          q75: '8',
+          count: 42,
+          null_percentage: 0,
+        },
+        {
+          column_name: 'b',
+          column_type: 'VARCHAR',
+          min: 'a',
+          max: 'z',
+          approx_unique: 7,
+          avg: null,
+          std: null,
+          q25: null,
+          q50: null,
+          q75: null,
+          count: 42,
+          null_percentage: 0,
+        },
+        {
+          column_name: 'index',
+          column_type: 'BIGINT',
+          min: '0',
+          max: '41',
+          approx_unique: 42,
+          avg: '20.5',
+          std: '12',
+          q25: '10',
+          q50: '20',
+          q75: '31',
+          count: 42, // total rows
+          null_percentage: 0,
+        },
+      ];
+    },
+    async copyToParquet(query: string): Promise<Uint8Array> {
+      src.lastCopyQuery = query;
+      return new Uint8Array([1, 2, 3, 4]);
+    },
+  };
+  return src;
+}
+
+describe('DuckBackend.initialState', () => {
+  it('builds a read-only viewer initial_state with renamed columns + stats', async () => {
+    const backend = new DuckBackend(fakeSource(), 'SELECT * FROM t');
+    const msg = await backend.initialState();
+
+    expect(msg.type).toBe('initial_state');
+    // total derived from the index column's SUMMARIZE count
+    expect(msg.df_meta.total_rows).toBe(42);
+    expect(msg.df_meta.columns).toBe(2);
+
+    const cfg = msg.df_display_args.main.df_viewer_config;
+    expect(cfg.column_config.map((c) => c.col_name)).toEqual(['a', 'b']);
+    expect(cfg.column_config[0].header_name).toBe('price');
+
+    // main rows are empty (delivered via infinite_request); stats are inline json
+    expect(msg.df_data_dict.main).toEqual([]);
+    const stats = msg.df_data_dict.all_stats as { format: string; data: unknown[] };
+    expect(stats.format).toBe('json');
+    expect(stats.data.length).toBeGreaterThan(0);
+  });
+});
+
+describe('DuckBackend.handleInfiniteRequest', () => {
+  it('emits a parquet_b64 envelope and a windowed/sorted query', async () => {
+    const src = fakeSource();
+    const backend = new DuckBackend(src, 'SELECT * FROM t');
+    await backend.initialState(); // establishes total + plan
+
+    const resp = await backend.handleInfiniteRequest({
+      sourceName: 'main',
+      start: 0,
+      end: 10,
+      origEnd: 10,
+      sort: 'a',
+      sort_direction: 'desc',
+    });
+
+    expect(resp.type).toBe('infinite_resp');
+    expect(resp.length).toBe(42);
+    expect(resp.payload).toEqual({
+      format: 'parquet_b64',
+      data: Buffer.from([1, 2, 3, 4]).toString('base64'),
+    });
+    expect(src.lastCopyQuery).toContain('ORDER BY a DESC, index ASC');
+    expect(src.lastCopyQuery).toContain('LIMIT 10 OFFSET 0');
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/columnConfig.test.ts
+++ b/packages/buckaroo-duckdb-node/test/columnConfig.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { duckTypeToColType, displayerForColType } from '../src/duckTypes';
+import {
+  buildColumnConfig,
+  buildDfViewerConfig,
+  buildPinnedRows,
+  V1_PINNED_STATS,
+} from '../src/columnConfig';
+import { buildRenamePlan } from '../src/rename';
+import type { DescribeRow } from '../src/DuckSource';
+
+describe('duckTypeToColType', () => {
+  it.each([
+    ['BIGINT', 'integer'],
+    ['INTEGER', 'integer'],
+    ['UTINYINT', 'integer'],
+    ['DOUBLE', 'float'],
+    ['DECIMAL(38,9)', 'float'],
+    ['REAL', 'float'],
+    ['VARCHAR', 'string'],
+    ['BOOLEAN', 'string'],
+    ['DATE', 'datetime'],
+    ['TIMESTAMP', 'datetime'],
+    ['TIMESTAMP WITH TIME ZONE', 'datetime'],
+    ['INTEGER[]', 'obj'],
+    ['STRUCT(a INT)', 'obj'],
+  ])('%s → %s', (duckType, expected) => {
+    expect(duckTypeToColType(duckType)).toBe(expected);
+  });
+});
+
+describe('displayerForColType (DefaultMainStyling parity)', () => {
+  it('renders integers via float with 0 fraction digits', () => {
+    expect(displayerForColType('integer')).toEqual({
+      displayer: 'float',
+      min_fraction_digits: 0,
+      max_fraction_digits: 0,
+    });
+  });
+  it('renders floats with 3 fraction digits', () => {
+    expect(displayerForColType('float')).toEqual({
+      displayer: 'float',
+      min_fraction_digits: 3,
+      max_fraction_digits: 3,
+    });
+  });
+  it('renders datetimes with the en-US locale displayer', () => {
+    expect(displayerForColType('datetime')).toEqual({
+      displayer: 'datetimeLocaleString',
+      locale: 'en-US',
+      args: {},
+    });
+  });
+});
+
+describe('buildColumnConfig', () => {
+  const plan = buildRenamePlan([
+    { name: 'price', type: 'DOUBLE' },
+    { name: 'qty', type: 'BIGINT' },
+    { name: 'name', type: 'VARCHAR' },
+  ] as DescribeRow[]);
+  const cc = buildColumnConfig(plan);
+
+  it('uses the alias as col_name and the original as header_name', () => {
+    expect(cc[0]).toMatchObject({ col_name: 'a', header_name: 'price' });
+    expect(cc[1]).toMatchObject({ col_name: 'b', header_name: 'qty' });
+  });
+
+  it('attaches a tooltip only to string columns, keyed by the alias', () => {
+    expect(cc[2].tooltip_config).toEqual({ tooltip_type: 'simple', val_column: 'c' });
+    expect(cc[0].tooltip_config).toBeUndefined();
+  });
+});
+
+describe('buildPinnedRows / buildDfViewerConfig', () => {
+  it('pins only the v1 stats, dtype via obj and the rest via inherit', () => {
+    const pinned = buildPinnedRows();
+    expect(pinned.map((p) => p.primary_key_val)).toEqual(
+      V1_PINNED_STATS.map((s) => s.stat),
+    );
+    expect(pinned[0]).toEqual({
+      primary_key_val: 'dtype',
+      displayer_args: { displayer: 'obj' },
+    });
+    expect(pinned[1].displayer_args).toEqual({ displayer: 'inherit' });
+  });
+
+  it('assembles a full viewer config with a left index column', () => {
+    const plan = buildRenamePlan([{ name: 'x', type: 'INTEGER' }] as DescribeRow[]);
+    const cfg = buildDfViewerConfig(plan);
+    expect(cfg.column_config).toHaveLength(1);
+    expect(cfg.left_col_configs[0].col_name).toBe('index');
+    expect(cfg.pinned_rows.length).toBe(V1_PINNED_STATS.length);
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/query.test.ts
+++ b/packages/buckaroo-duckdb-node/test/query.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { effectiveQuery, countQuery, windowedQuery } from '../src/query';
+import type { QueryTransform } from '../src/query';
+import { buildRenamePlan } from '../src/rename';
+import type { DescribeRow } from '../src/DuckSource';
+
+const rows: DescribeRow[] = [
+  { name: 'price', type: 'DOUBLE' },
+  { name: 'name', type: 'VARCHAR' },
+];
+const plan = buildRenamePlan(rows);
+
+describe('effectiveQuery', () => {
+  it('returns the base statement unchanged with no transforms (v1)', () => {
+    expect(effectiveQuery('SELECT * FROM t')).toBe('SELECT * FROM t');
+  });
+  it('composes transforms left to right', () => {
+    const where: QueryTransform = {
+      kind: 'where',
+      apply: (sql) => `SELECT * FROM (${sql}) WHERE price > 0`,
+    };
+    expect(effectiveQuery('SELECT * FROM t', [where])).toBe(
+      'SELECT * FROM (SELECT * FROM t) WHERE price > 0',
+    );
+  });
+});
+
+describe('countQuery', () => {
+  it('wraps the effective query in count(*)', () => {
+    expect(countQuery('SELECT * FROM t')).toBe(
+      'SELECT count(*) AS n FROM (SELECT * FROM t) AS _buckaroo_count',
+    );
+  });
+});
+
+describe('windowedQuery', () => {
+  it('applies LIMIT/OFFSET from start/end and defaults sort to index', () => {
+    const sql = windowedQuery('SELECT * FROM t', plan, { start: 100, end: 200 });
+    expect(sql).toContain('LIMIT 100 OFFSET 100');
+    expect(sql).toContain('ORDER BY index ASC');
+  });
+
+  it('sorts by the renamed alias with an index tie-break', () => {
+    const sql = windowedQuery('SELECT * FROM t', plan, {
+      start: 0,
+      end: 50,
+      sort: 'a',
+      sort_direction: 'desc',
+    });
+    expect(sql).toContain('ORDER BY a DESC, index ASC');
+    expect(sql).toContain('LIMIT 50 OFFSET 0');
+  });
+
+  it('ignores an unknown sort column and falls back to index', () => {
+    const sql = windowedQuery('SELECT * FROM t', plan, {
+      start: 0,
+      end: 10,
+      sort: 'zzz',
+    });
+    expect(sql).toContain('ORDER BY index ASC');
+  });
+
+  it('clamps negative/empty windows to zero', () => {
+    const sql = windowedQuery('SELECT * FROM t', plan, { start: 5, end: 5 });
+    expect(sql).toContain('LIMIT 0 OFFSET 5');
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/rename.test.ts
+++ b/packages/buckaroo-duckdb-node/test/rename.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { colAlias, quoteIdent, buildRenamePlan, INDEX_COL } from '../src/rename';
+import type { DescribeRow } from '../src/DuckSource';
+
+describe('colAlias (base-26, matches df_util.py:to_chars)', () => {
+  it('maps 0..25 to a..z', () => {
+    expect(colAlias(0)).toBe('a');
+    expect(colAlias(1)).toBe('b');
+    expect(colAlias(25)).toBe('z');
+  });
+  it('rolls over with a as the zero digit', () => {
+    expect(colAlias(26)).toBe('ba');
+    expect(colAlias(27)).toBe('bb');
+    expect(colAlias(51)).toBe('bz');
+    expect(colAlias(52)).toBe('ca');
+  });
+});
+
+describe('quoteIdent', () => {
+  it('quotes and doubles embedded quotes', () => {
+    expect(quoteIdent('price')).toBe('"price"');
+    expect(quoteIdent('price.usd')).toBe('"price.usd"');
+    expect(quoteIdent('we"ird')).toBe('"we""ird"');
+  });
+});
+
+describe('buildRenamePlan', () => {
+  const rows: DescribeRow[] = [
+    { name: 'price.usd', type: 'DOUBLE' },
+    { name: 'index', type: 'BIGINT' },
+    { name: 'name', type: 'VARCHAR' },
+  ];
+  const plan = buildRenamePlan(rows);
+
+  it('renames every column to a,b,c and keeps the original-name map', () => {
+    expect(plan.aliases).toEqual(['a', 'b', 'c']);
+    expect(plan.renameMap).toEqual({ a: 'price.usd', b: 'index', c: 'name' });
+  });
+
+  it('carries dtype alongside each alias', () => {
+    expect(plan.columns).toEqual([
+      { alias: 'a', origName: 'price.usd', type: 'DOUBLE' },
+      { alias: 'b', origName: 'index', type: 'BIGINT' },
+      { alias: 'c', origName: 'name', type: 'VARCHAR' },
+    ]);
+  });
+
+  it('a user column named index does not collide with the synthesized index', () => {
+    const sql = plan.renamedRelation('SELECT 1');
+    // the user's "index" column became alias b; our synthesized index is separate
+    expect(sql).toContain('"index" AS b');
+    expect(sql).toContain(`AS ${INDEX_COL}`);
+  });
+
+  it('projects aliases, synthesizes a 0-based index, and quotes dotted names', () => {
+    const sql = plan.renamedRelation('SELECT * FROM t');
+    expect(sql).toContain('"price.usd" AS a');
+    expect(sql).toContain('(ROW_NUMBER() OVER ()) - 1 AS index');
+    expect(sql).toContain('FROM (SELECT * FROM t) AS _buckaroo_src');
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/spike.duckdb.test.ts
+++ b/packages/buckaroo-duckdb-node/test/spike.duckdb.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Spike: prove the transport's serialization layer end to end, before any
+ * histogram SQL (plan §"The spike", step 1 + step 3). This is the part of the
+ * spike that does NOT depend on #933.
+ *
+ *   1. Serialization fidelity + latency — COPY mixed BIGINT>2^53, DECIMAL(38,9),
+ *      DATE, TIMESTAMP, NULL to a tempfile parquet, read it back with hyparquet,
+ *      assert fidelity AND measure the per-window COPY→read round-trip.
+ *   3. Stats round-trip — SUMMARIZE → SDType → pivoted stat rows.
+ *
+ * Reaches a real DuckDB instance via @duckdb/node-api. If that native module
+ * isn't installed the suite skips (it's an optional peer dep).
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { parquetReadObjects, asyncBufferFromFile } from 'hyparquet';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { createNodeApiDuckSource } from '../src/adapters/nodeApiDuckSource';
+import type { DuckDBConnectionLike } from '../src/adapters/nodeApiDuckSource';
+import { buildRenamePlan } from '../src/rename';
+import { effectiveQuery, windowedQuery } from '../src/query';
+import { summarizeToSDType, sdTypeToStatRows } from '../src/stats';
+import type { DuckSource } from '../src/DuckSource';
+
+// Dynamically import the optional native module; skip the suite if absent.
+let connection: DuckDBConnectionLike | undefined;
+let source: DuckSource | undefined;
+
+async function readParquet(bytes: Uint8Array): Promise<Record<string, unknown>[]> {
+  const dir = await mkdtemp(join(tmpdir(), 'buckaroo-spike-'));
+  const file = join(dir, `${randomUUID()}.parquet`);
+  try {
+    await writeFile(file, bytes);
+    const buf = await asyncBufferFromFile(file);
+    return (await parquetReadObjects({ file: buf })) as Record<string, unknown>[];
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+beforeAll(async () => {
+  try {
+    const duck = await import('@duckdb/node-api');
+    const instance = await duck.DuckDBInstance.create(':memory:');
+    connection = (await instance.connect()) as unknown as DuckDBConnectionLike;
+    source = createNodeApiDuckSource(connection);
+  } catch (err) {
+    console.warn(
+      '[spike] @duckdb/node-api not available, skipping DuckDB spike:',
+      (err as Error).message,
+    );
+  }
+});
+
+// A statement exercising the fidelity-critical types. Column → alias:
+//   big64 (BIGINT > 2^53) → a, huge (HUGEINT) → b, dec (DECIMAL(38,9)) → c,
+//   d (DATE) → d, ts (TIMESTAMP) → e, name (nullable VARCHAR) → f.
+const MIXED_STMT = `
+  SELECT
+    (9007199254740993 + i)::BIGINT AS big64,
+    (i * 1000000000)::HUGEINT + 9007199254740993 AS huge,
+    (i + 0.123456789)::DECIMAL(38,9) AS dec,
+    DATE '2020-01-01' + i::INTEGER AS d,
+    TIMESTAMP '2020-01-01 00:00:00' + to_hours(i::INTEGER) AS ts,
+    CASE WHEN i % 7 = 0 THEN NULL ELSE 'row' || i END AS name
+  FROM range(0, 101) t(i)
+`;
+
+describe.runIf(process.env.SKIP_DUCKDB !== '1')('DuckDB serialization spike', () => {
+  it('round-trips mixed types through COPY → parquet → hyparquet with fidelity', async () => {
+    if (!source) {
+      console.warn('[spike] skipped: no DuckDB');
+      return;
+    }
+    const stmt = effectiveQuery(MIXED_STMT);
+    const describe_ = await source.describe(stmt);
+    const plan = buildRenamePlan(describe_);
+
+    const t0 = performance.now();
+    const windowSql = windowedQuery(stmt, plan, { start: 0, end: 101 });
+    const bytes = await source.copyToParquet(windowSql);
+    const copyMs = performance.now() - t0;
+
+    const rows = await readParquet(bytes);
+    const readMs = performance.now() - t0 - copyMs;
+
+    expect(rows).toHaveLength(101);
+
+    // index synthesized 0..100, in order
+    expect(rows[0].index).toBe(0n);
+    expect(rows[100].index).toBe(100n);
+
+    // BIGINT above 2^53 survives EXACTLY as a bigint — the plan's core fidelity
+    // requirement and the whole reason for the COPY→parquet no-coercion path.
+    // 9007199254740993 = 2^53 + 1, unrepresentable as a JS number.
+    expect(typeof rows[0].a).toBe('bigint');
+    expect(rows[0].a).toBe(9007199254740993n);
+    expect(rows[1].a).toBe(9007199254740994n);
+
+    // NULL preserved (row 0: i%7==0 → name NULL)
+    expect(rows[0].f).toBeNull();
+    expect(rows[1].f).toBe('row1');
+
+    // DATE / TIMESTAMP decode to JS Date instants (TZ-independent underlying value)
+    expect(rows[0].d).toBeInstanceOf(Date);
+    expect(rows[0].e).toBeInstanceOf(Date);
+
+    // DOCUMENTED v1 LIMITATIONS (spike findings, not bugs in this code):
+    //  - HUGEINT: DuckDB COPY serializes it as parquet DOUBLE, so values above
+    //    2^53 are lossy. Out of the plan's required fidelity set.
+    //  - DECIMAL(38,9): hyparquet decodes parquet DECIMAL as a JS double, so
+    //    high-precision decimals are not exact. Matches the plan: "v1 casts
+    //    DECIMAL → DOUBLE; exactness tracked in #934".
+    expect(typeof rows[1].b).toBe('number'); // HUGEINT → double
+    expect(typeof rows[0].c).toBe('number'); // DECIMAL → double
+
+    // latency visibility (not an assertion threshold — the plan's open question)
+    console.log(
+      `[spike] 101-row window: COPY=${copyMs.toFixed(1)}ms read=${readMs.toFixed(1)}ms`,
+    );
+    // a generous ceiling so a pathological environment still flags
+    expect(copyMs).toBeLessThan(5000);
+  });
+
+  it('SUMMARIZE → SDType → pivoted stat rows', async () => {
+    if (!source) return;
+    const stmt = effectiveQuery(MIXED_STMT);
+    const plan = buildRenamePlan(await source.describe(stmt));
+    const summarizeRows = await source.summarize(plan.renamedRelation(stmt));
+    const sd = summarizeToSDType(summarizeRows);
+
+    // alias a is big64 (BIGINT, 9007199254740993 + i for i in 0..100)
+    expect(sd.a.dtype).toContain('INT');
+    expect(Number(sd.a.min)).toBe(9007199254740993);
+    expect(Number(sd.a.max)).toBe(9007199254740993 + 100);
+    expect(sd.a.distinct_count).not.toBeNull();
+
+    const rows = sdTypeToStatRows(sd);
+    const dtypeRow = rows.find((r) => r.index === 'dtype')!;
+    expect(dtypeRow.a).toContain('INT');
+    // 'name' (alias f): 101 rows, ~15 nulls (i%7==0 for i in 0..100)
+    const nullRow = rows.find((r) => r.index === 'null_count')!;
+    expect(Number(nullRow.f)).toBeGreaterThan(0);
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/stats.test.ts
+++ b/packages/buckaroo-duckdb-node/test/stats.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  summarizeToSDType,
+  sdTypeToStatRows,
+  sdTypeToWideRow,
+  V1_STAT_NAMES,
+} from '../src/stats';
+import type { SummarizeRow } from '../src/DuckSource';
+
+const summarizeRows: SummarizeRow[] = [
+  {
+    column_name: 'a',
+    column_type: 'BIGINT',
+    min: '1',
+    max: '1000',
+    approx_unique: 950,
+    avg: '500.5',
+    std: '288.8',
+    q25: '250',
+    q50: '500',
+    q75: '750',
+    count: 1000,
+    null_percentage: 10, // 10% of 1000 = 100 nulls
+  },
+  {
+    column_name: 'b',
+    column_type: 'VARCHAR',
+    min: 'aaa',
+    max: 'zzz',
+    approx_unique: 26,
+    avg: null,
+    std: null,
+    q25: null,
+    q50: null,
+    q75: null,
+    count: 1000,
+    null_percentage: 0,
+  },
+  // the synthesized index column must be ignored
+  {
+    column_name: 'index',
+    column_type: 'BIGINT',
+    min: '0',
+    max: '999',
+    approx_unique: 1000,
+    avg: '499.5',
+    std: '288',
+    q25: '0',
+    q50: '0',
+    q75: '0',
+    count: 1000,
+    null_percentage: 0,
+  },
+];
+
+describe('summarizeToSDType', () => {
+  const sd = summarizeToSDType(summarizeRows);
+
+  it('skips the synthesized index column', () => {
+    expect(Object.keys(sd)).toEqual(['a', 'b']);
+  });
+
+  it('maps SUMMARIZE fields per the v1 plan table', () => {
+    expect(sd.a).toMatchObject({
+      dtype: 'BIGINT',
+      distinct_count: 950,
+      mean: 500.5,
+      std: 288.8,
+      min: 1,
+      max: 1000,
+      q25: 250,
+      q50: 500,
+      q75: 750,
+    });
+  });
+
+  it('derives null_count = count × null_percentage / 100', () => {
+    expect(sd.a.null_count).toBe(100);
+    expect(sd.b.null_count).toBe(0);
+  });
+
+  it('keeps non-numeric min/max as strings and nulls absent stats', () => {
+    expect(sd.b.min).toBe('aaa');
+    expect(sd.b.max).toBe('zzz');
+    expect(sd.b.mean).toBeNull();
+    expect(sd.b.std).toBeNull();
+  });
+});
+
+describe('sdTypeToStatRows', () => {
+  const rows = sdTypeToStatRows(summarizeToSDType(summarizeRows));
+
+  it('produces one row per v1 stat, keyed by index/level_0', () => {
+    expect(rows).toHaveLength(V1_STAT_NAMES.length);
+    expect(rows.map((r) => r.index)).toEqual([...V1_STAT_NAMES]);
+    expect(rows[0].level_0).toBe('dtype');
+  });
+
+  it('places each column value under its alias key', () => {
+    const meanRow = rows.find((r) => r.index === 'mean')!;
+    expect(meanRow.a).toBe(500.5);
+    expect(meanRow.b).toBeNull();
+    const dtypeRow = rows.find((r) => r.index === 'dtype')!;
+    expect(dtypeRow.a).toBe('BIGINT');
+    expect(dtypeRow.b).toBe('VARCHAR');
+  });
+});
+
+describe('sdTypeToWideRow', () => {
+  it('builds {col}__{stat} keys', () => {
+    const wide = sdTypeToWideRow(summarizeToSDType(summarizeRows));
+    expect(wide.a__dtype).toBe('BIGINT');
+    expect(wide.a__mean).toBe(500.5);
+    expect(wide.b__null_count).toBe(0);
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/stats.test.ts
+++ b/packages/buckaroo-duckdb-node/test/stats.test.ts
@@ -36,6 +36,22 @@ const summarizeRows: SummarizeRow[] = [
     count: 1000,
     null_percentage: 0,
   },
+  // a VARCHAR column whose min/max look numeric (ZIP codes / zero-padded IDs):
+  // they must stay strings, not be coerced to a number (which strips zeros).
+  {
+    column_name: 'c',
+    column_type: 'VARCHAR',
+    min: '00123',
+    max: '00999',
+    approx_unique: 50,
+    avg: null,
+    std: null,
+    q25: null,
+    q50: null,
+    q75: null,
+    count: 1000,
+    null_percentage: 0,
+  },
   // the synthesized index column must be ignored
   {
     column_name: 'index',
@@ -57,7 +73,7 @@ describe('summarizeToSDType', () => {
   const sd = summarizeToSDType(summarizeRows);
 
   it('skips the synthesized index column', () => {
-    expect(Object.keys(sd)).toEqual(['a', 'b']);
+    expect(Object.keys(sd)).toEqual(['a', 'b', 'c']);
   });
 
   it('maps SUMMARIZE fields per the v1 plan table', () => {
@@ -84,6 +100,11 @@ describe('summarizeToSDType', () => {
     expect(sd.b.max).toBe('zzz');
     expect(sd.b.mean).toBeNull();
     expect(sd.b.std).toBeNull();
+  });
+
+  it('keeps numeric-looking VARCHAR min/max as strings (no zero-stripping)', () => {
+    expect(sd.c.min).toBe('00123');
+    expect(sd.c.max).toBe('00999');
   });
 });
 

--- a/packages/buckaroo-duckdb-node/tsconfig.json
+++ b/packages/buckaroo-duckdb-node/tsconfig.json
@@ -2,8 +2,8 @@
   "compilerOptions": {
     "target": "ES2022",
     "lib": ["ES2022"],
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",

--- a/packages/buckaroo-duckdb-node/tsconfig.json
+++ b/packages/buckaroo-duckdb-node/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "test"]
+}

--- a/packages/buckaroo-duckdb-node/vitest.config.ts
+++ b/packages/buckaroo-duckdb-node/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    // The spike test reaches a real DuckDB instance and writes temp parquet;
+    // give it room beyond the 5s default.
+    testTimeout: 30_000,
+  },
+});

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -12,6 +12,25 @@ importers:
         specifier: 1.9.4
         version: 1.9.4
 
+  buckaroo-duckdb-node:
+    dependencies:
+      hyparquet:
+        specifier: ^1.8.2
+        version: 1.23.3
+    devDependencies:
+      '@duckdb/node-api':
+        specifier: 1.4.4-r.3
+        version: 1.4.4-r.3
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.19.3
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.3)(jsdom@26.1.0)
+
   buckaroo-js-core:
     dependencies:
       ag-grid-community:
@@ -503,6 +522,42 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@duckdb/node-api@1.4.4-r.3':
+    resolution: {integrity: sha512-zsTihV7WTGp+n6nI0rNY+cNamKiN9lj0YTS4jrjBMd5ESJpDIJNJOB3o0xBbBghalgGu6PZfZOIcNofUbUHAYg==}
+
+  '@duckdb/node-bindings-darwin-arm64@1.4.4-r.3':
+    resolution: {integrity: sha512-8tfUVcbkNhpCezUNFlrMOwNZL8p1XfE9jxhjlPine1zKM9mNNtKW1pwLXId6MZ/BDMpVfQmlxnu97NYtPmpgRw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-darwin-x64@1.4.4-r.3':
+    resolution: {integrity: sha512-7pqSajMX/qb2vRnCMxOaM/cNkUX4kzHKAfdfQT+7dglvuIND2xy8+7EQ4+wHzk+gkPJsWUHZF0l0n6X6tyKFEA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@duckdb/node-bindings-linux-arm64@1.4.4-r.3':
+    resolution: {integrity: sha512-qF2/WhB+i+8is60RrpTY/5ZnywIUayuBiVXSuQ4rrRn1m1gvfKqPvjySbiDjYgQo/6OXu/fax0KC1gXnNWoLEA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@duckdb/node-bindings-linux-x64@1.4.4-r.3':
+    resolution: {integrity: sha512-Z59zpUIcZilHBmcZpmwfFwi6/OAnKlVQCE9/NGgZCFSqYeb+3ij5HQy26hp10GIiv3HxUQGId8HVs92x2jvckQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@duckdb/node-bindings-win32-arm64@1.4.4-r.3':
+    resolution: {integrity: sha512-ejjMqDm2UbGIKq+4wBE27cqcZjxBzLnc1dniEE/xs9CVs4iYsiFP1BJLDAh4188P9pqgN9+VR3O69QfoZQ8rqQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@duckdb/node-bindings-win32-x64@1.4.4-r.3':
+    resolution: {integrity: sha512-5CzkI3jPkwALPYS66/vj/3wgsICxALkqRdOEJc8wHqPPlpM/Ez7jFAovI7+S8JrTaxUANkiIAcCtYYAJPElbRQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@duckdb/node-bindings@1.4.4-r.3':
+    resolution: {integrity: sha512-ucvhCF3IK60BzxTFwYTjyQao9zavEwXJ1JdGk70UEXa85JQlos3pJslEG3lIczhdtSPu0aum+hv67aBmpH21cw==}
 
   '@emotion/is-prop-valid@1.2.2':
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
@@ -1573,14 +1628,37 @@ packages:
   '@vitest/expect@2.0.5':
     resolution: {integrity: sha512-yHZtwuP7JZivj65Gxoi8upUN2OzHTi3zVfjwdpu2WrvCZPLwsJ2Ey5ILIPccoW23dd/zQBlJ4/dhi7DWNyXCpA==}
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@2.0.5':
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
 
   '@vitest/pretty-format@2.1.9':
     resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
 
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/spy@2.0.5':
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
 
   '@vitest/utils@2.0.5':
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
@@ -1813,6 +1891,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -2129,6 +2211,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -2243,6 +2328,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -3036,6 +3125,9 @@ packages:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -3280,6 +3372,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3311,6 +3406,12 @@ packages:
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   storybook@8.6.15:
     resolution: {integrity: sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==}
@@ -3401,9 +3502,19 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
@@ -3604,6 +3715,11 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-plugin-dts@4.5.4:
     resolution: {integrity: sha512-d4sOM8M/8z7vRXHHq/ebbblfaxENjogAAekcfcDCCwAyvGqnPrc7f4NZbvItS+g4WTgerW0xDwSz5qz11JT3vg==}
     peerDependencies:
@@ -3650,6 +3766,31 @@ packages:
       sugarss:
         optional: true
       terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vscode-uri@3.1.0:
@@ -3704,6 +3845,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -4132,6 +4278,37 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@duckdb/node-api@1.4.4-r.3':
+    dependencies:
+      '@duckdb/node-bindings': 1.4.4-r.3
+
+  '@duckdb/node-bindings-darwin-arm64@1.4.4-r.3':
+    optional: true
+
+  '@duckdb/node-bindings-darwin-x64@1.4.4-r.3':
+    optional: true
+
+  '@duckdb/node-bindings-linux-arm64@1.4.4-r.3':
+    optional: true
+
+  '@duckdb/node-bindings-linux-x64@1.4.4-r.3':
+    optional: true
+
+  '@duckdb/node-bindings-win32-arm64@1.4.4-r.3':
+    optional: true
+
+  '@duckdb/node-bindings-win32-x64@1.4.4-r.3':
+    optional: true
+
+  '@duckdb/node-bindings@1.4.4-r.3':
+    optionalDependencies:
+      '@duckdb/node-bindings-darwin-arm64': 1.4.4-r.3
+      '@duckdb/node-bindings-darwin-x64': 1.4.4-r.3
+      '@duckdb/node-bindings-linux-arm64': 1.4.4-r.3
+      '@duckdb/node-bindings-linux-x64': 1.4.4-r.3
+      '@duckdb/node-bindings-win32-arm64': 1.4.4-r.3
+      '@duckdb/node-bindings-win32-x64': 1.4.4-r.3
 
   '@emotion/is-prop-valid@1.2.2':
     dependencies:
@@ -5249,6 +5426,21 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 1.2.0
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.3))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.3)
+
   '@vitest/pretty-format@2.0.5':
     dependencies:
       tinyrainbow: 1.2.0
@@ -5257,7 +5449,22 @@ snapshots:
     dependencies:
       tinyrainbow: 1.2.0
 
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/spy@2.0.5':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/spy@2.1.9':
     dependencies:
       tinyspy: 3.0.2
 
@@ -5536,6 +5743,8 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -5801,6 +6010,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -5984,6 +6195,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit@0.1.2: {}
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -6974,6 +7187,8 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.2
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -7246,6 +7461,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -7268,6 +7485,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   storybook@8.6.15:
     dependencies:
@@ -7354,10 +7575,16 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@1.2.0: {}
 
@@ -7546,6 +7773,24 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@2.1.9(@types/node@22.19.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-plugin-dts@4.5.4(@types/node@22.19.3)(rollup@4.54.0)(typescript@5.6.3)(vite@5.4.21(@types/node@22.19.3)):
     dependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@22.19.3)
@@ -7584,6 +7829,42 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.3)(jsdom@26.1.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.3))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.3)
+      vite-node: 2.1.9(@types/node@22.19.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.3
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vscode-uri@3.1.0: {}
 
@@ -7638,6 +7919,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/packages/pnpm-lock.yaml
+++ b/packages/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.3)(jsdom@26.1.0)
+      ws:
+        specifier: ^8.18.0
+        version: 8.18.3
 
   buckaroo-js-core:
     dependencies:

--- a/packages/pnpm-workspace.yaml
+++ b/packages/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
   - "buckaroo-js-core"
+  - "buckaroo-duckdb-node"
   - "js"
 


### PR DESCRIPTION
New package `packages/buckaroo-duckdb-node` — a DuckDB-backed buckaroo backend for pure Node/Electron hosts with no Python kernel. It produces the same wire payloads (`initial_state`, `infinite_resp`, wide summary stats) that buckaroo-js-core's `DFViewerInfinite` already speaks, so the viewer renders behind DuckDB exactly as it does behind pandas/polars. Implements [#930](https://github.com/buckaroo-data/buckaroo/issues/930); design in `docs/plans/930-duckdb-node-backend.md`.

## What's here (v1)

Transport-agnostic, core imports zero native bindings:

- **rename** — `DESCRIBE` → buckaroo's `a,b,c…` space + synthesized `index` (base-26 matching `df_util.py:to_chars`). Removes the `index`-collision, dotted-name, and duplicate-name foot-guns.
- **query** — effective-query seam + `infinite_request` → sorted/windowed/renamed SQL (`index` assigned pre-sort so rows keep their position).
- **stats** — `SUMMARIZE` → `SDType` → pivoted stat rows (dtype, null_count derived from count×null%, distinct_count, mean/std/min/q25/q50/q75/max).
- **column config** — DuckDB type → displayer with `DefaultMainStyling` parity.
- **serialization** — `COPY → tmpfile parquet` no-coercion path + a `@duckdb/node-api` adapter (separate `./node-api` entry).
- **transport** — `IModel`-over-IPC adapter for Electron (renderer ⇄ main).

## Spike findings

`test/spike.duckdb.test.ts` exercises a real DuckDB via `@duckdb/node-api`:

| DuckDB type | hyparquet decode | v1 fidelity |
|---|---|---|
| `BIGINT` (incl. > 2^53) | `bigint` | exact |
| `DATE` / `TIMESTAMP` | `Date` | exact instant |
| `VARCHAR`, `NULL` | `string` / `null` | exact |
| `DECIMAL(38,9)` | `number` (double) | lossy — matches plan's "v1 casts DECIMAL→DOUBLE; #934" |
| `HUGEINT` | `number` | lossy > 2^53 (DuckDB COPY writes it as parquet DOUBLE) |

Temp-file-per-window latency is negligible (~3ms COPY + ~5ms read per 101-row window), **answering the plan's open question** — no ramdisk needed.

## Blocked on #933 (only the renderer side)

The producer side (the `parquet_b64` inline envelope) is complete and unit-tested against the contract. End-to-end *rendering* needs #933's `decodeDFData(msg.payload, buffers)` — today the infinite path does `parquetRead(buffers[0])` and can't consume a single-JSON inline-parquet reply. Don't ship the renderer integration before #933.

## Tests

45 vitest tests pass; `tsc` clean. The DuckDB spike skips cleanly with `SKIP_DUCKDB=1` (optional peer dep). As a greenfield package with no CI wiring yet, tests are bundled with the implementation rather than committed failing-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)