### PR TITLE
feat(duckdb-node): histogram summary stat (numeric .01–.99 + categorical)

### DIFF
--- a/packages/buckaroo-duckdb-node/src/DuckSource.ts
+++ b/packages/buckaroo-duckdb-node/src/DuckSource.ts
@@ -26,6 +26,13 @@ export interface DuckSource {
    * natively and the caller never touches a `DuckDBValue`.
    */
   copyToParquet(query: string): Promise<Uint8Array>;
+
+  /**
+   * Run a read query → JSON row objects. Used for the small histogram
+   * aggregates (quantiles, bin counts, value counts), whose results are scalar
+   * counts/labels — not user row data — so the no-coercion rule does not apply.
+   */
+  queryRows(sql: string): Promise<Array<Record<string, unknown>>>;
 }
 
 /** One row of `DESCRIBE (<stmt>)`. DuckDB returns more columns; we use these. */

--- a/packages/buckaroo-duckdb-node/src/adapters/nodeApiDuckSource.ts
+++ b/packages/buckaroo-duckdb-node/src/adapters/nodeApiDuckSource.ts
@@ -61,6 +61,11 @@ export function createNodeApiDuckSource(
       return reader.getRowObjectsJson() as unknown as SummarizeRow[];
     },
 
+    async queryRows(sql: string): Promise<Array<Record<string, unknown>>> {
+      const reader = await connection.runAndReadAll(sql);
+      return reader.getRowObjectsJson();
+    },
+
     async copyToParquet(query: string): Promise<Uint8Array> {
       const dir = await mkdtemp(join(baseTmp, 'buckaroo-duck-'));
       const file = join(dir, `${randomUUID()}.parquet`);

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -18,6 +18,7 @@ import { buildRenamePlan, INDEX_COL, type RenamePlan } from './rename.js';
 import { effectiveQuery, windowedQuery, type QueryTransform } from './query.js';
 import { buildDfViewerConfig } from './columnConfig.js';
 import { summarizeToSDType, sdTypeToStatRows } from './stats.js';
+import { computeHistograms } from './histogramSql.js';
 import type {
   BuckarooOptions,
   BuckarooState,
@@ -105,6 +106,19 @@ export class DuckBackend {
 
     const sd = summarizeToSDType(summarizeRows);
     const statRows = sdTypeToStatRows(sd);
+
+    // The histogram bars are a per-column list of objects, not a scalar stat,
+    // so they ride as their own pinned row (injected right after dtype, the
+    // position the `histogram` pin in columnConfig expects) rather than through
+    // the SDType pivot.
+    const histos = await computeHistograms(
+      this.source,
+      plan.renamedRelation(this.effectiveSql),
+      plan,
+      sd,
+      this.totalRows,
+    );
+    statRows.splice(1, 0, { [INDEX_COL]: 'histogram', level_0: 'histogram', ...histos });
 
     const dfViewerConfig = buildDfViewerConfig(plan);
 

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -97,10 +97,11 @@ export class DuckBackend {
   async initialState(): Promise<InitialStateMessage> {
     const plan = await this.ensurePlan();
 
-    // Stats over the renamed relation; column names come back as aliases. The
+    // Stats over the stats-safe relation (non-finite floats nulled so SUMMARIZE's
+    // STDDEV_SAMP doesn't overflow); column names come back as aliases. The
     // relation includes the synthesized, non-null `index` column, so its
     // SUMMARIZE count is the total row count — no extra count query needed.
-    const summarizeRows = await this.source.summarize(plan.renamedRelation(this.effectiveSql));
+    const summarizeRows = await this.source.summarize(plan.statsRelation(this.effectiveSql));
     const indexRow = summarizeRows.find((r) => r.column_name === INDEX_COL);
     this.totalRows = indexRow ? Number(indexRow.count) : 0;
 

--- a/packages/buckaroo-duckdb-node/src/columnConfig.ts
+++ b/packages/buckaroo-duckdb-node/src/columnConfig.ts
@@ -2,39 +2,45 @@
  * Build the `df_viewer_config` (column_config + pinned_rows + left_col_configs)
  * from the rename plan.
  *
- * Pinned rows reference only the v1 stats this backend actually computes from
- * `SUMMARIZE` (see stats.ts) so no pinned row renders empty. Histogram rows are
- * a fast-follow once the histogram SQL lands.
+ * Pinned rows reference only stats this backend actually computes — the
+ * `SUMMARIZE`-derived stats (see stats.ts) plus the `histogram` row the backend
+ * injects — so no pinned row renders empty.
  */
 
 import type { RenamePlan } from './rename.js';
 import { INDEX_COL } from './rename.js';
 import { duckTypeToColType, displayerForColType } from './duckTypes.js';
-import type { ColumnConfig, DFViewerConfig, PinnedRowConfig } from './wireTypes.js';
+import type {
+  ColumnConfig,
+  DFViewerConfig,
+  DisplayerArgs,
+  PinnedRowConfig,
+} from './wireTypes.js';
 
 /**
- * The stat keys pinned in v1, in display order. Each must match a stat name
- * produced by stats.ts (and therefore a wide `{col}__{stat}` column).
- * `dtype` renders via `obj`; the rest `inherit` the column's own displayer
- * (styling_helpers.py: obj_/inherit_).
+ * The stat keys pinned in v1, in display order. `dtype` renders via `obj`,
+ * `histogram` via the histogram displayer, and the rest `inherit` the column's
+ * own displayer (styling_helpers.py: obj_/inherit_/pinned_histogram). The
+ * histogram row sits right after dtype to match DefaultMainStyling.pinned_rows.
  */
-export const V1_PINNED_STATS: ReadonlyArray<{ stat: string; inherit: boolean }> = [
-  { stat: 'dtype', inherit: false },
-  { stat: 'null_count', inherit: true },
-  { stat: 'distinct_count', inherit: true },
-  { stat: 'mean', inherit: true },
-  { stat: 'std', inherit: true },
-  { stat: 'min', inherit: true },
-  { stat: 'q25', inherit: true },
-  { stat: 'q50', inherit: true },
-  { stat: 'q75', inherit: true },
-  { stat: 'max', inherit: true },
+export const V1_PINNED_STATS: ReadonlyArray<{ stat: string; displayer_args: DisplayerArgs }> = [
+  { stat: 'dtype', displayer_args: { displayer: 'obj' } },
+  { stat: 'histogram', displayer_args: { displayer: 'histogram' } },
+  { stat: 'null_count', displayer_args: { displayer: 'inherit' } },
+  { stat: 'distinct_count', displayer_args: { displayer: 'inherit' } },
+  { stat: 'mean', displayer_args: { displayer: 'inherit' } },
+  { stat: 'std', displayer_args: { displayer: 'inherit' } },
+  { stat: 'min', displayer_args: { displayer: 'inherit' } },
+  { stat: 'q25', displayer_args: { displayer: 'inherit' } },
+  { stat: 'q50', displayer_args: { displayer: 'inherit' } },
+  { stat: 'q75', displayer_args: { displayer: 'inherit' } },
+  { stat: 'max', displayer_args: { displayer: 'inherit' } },
 ];
 
 export function buildPinnedRows(): PinnedRowConfig[] {
-  return V1_PINNED_STATS.map(({ stat, inherit }) => ({
+  return V1_PINNED_STATS.map(({ stat, displayer_args }) => ({
     primary_key_val: stat,
-    displayer_args: inherit ? { displayer: 'inherit' } : { displayer: 'obj' },
+    displayer_args,
   }));
 }
 

--- a/packages/buckaroo-duckdb-node/src/histogram.ts
+++ b/packages/buckaroo-duckdb-node/src/histogram.ts
@@ -1,0 +1,209 @@
+/**
+ * Histogram bars: the `histogram` summary stat the viewer renders through the
+ * `displayer: 'histogram'` pinned row.
+ *
+ * This is a faithful TS port of buckaroo's Python producer
+ * (`customizations/histogram.py`) so a DuckDB-backed column renders the same
+ * bars as the pandas/polars backends:
+ *
+ *   - NUMERIC: a low-tail marker, 10 "meat" buckets over the 1st–99th
+ *     percentile range (population %), a high-tail marker, then an NA bucket.
+ *   - CATEGORICAL: the top-7 categories (`cat_pop` %), then `longtail`,
+ *     `unique`, and `NA` buckets.
+ *
+ * All percentages are on the 0–100 scale and rounded with numpy's
+ * round-half-to-even (`np.round`) so the labels match the Python output
+ * bit-for-bit. The SQL that produces the raw inputs lives in `histogramSql.ts`.
+ */
+
+import type { HistogramBar } from './wireTypes.js';
+
+/** numpy `np.round(x, 0)` — round half to even (banker's rounding). */
+export function npRound0(x: number): number {
+  const floor = Math.floor(x);
+  const diff = x - floor;
+  if (diff < 0.5) return floor;
+  if (diff > 0.5) return floor + 1;
+  // exact .5 → round to the even neighbour
+  return floor % 2 === 0 ? floor : floor + 1;
+}
+
+/** histogram.py:_trim — strip trailing zeros after the decimal point only. */
+function trim(s: string): string {
+  if (s.includes('.')) {
+    return s.replace(/0+$/, '').replace(/\.$/, '');
+  }
+  return s;
+}
+
+/** histogram.py:fmt_num — SI prefix (K/M/B/T) + step-based precision. */
+export function fmtNum(value: number, step: number, ref: number): string {
+  if (step > 0 && Math.abs(value) < step * 1e-9) {
+    value = 0.0;
+  }
+  const tiers: Array<[number, string]> = [
+    [1e12, 'T'],
+    [1e9, 'B'],
+    [1e6, 'M'],
+    [1e3, 'K'],
+  ];
+  for (const [threshold, suffix] of tiers) {
+    if (ref >= threshold) {
+      const scaled = value / threshold;
+      const stepS = step / threshold;
+      let dec = stepS > 0 ? Math.max(0, -Math.floor(Math.log10(stepS)) + 1) : 1;
+      dec = Math.min(dec, 2);
+      return trim(scaled.toFixed(dec)) + suffix;
+    }
+  }
+  let dec = step > 0 ? Math.max(0, -Math.floor(Math.log10(step)) + 1) : 0;
+  dec = Math.min(dec, 6);
+  return trim(value.toFixed(dec));
+}
+
+/**
+ * histogram.py:_join_bounds — any negative bound switches the separator to
+ * `<>`; the minus sign and en-dash are near-identical glyphs and `-0.5–0.5`
+ * reads as a double dash.
+ */
+function joinBounds(loS: string, hiS: string): string {
+  const sep = loS.startsWith('-') || hiS.startsWith('-') ? '<>' : '–';
+  return `${loS}${sep}${hiS}`;
+}
+
+/** histogram.py:fmt_bucket */
+export function fmtBucket(lo: number, hi: number, step: number, ref: number): string {
+  return joinBounds(fmtNum(lo, step, ref), fmtNum(hi, step, ref));
+}
+
+/**
+ * histogram.py:fmt_tail_bucket — per-bound SI prefix (ref = |bound|) so a far
+ * outlier bound doesn't drag a small bound down to '0K'.
+ */
+function fmtTailBucket(lo: number, hi: number, step: number): string {
+  return joinBounds(fmtNum(lo, step, Math.abs(lo)), fmtNum(hi, step, Math.abs(hi)));
+}
+
+/** histogram.py:numeric_histogram_labels — one label per bucket from the edges. */
+export function numericHistogramLabels(endpoints: number[]): string[] {
+  let left = endpoints[0];
+  const labels: string[] = [];
+  const minVal = endpoints[0];
+  const maxVal = endpoints[endpoints.length - 1];
+  const step = (maxVal - minVal) / Math.max(endpoints.length - 1, 1);
+  const ref = Math.max(Math.abs(minVal), Math.abs(maxVal));
+  for (const edge of endpoints.slice(1)) {
+    labels.push(fmtBucket(left, edge, step, ref));
+    left = edge;
+  }
+  return labels;
+}
+
+/**
+ * The raw numeric-histogram inputs, mirroring Python's `histogram_args`:
+ *   - `meatCounts`        — np.histogram bin counts (10 bins).
+ *   - `endpoints`         — the 11 bin edges (linspace over the meat range).
+ *   - `lowTail`/`highTail`— the 1st/99th percentile cut points.
+ * `normalizedPopulations` is derived here (counts / sum) so callers only carry
+ * the SQL-shaped values.
+ */
+export interface NumericHistogramArgs {
+  meatCounts: number[];
+  endpoints: number[];
+  lowTail: number;
+  highTail: number;
+}
+
+/** histogram.py:numeric_histogram */
+export function numericHistogram(
+  args: NumericHistogramArgs,
+  min: number,
+  max: number,
+  nanPer: number,
+): HistogramBar[] {
+  const naObs: HistogramBar = { name: 'NA', NA: npRound0(nanPer * 100) };
+  if (nanPer === 1.0) return [naObs];
+
+  const { meatCounts, endpoints, lowTail, highTail } = args;
+  const total = meatCounts.reduce((a, b) => a + b, 0);
+  const normalizedPop = meatCounts.map((c) => (total > 0 ? c / total : 0));
+  const labels = numericHistogramLabels(endpoints);
+
+  const eLo = endpoints[0];
+  const eHi = endpoints[endpoints.length - 1];
+  const step = (eHi - eLo) / Math.max(endpoints.length - 1, 1);
+
+  const histo: HistogramBar[] = [];
+  histo.push({ name: fmtTailBucket(min, lowTail, step), tail: 1 });
+  labels.forEach((label, i) => {
+    histo.push({ name: label, population: npRound0(normalizedPop[i] * 100) });
+  });
+  histo.push({ name: fmtTailBucket(highTail, max, step), tail: 1 });
+  if (nanPer > 0.0) histo.push(naObs);
+  return histo;
+}
+
+/** A distinct value and its row count, as returned by the value-counts query. */
+export interface ValueCount {
+  name: string;
+  count: number;
+}
+
+/**
+ * histogram.py:categorical_histogram (with categorical_dict inlined).
+ *
+ * `top` is the top-N value counts (already sorted desc); `restSum` is the
+ * summed count of every other distinct value; `uniqueCount` is the number of
+ * distinct values that occur exactly once (over the whole column). `length`
+ * includes nulls.
+ */
+export function categoricalHistogram(
+  length: number,
+  top: ValueCount[],
+  restSum: number,
+  uniqueCount: number,
+  nanPer: number,
+): HistogramBar[] {
+  const histo: HistogramBar[] = [];
+  for (const { name, count } of top) {
+    const percent = npRound0((count / length) * 100);
+    if (percent > 0.3) {
+      histo.push({ name: String(name), cat_pop: percent });
+    }
+  }
+  const longTail = restSum - uniqueCount;
+  if (longTail > 0) {
+    histo.push({ name: 'longtail', longtail: npRound0((longTail / length) * 100) });
+  }
+  if (uniqueCount > 0) {
+    histo.push({ name: 'unique', unique: npRound0((uniqueCount / length) * 100) });
+  }
+  if (nanPer > 0.0) {
+    histo.push({ name: 'NA', NA: npRound0(nanPer * 100) });
+  }
+  return histo;
+}
+
+/**
+ * histogram.py:histogram — pick the numeric path only when the column is
+ * numeric, has more than 5 distinct values, valid histogram args, and the
+ * resulting numeric histogram has more than 5 bars; otherwise fall back to the
+ * categorical histogram.
+ */
+export function buildHistogram(opts: {
+  isNumeric: boolean;
+  distinctCount: number;
+  length: number;
+  nanPer: number;
+  min: number | null;
+  max: number | null;
+  numericArgs: NumericHistogramArgs | null;
+  categorical: { top: ValueCount[]; restSum: number; uniqueCount: number };
+}): HistogramBar[] {
+  const { isNumeric, distinctCount, length, nanPer, min, max, numericArgs, categorical } = opts;
+  if (isNumeric && distinctCount > 5 && numericArgs && min !== null && max !== null) {
+    const temp = numericHistogram(numericArgs, min, max, nanPer);
+    if (temp.length > 5) return temp;
+  }
+  return categoricalHistogram(length, categorical.top, categorical.restSum, categorical.uniqueCount, nanPer);
+}

--- a/packages/buckaroo-duckdb-node/src/histogram.ts
+++ b/packages/buckaroo-duckdb-node/src/histogram.ts
@@ -184,26 +184,44 @@ export function categoricalHistogram(
   return histo;
 }
 
+/** The categorical inputs `buildHistogram` needs (see `parseCategorical`). */
+export interface CategoricalArgs {
+  top: ValueCount[];
+  restSum: number;
+  uniqueCount: number;
+}
+
 /**
  * histogram.py:histogram — pick the numeric path only when the column is
  * numeric, has more than 5 distinct values, valid histogram args, and the
  * resulting numeric histogram has more than 5 bars; otherwise fall back to the
  * categorical histogram.
+ *
+ * The numeric and categorical inputs are fetched lazily so the categorical
+ * query only runs when the numeric path doesn't win — matching histogram.py's
+ * short-circuit. This is the single dispatcher: the production pipeline
+ * (histogramSql.ts:computeColumnHistogram) supplies SQL-backed fetchers, the
+ * unit tests supply in-memory ones, so the same branch logic is what ships.
  */
-export function buildHistogram(opts: {
+export async function buildHistogram(opts: {
   isNumeric: boolean;
   distinctCount: number;
   length: number;
   nanPer: number;
   min: number | null;
   max: number | null;
-  numericArgs: NumericHistogramArgs | null;
-  categorical: { top: ValueCount[]; restSum: number; uniqueCount: number };
-}): HistogramBar[] {
-  const { isNumeric, distinctCount, length, nanPer, min, max, numericArgs, categorical } = opts;
-  if (isNumeric && distinctCount > 5 && numericArgs && min !== null && max !== null) {
-    const temp = numericHistogram(numericArgs, min, max, nanPer);
-    if (temp.length > 5) return temp;
+  fetchNumericArgs: () => Promise<NumericHistogramArgs | null>;
+  fetchCategorical: () => Promise<CategoricalArgs>;
+}): Promise<HistogramBar[]> {
+  const { isNumeric, distinctCount, length, nanPer, min, max, fetchNumericArgs, fetchCategorical } =
+    opts;
+  if (isNumeric && distinctCount > 5 && min !== null && max !== null) {
+    const numericArgs = await fetchNumericArgs();
+    if (numericArgs) {
+      const temp = numericHistogram(numericArgs, min, max, nanPer);
+      if (temp.length > 5) return temp;
+    }
   }
+  const categorical = await fetchCategorical();
   return categoricalHistogram(length, categorical.top, categorical.restSum, categorical.uniqueCount, nanPer);
 }

--- a/packages/buckaroo-duckdb-node/src/histogramSql.ts
+++ b/packages/buckaroo-duckdb-node/src/histogramSql.ts
@@ -17,8 +17,8 @@
 import { quoteIdent } from './rename.js';
 import { duckTypeToColType } from './duckTypes.js';
 import {
-  numericHistogram,
-  categoricalHistogram,
+  buildHistogram,
+  type CategoricalArgs,
   type NumericHistogramArgs,
   type ValueCount,
 } from './histogram.js';
@@ -131,11 +131,7 @@ export function parseNumericArgs(rows: Array<Record<string, unknown>>): NumericH
 }
 
 /** Parse the categorical query rows into `categoricalHistogram` inputs. */
-export function parseCategorical(rows: Array<Record<string, unknown>>): {
-  top: ValueCount[];
-  restSum: number;
-  uniqueCount: number;
-} {
+export function parseCategorical(rows: Array<Record<string, unknown>>): CategoricalArgs {
   if (rows.length === 0) return { top: [], restSum: 0, uniqueCount: 0 };
   const nonNull = num(rows[0].non_null);
   const uniqueCount = num(rows[0].unique_count);
@@ -168,25 +164,22 @@ function colMeta(sd: SDType[string] | undefined, duckType: string, length: numbe
   };
 }
 
-async function computeColumnHistogram(
+function computeColumnHistogram(
   source: DuckSource,
   relation: string,
   alias: string,
   meta: ColMeta,
 ): Promise<HistogramBar[]> {
-  // Numeric path first; only fall through to a categorical query when the
-  // numeric histogram is unavailable (too few distinct values, no min/max, or a
-  // degenerate meat range), exactly like histogram.py:histogram.
-  if (meta.isNumeric && meta.distinctCount > 5 && meta.min !== null && meta.max !== null) {
-    const rows = await source.queryRows(numericHistogramSql(relation, alias));
-    const args = parseNumericArgs(rows);
-    if (args) {
-      const temp = numericHistogram(args, meta.min, meta.max, meta.nanPer);
-      if (temp.length > 5) return temp;
-    }
-  }
-  const cat = parseCategorical(await source.queryRows(categoricalHistogramSql(relation, alias)));
-  return categoricalHistogram(meta.length, cat.top, cat.restSum, cat.uniqueCount, meta.nanPer);
+  // The numeric-vs-categorical dispatch lives in histogram.ts:buildHistogram
+  // (the single, unit-tested copy). Here we only supply the lazy SQL fetchers,
+  // so the categorical query runs only when the numeric path doesn't win.
+  return buildHistogram({
+    ...meta,
+    fetchNumericArgs: async () =>
+      parseNumericArgs(await source.queryRows(numericHistogramSql(relation, alias))),
+    fetchCategorical: async () =>
+      parseCategorical(await source.queryRows(categoricalHistogramSql(relation, alias))),
+  });
 }
 
 /**

--- a/packages/buckaroo-duckdb-node/src/histogramSql.ts
+++ b/packages/buckaroo-duckdb-node/src/histogramSql.ts
@@ -1,0 +1,214 @@
+/**
+ * Histogram SQL: turn a renamed relation + column alias into the small
+ * aggregate queries that feed `histogram.ts`.
+ *
+ * Two shapes, mirroring the two Python paths:
+ *   - NUMERIC — `quantile_cont(col, 0.01/0.99)` for the tails, then the meat
+ *     (values strictly between the tails) bucketed into 10 `width_bucket` bins.
+ *     This is the DuckDB equivalent of `np.histogram(meat, 10)` over the
+ *     1st–99th percentile range (pd_stats_v2.py:histogram_series).
+ *   - CATEGORICAL — top-7 value counts plus the `unique`/`longtail` aggregates.
+ *
+ * The numeric meta the dispatcher needs (is_numeric, distinct_count, min, max,
+ * null %) already comes from `SUMMARIZE` (stats.ts), so a numeric column costs
+ * one extra query and a categorical column one — no per-column count pass.
+ */
+
+import { quoteIdent } from './rename.js';
+import { duckTypeToColType } from './duckTypes.js';
+import {
+  numericHistogram,
+  categoricalHistogram,
+  type NumericHistogramArgs,
+  type ValueCount,
+} from './histogram.js';
+import type { DuckSource, SDType } from './DuckSource.js';
+import type { RenamePlan } from './rename.js';
+import type { HistogramBar } from './wireTypes.js';
+
+/** Number of meat buckets, matching `np.histogram(meat, 10)`. */
+export const MEAT_BINS = 10;
+
+/**
+ * Numeric histogram query: the 1st/99th percentile tails and the meat bucketed
+ * into 10 equal-width bins. Returns up to 10 rows `{low_tail, high_tail,
+ * meat_min, meat_max, bin, c}` (bin is 0-based; the tail/min/max columns repeat
+ * per row). Zero rows means a degenerate meat range (all meat values equal) —
+ * the caller falls back to the categorical histogram.
+ *
+ * The bin is `floor((v - meat_min) / width)` clamped to `[0, 9]` — DuckDB has
+ * no `width_bucket`, and this matches `np.histogram(meat, 10)`'s
+ * left-closed/last-inclusive edges (the meat_max value floors to 10 and is
+ * clamped back into the final bin).
+ */
+export function numericHistogramSql(relation: string, alias: string): string {
+  const col = quoteIdent(alias);
+  const lastBin = MEAT_BINS - 1;
+  return `WITH _src AS (${relation}),
+_q AS (
+  SELECT quantile_cont(${col}, 0.01) AS low_tail,
+         quantile_cont(${col}, 0.99) AS high_tail
+  FROM _src
+),
+_meat AS (
+  SELECT CAST(${col} AS DOUBLE) AS v
+  FROM _src, _q
+  WHERE ${col} > _q.low_tail AND ${col} < _q.high_tail
+),
+_mm AS (SELECT min(v) AS meat_min, max(v) AS meat_max FROM _meat)
+SELECT
+  (SELECT low_tail FROM _q) AS low_tail,
+  (SELECT high_tail FROM _q) AS high_tail,
+  _mm.meat_min AS meat_min,
+  _mm.meat_max AS meat_max,
+  least(${lastBin}, greatest(0, floor((_meat.v - _mm.meat_min) / ((_mm.meat_max - _mm.meat_min) / ${MEAT_BINS}.0))))::INTEGER AS bin,
+  count(*) AS c
+FROM _meat, _mm
+WHERE _mm.meat_max > _mm.meat_min
+GROUP BY ALL
+ORDER BY bin`;
+}
+
+/**
+ * Categorical value-counts query: the top-N distinct values by frequency, each
+ * row carrying the column-wide `non_null` and `unique_count` aggregates so the
+ * caller can derive the longtail without a second pass. Zero rows means an
+ * all-null column.
+ */
+export function categoricalHistogramSql(relation: string, alias: string, topN = 7): string {
+  const col = quoteIdent(alias);
+  return `WITH _src AS (${relation}),
+_vc AS (
+  SELECT ${col} AS val, count(*) AS c
+  FROM _src
+  WHERE ${col} IS NOT NULL
+  GROUP BY ${col}
+),
+_agg AS (
+  SELECT
+    coalesce(sum(c), 0) AS non_null,
+    coalesce(count(*) FILTER (WHERE c = 1), 0) AS unique_count
+  FROM _vc
+)
+SELECT
+  CAST(_vc.val AS VARCHAR) AS name,
+  _vc.c AS c,
+  _agg.non_null AS non_null,
+  _agg.unique_count AS unique_count
+FROM _vc, _agg
+ORDER BY _vc.c DESC, name
+LIMIT ${topN}`;
+}
+
+function num(v: unknown): number {
+  if (v === null || v === undefined) return NaN;
+  return typeof v === 'bigint' ? Number(v) : Number(v as number);
+}
+
+/** Build `NumericHistogramArgs` from the numeric query rows, or null if degenerate. */
+export function parseNumericArgs(rows: Array<Record<string, unknown>>): NumericHistogramArgs | null {
+  if (rows.length === 0) return null;
+  const first = rows[0];
+  const meatMin = num(first.meat_min);
+  const meatMax = num(first.meat_max);
+  if (!Number.isFinite(meatMin) || !Number.isFinite(meatMax) || meatMax <= meatMin) {
+    return null;
+  }
+  const meatCounts = new Array<number>(MEAT_BINS).fill(0);
+  for (const r of rows) {
+    const bin = num(r.bin);
+    const c = num(r.c);
+    if (bin >= 0 && bin < MEAT_BINS) meatCounts[bin] = c;
+  }
+  const width = (meatMax - meatMin) / MEAT_BINS;
+  const endpoints = Array.from({ length: MEAT_BINS + 1 }, (_, i) => meatMin + i * width);
+  return {
+    meatCounts,
+    endpoints,
+    lowTail: num(first.low_tail),
+    highTail: num(first.high_tail),
+  };
+}
+
+/** Parse the categorical query rows into `categoricalHistogram` inputs. */
+export function parseCategorical(rows: Array<Record<string, unknown>>): {
+  top: ValueCount[];
+  restSum: number;
+  uniqueCount: number;
+} {
+  if (rows.length === 0) return { top: [], restSum: 0, uniqueCount: 0 };
+  const nonNull = num(rows[0].non_null);
+  const uniqueCount = num(rows[0].unique_count);
+  const top: ValueCount[] = rows.map((r) => ({ name: String(r.name), count: num(r.c) }));
+  const topSum = top.reduce((a, b) => a + b.count, 0);
+  return { top, restSum: Math.max(0, nonNull - topSum), uniqueCount };
+}
+
+/** Per-column metadata the dispatcher needs, derived from the SUMMARIZE stats. */
+interface ColMeta {
+  isNumeric: boolean;
+  distinctCount: number;
+  length: number;
+  nanPer: number;
+  min: number | null;
+  max: number | null;
+}
+
+function colMeta(sd: SDType[string] | undefined, duckType: string, length: number): ColMeta {
+  const colType = duckTypeToColType(duckType);
+  const isNumeric = colType === 'integer' || colType === 'float';
+  const nullCount = num(sd?.null_count);
+  return {
+    isNumeric,
+    distinctCount: num(sd?.distinct_count) || 0,
+    length,
+    nanPer: length > 0 && Number.isFinite(nullCount) ? nullCount / length : 0,
+    min: isNumeric && typeof sd?.min === 'number' ? sd.min : null,
+    max: isNumeric && typeof sd?.max === 'number' ? sd.max : null,
+  };
+}
+
+async function computeColumnHistogram(
+  source: DuckSource,
+  relation: string,
+  alias: string,
+  meta: ColMeta,
+): Promise<HistogramBar[]> {
+  // Numeric path first; only fall through to a categorical query when the
+  // numeric histogram is unavailable (too few distinct values, no min/max, or a
+  // degenerate meat range), exactly like histogram.py:histogram.
+  if (meta.isNumeric && meta.distinctCount > 5 && meta.min !== null && meta.max !== null) {
+    const rows = await source.queryRows(numericHistogramSql(relation, alias));
+    const args = parseNumericArgs(rows);
+    if (args) {
+      const temp = numericHistogram(args, meta.min, meta.max, meta.nanPer);
+      if (temp.length > 5) return temp;
+    }
+  }
+  const cat = parseCategorical(await source.queryRows(categoricalHistogramSql(relation, alias)));
+  return categoricalHistogram(meta.length, cat.top, cat.restSum, cat.uniqueCount, meta.nanPer);
+}
+
+/**
+ * Compute the `histogram` bar list for every column of the renamed relation,
+ * keyed by alias. A failure on any single column yields an empty histogram for
+ * that column rather than failing the whole `initial_state`.
+ */
+export async function computeHistograms(
+  source: DuckSource,
+  relation: string,
+  plan: RenamePlan,
+  sd: SDType,
+  length: number,
+): Promise<Record<string, HistogramBar[]>> {
+  const out: Record<string, HistogramBar[]> = {};
+  for (const c of plan.columns) {
+    const meta = colMeta(sd[c.alias], c.type, length);
+    try {
+      out[c.alias] = await computeColumnHistogram(source, relation, c.alias, meta);
+    } catch {
+      out[c.alias] = [];
+    }
+  }
+  return out;
+}

--- a/packages/buckaroo-duckdb-node/src/rename.ts
+++ b/packages/buckaroo-duckdb-node/src/rename.ts
@@ -45,6 +45,17 @@ export function quoteIdent(name: string): string {
   return `"${name.replace(/"/g, '""')}"`;
 }
 
+/**
+ * Real IEEE-754 floating types — the only ones that can hold `nan`/`±inf`.
+ * DECIMAL/NUMERIC are fixed-point and cannot, so they're excluded from the
+ * non-finite guard (`statsRelation`).
+ */
+const REAL_FLOAT_TYPES = new Set(['DOUBLE', 'REAL', 'FLOAT', 'FLOAT4', 'FLOAT8']);
+
+function isRealFloatType(duckType: string): boolean {
+  return REAL_FLOAT_TYPES.has(duckType.trim().toUpperCase().replace(/\(.*$/, '').trim());
+}
+
 export interface RenamePlan {
   /** alias (`a`) → original column name. For `header_name` + sort reversal. */
   renameMap: Record<string, string>;
@@ -58,6 +69,15 @@ export interface RenamePlan {
    * Callers wrap this with ORDER BY / LIMIT / OFFSET.
    */
   renamedRelation(stmt: string): string;
+  /**
+   * The stats-only relation: `renamedRelation` with non-finite floats
+   * (`nan`/`±inf`) replaced by NULL. DuckDB's `SUMMARIZE` runs `STDDEV_SAMP`,
+   * which overflows ("out of range") on a non-finite value and aborts the whole
+   * stats query — so for summary statistics those values are treated as missing.
+   * Only this path is guarded; the row (COPY) and histogram paths keep every
+   * value (no coercion).
+   */
+  statsRelation(stmt: string): string;
 }
 
 /**
@@ -86,5 +106,15 @@ export function buildRenamePlan(describeRows: DescribeRow[]): RenamePlan {
     return `SELECT ${projections.join(', ')} FROM (${stmt}) AS _buckaroo_src`;
   };
 
-  return { renameMap, aliases, columns, renamedRelation };
+  const statsRelation = (stmt: string): string => {
+    const projections = columns.map((c) =>
+      isRealFloatType(c.type)
+        ? `CASE WHEN isfinite(${c.alias}) THEN ${c.alias} ELSE NULL END AS ${c.alias}`
+        : c.alias,
+    );
+    projections.push(INDEX_COL);
+    return `SELECT ${projections.join(', ')} FROM (${renamedRelation(stmt)}) AS _buckaroo_renamed`;
+  };
+
+  return { renameMap, aliases, columns, renamedRelation, statsRelation };
 }

--- a/packages/buckaroo-duckdb-node/src/wireTypes.ts
+++ b/packages/buckaroo-duckdb-node/src/wireTypes.ts
@@ -58,6 +58,28 @@ export interface HistogramDisplayerA {
   displayer: 'histogram';
 }
 
+/**
+ * One bar of a `histogram` summary stat — the cell value the `displayer:
+ * 'histogram'` pinned row renders. Mirrors buckaroo-js-core's `HistogramBar`
+ * (HistogramCell.tsx). Exactly one of the value keys is set per bar; `name` is
+ * always the bucket label. Percentages are on the 0–100 scale.
+ */
+export interface HistogramBar {
+  name: string;
+  /** numeric meat-bucket population % */
+  population?: number;
+  /** categorical top-N population % */
+  cat_pop?: number;
+  /** numeric low/high tail marker (always 1) */
+  tail?: number;
+  /** longtail bucket % */
+  longtail?: number;
+  /** unique-values bucket % */
+  unique?: number;
+  /** missing-values bucket % */
+  NA?: number;
+}
+
 export interface InheritDisplayerA {
   displayer: 'inherit';
 }

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -61,6 +61,11 @@ function fakeSource(): DuckSource & { lastCopyQuery?: string } {
         },
       ];
     },
+    async queryRows(): Promise<Array<Record<string, unknown>>> {
+      // both columns are low-cardinality here (approx_unique ≤ 7), so only the
+      // categorical value-counts query runs; return a single dominant category.
+      return [{ name: 'x', c: 42, non_null: 42, unique_count: 0 }];
+    },
     async copyToParquet(query: string): Promise<Uint8Array> {
       src.lastCopyQuery = query;
       return new Uint8Array([1, 2, 3, 4]);
@@ -88,9 +93,23 @@ describe('DuckBackend.initialState', () => {
     expect(msg.df_display_args.main.data_key).toBe('main');
     // main rows are empty (delivered via infinite_request); stats are inline json
     expect(msg.df_data_dict.main).toEqual([]);
-    const stats = msg.df_data_dict.all_stats as { format: string; data: unknown[] };
+    const stats = msg.df_data_dict.all_stats as {
+      format: string;
+      data: Array<Record<string, unknown>>;
+    };
     expect(stats.format).toBe('json');
     expect(stats.data.length).toBeGreaterThan(0);
+
+    // the histogram pinned row sits right after dtype and carries a bar list
+    // per column (categorical fallback here)
+    expect(cfg.pinned_rows[1]).toEqual({
+      primary_key_val: 'histogram',
+      displayer_args: { displayer: 'histogram' },
+    });
+    const histoRow = stats.data.find((r) => r.index === 'histogram')!;
+    expect(stats.data.indexOf(histoRow)).toBe(1);
+    expect(histoRow.a).toEqual([{ name: 'x', cat_pop: 100 }]);
+    expect(histoRow.b).toEqual([{ name: 'x', cat_pop: 100 }]);
   });
 });
 

--- a/packages/buckaroo-duckdb-node/test/columnConfig.test.ts
+++ b/packages/buckaroo-duckdb-node/test/columnConfig.test.ts
@@ -73,7 +73,7 @@ describe('buildColumnConfig', () => {
 });
 
 describe('buildPinnedRows / buildDfViewerConfig', () => {
-  it('pins only the v1 stats, dtype via obj and the rest via inherit', () => {
+  it('pins the v1 stats: dtype via obj, histogram via histogram, the rest inherit', () => {
     const pinned = buildPinnedRows();
     expect(pinned.map((p) => p.primary_key_val)).toEqual(
       V1_PINNED_STATS.map((s) => s.stat),
@@ -82,7 +82,11 @@ describe('buildPinnedRows / buildDfViewerConfig', () => {
       primary_key_val: 'dtype',
       displayer_args: { displayer: 'obj' },
     });
-    expect(pinned[1].displayer_args).toEqual({ displayer: 'inherit' });
+    expect(pinned[1]).toEqual({
+      primary_key_val: 'histogram',
+      displayer_args: { displayer: 'histogram' },
+    });
+    expect(pinned[2].displayer_args).toEqual({ displayer: 'inherit' });
   });
 
   it('assembles a full viewer config with a left index column', () => {

--- a/packages/buckaroo-duckdb-node/test/ddd.duckdb.test.ts
+++ b/packages/buckaroo-duckdb-node/test/ddd.duckdb.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The Dastardly Dataframe Dataset, DuckDB edition.
+ *
+ * Ports the pathologies from buckaroo's `ddd_library.py` ("the weirdest
+ * dataframes that cause trouble frequently") that survive translation to a SQL
+ * relation. The MultiIndex column/row frames, named indexes, and tuple columns
+ * are pandas *display* shapes with no DuckDB analog, so they're out of scope —
+ * but every data/dtype pathology below maps to a real DuckDB column and is
+ * exactly where this backend can misbehave.
+ *
+ * Reaches a real DuckDB via @duckdb/node-api and skips on CI (`SKIP_DUCKDB=1`),
+ * matching spike.duckdb.test.ts.
+ */
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { parquetReadObjects, asyncBufferFromFile } from 'hyparquet';
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+import { DuckBackend } from '../src/backend';
+import { createNodeApiDuckSource } from '../src/adapters/nodeApiDuckSource';
+import type { DuckDBConnectionLike } from '../src/adapters/nodeApiDuckSource';
+import type { DuckSource } from '../src/DuckSource';
+import type { PayloadResponse } from '../src/wireTypes';
+
+let connection: DuckDBConnectionLike | undefined;
+let source: DuckSource | undefined;
+
+beforeAll(async () => {
+  try {
+    const duck = await import('@duckdb/node-api');
+    const instance = await duck.DuckDBInstance.create(':memory:');
+    connection = (await instance.connect()) as unknown as DuckDBConnectionLike;
+    source = createNodeApiDuckSource(connection);
+  } catch (err) {
+    console.warn('[ddd] @duckdb/node-api not available, skipping:', (err as Error).message);
+  }
+});
+
+async function readParquet(bytes: Uint8Array): Promise<Record<string, unknown>[]> {
+  const dir = await mkdtemp(join(tmpdir(), 'buckaroo-ddd-'));
+  const file = join(dir, `${randomUUID()}.parquet`);
+  try {
+    await writeFile(file, bytes);
+    const buf = await asyncBufferFromFile(file);
+    return (await parquetReadObjects({ file: buf })) as Record<string, unknown>[];
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch(() => {});
+  }
+}
+
+function decodePayload(resp: PayloadResponse): Promise<Record<string, unknown>[]> {
+  return readParquet(Buffer.from(resp.payload.data, 'base64'));
+}
+
+/** Pull one full window of rows back through COPY → parquet → hyparquet. */
+async function readRows(backend: DuckBackend): Promise<Record<string, unknown>[]> {
+  const resp = await backend.handleInfiniteRequest({
+    sourceName: 'main',
+    start: 0,
+    end: 100,
+    origEnd: 100,
+  });
+  return decodePayload(resp);
+}
+
+/** The pivoted stat rows the viewer consumes (json envelope). */
+function statData(msg: Awaited<ReturnType<DuckBackend['initialState']>>): Array<Record<string, unknown>> {
+  return (msg.df_data_dict.all_stats as { format: string; data: Array<Record<string, unknown>> }).data;
+}
+
+describe.runIf(process.env.SKIP_DUCKDB !== '1')('ddd: dastardly dataframes (DuckDB backend)', () => {
+  // ddd_library.py:df_with_col_named_index — a column literally named "index".
+  // Dangerous here because the backend synthesizes its own `index` column
+  // (rename.ts:INDEX_COL) via ROW_NUMBER. The user column must survive without
+  // colliding with it.
+  it('df_with_col_named_index: a user "index" column survives alongside the synthesized index', async () => {
+    if (!source) return;
+    const backend = new DuckBackend(
+      source,
+      `SELECT * FROM (VALUES ('asdf','7777'),('foo_b','ooooo'),('bar_a','--- -')) t(a, "index")`,
+    );
+    const msg = await backend.initialState();
+    const cfg = msg.df_display_args.main.df_viewer_config;
+
+    // both source columns kept; the user 'index' is aliased to something other
+    // than 'index' so it never clashes with the ROW_NUMBER column.
+    expect(cfg.column_config.map((c) => c.header_name)).toEqual(['a', 'index']);
+    const userIndex = cfg.column_config.find((c) => c.header_name === 'index')!;
+    expect(userIndex.col_name).not.toBe('index');
+    expect(msg.df_meta.total_rows).toBe(3);
+
+    const rows = await readRows(backend);
+    // synthesized index 0..2 and the user 'index' values coexist in the window
+    expect(rows.map((r) => r.index)).toEqual([0n, 1n, 2n]);
+    expect(rows.map((r) => r[userIndex.col_name])).toEqual(['7777', 'ooooo', '--- -']);
+  });
+
+  // ddd_library.py:df_with_infinity — [nan, inf, -inf]. SUMMARIZE's STDDEV_SAMP
+  // overflows ("out of range") on any non-finite value and would abort the whole
+  // stats query, so the stats path (statsRelation) nulls non-finite floats. Here
+  // every value is non-finite, so the scalar stats collapse to null — but
+  // initialState succeeds and the column still renders.
+  it('df_with_infinity: ±inf / nan are treated as missing for stats instead of crashing', async () => {
+    if (!source) return;
+    const backend = new DuckBackend(
+      source,
+      `SELECT * FROM (VALUES ('nan'::DOUBLE),('inf'::DOUBLE),('-inf'::DOUBLE)) t(a)`,
+    );
+    const msg = await backend.initialState(); // no longer throws
+    const stats = statData(msg);
+    expect(stats.find((r) => r.index === 'dtype')!.a).toBe('DOUBLE');
+    expect(stats.find((r) => r.index === 'min')!.a).toBeNull();
+    expect(stats.find((r) => r.index === 'std')!.a).toBeNull();
+    // the column still gets a histogram bar list (no crash)
+    expect(Array.isArray(stats.find((r) => r.index === 'histogram')!.a)).toBe(true);
+  });
+
+  // The guard must not throw away finite data: a column mixing finite values with
+  // nan/±inf keeps real min/max/std computed over the finite values only.
+  it('df_with_infinity (mixed): finite stats survive alongside non-finite values', async () => {
+    if (!source) return;
+    const backend = new DuckBackend(
+      source,
+      `SELECT * FROM (VALUES ('inf'::DOUBLE),('-inf'::DOUBLE),('nan'::DOUBLE),(1.5::DOUBLE),(2.5::DOUBLE)) t(a)`,
+    );
+    const stats = statData(await backend.initialState());
+    expect(Number(stats.find((r) => r.index === 'min')!.a)).toBe(1.5);
+    expect(Number(stats.find((r) => r.index === 'max')!.a)).toBe(2.5);
+    expect(stats.find((r) => r.index === 'std')!.a).not.toBeNull();
+  });
+
+  // ddd_library.py:df_with_really_big_number — an int beyond int64. In DuckDB
+  // that's HUGEINT, which the v1 paths render through JS `number`: lossy. The
+  // categorical histogram, built via CAST(... AS VARCHAR), keeps the exact
+  // digits — so the two surfaces disagree, and that's worth pinning.
+  it('df_with_really_big_number: HUGEINT > 2^63 is lossy in stats/rows but exact in the histogram label', async () => {
+    if (!source) return;
+    const backend = new DuckBackend(
+      source,
+      `SELECT * FROM (VALUES (9999999999999999999::HUGEINT),(1::HUGEINT)) t(col1)`,
+    );
+    const msg = await backend.initialState();
+    const stats = statData(msg);
+
+    expect(stats.find((r) => r.index === 'dtype')!.a).toBe('HUGEINT');
+    // max goes through Number() → 9999999999999999999 rounds up to 1e19 (lossy)
+    expect(stats.find((r) => r.index === 'max')!.a).toBe(10000000000000000000);
+    // the histogram label preserves the exact value (VARCHAR cast, not numeric)
+    const histo = stats.find((r) => r.index === 'histogram')!.a as Array<{ name: string }>;
+    expect(histo.map((b) => b.name)).toContain('9999999999999999999');
+
+    // the row path is lossy too: HUGEINT serializes as parquet DOUBLE
+    const rows = await readRows(backend);
+    expect(rows.map((r) => r.a).sort()).toEqual([1, 10000000000000000000]);
+  });
+
+  // ddd_library.py:pl_df_with_weird_types — Duration/Time/Categorical/Decimal/
+  // Binary. The DuckDB analogs are INTERVAL/TIME/ENUM/DECIMAL/BLOB. None should
+  // crash initialState; each gets a displayer and a histogram.
+  const WEIRD_STMT = `SELECT
+    'red'::ENUM('red','green','blue') AS categorical,
+    INTERVAL 1 HOUR AS duration,
+    TIME '14:30:00' AS t,
+    100.50::DECIMAL(10,2) AS dec,
+    'hello'::BLOB AS binary,
+    10 AS int_col`;
+
+  it('pl_df_with_weird_types: assigns a displayer + histogram to every exotic dtype', async () => {
+    if (!source) return;
+    const msg = await new DuckBackend(source, WEIRD_STMT).initialState();
+    const cfg = msg.df_display_args.main.df_viewer_config;
+
+    const byHeader = Object.fromEntries(
+      cfg.column_config.map((c) => [c.header_name, c.displayer_args.displayer]),
+    );
+    expect(byHeader).toEqual({
+      categorical: 'obj', // ENUM is not mapped to string in v1
+      duration: 'obj', // INTERVAL → obj
+      t: 'datetimeLocaleString', // TIME → datetime
+      dec: 'float', // DECIMAL → float
+      binary: 'obj', // BLOB → obj
+      int_col: 'float', // integers render through the float displayer (0 frac digits)
+    });
+
+    // every column carries a (categorical-fallback) histogram bar list
+    const histoRow = statData(msg).find((r) => r.index === 'histogram')!;
+    for (const c of cfg.column_config) {
+      expect(Array.isArray(histoRow[c.col_name])).toBe(true);
+    }
+  });
+
+  it('pl_df_with_weird_types: COPY serializes every exotic dtype, but hyparquet cannot decode INTERVAL', async () => {
+    if (!source) return;
+    const backend = new DuckBackend(source, WEIRD_STMT);
+    const resp = await backend.handleInfiniteRequest({
+      sourceName: 'main',
+      start: 0,
+      end: 100,
+      origEnd: 100,
+    });
+    // the backend never coerces — COPY → parquet succeeds for all of them
+    expect(resp.payload.format).toBe('parquet_b64');
+    // but the reader chokes on the INTERVAL column: a v1 row-path limitation
+    await expect(decodePayload(resp)).rejects.toThrow(/interval not supported/i);
+
+    // drop INTERVAL and the rest round-trips cleanly (aliases shift up by one)
+    const rows = await readRows(
+      new DuckBackend(source, WEIRD_STMT.replace('INTERVAL 1 HOUR AS duration,', '')),
+    );
+    expect(rows).toHaveLength(1);
+    expect(rows[0].a).toBe('red'); // ENUM → string
+    expect(rows[0].c).toBe(100.5); // DECIMAL → double
+    expect(rows[0].e).toBe(10); // int_col
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/histogram.test.ts
+++ b/packages/buckaroo-duckdb-node/test/histogram.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect } from 'vitest';
+import {
+  npRound0,
+  fmtBucket,
+  numericHistogram,
+  numericHistogramLabels,
+  categoricalHistogram,
+  buildHistogram,
+  type NumericHistogramArgs,
+} from '../src/histogram';
+
+// Ground-truth assertions ported from the Python producer's tests
+// (tests/unit/histogram_test.py, polars_categorical_histogram_test.py) so a
+// DuckDB column renders the exact same bars as pandas/polars.
+
+describe('npRound0 (numpy round-half-to-even)', () => {
+  it.each([
+    [2.5, 2],
+    [3.5, 4],
+    [0.5, 0],
+    [1.5, 2],
+    [2.4, 2],
+    [2.6, 3],
+    [33.0, 33],
+  ])('round(%f) → %i', (x, expected) => {
+    expect(npRound0(x)).toBe(expected);
+  });
+});
+
+describe('fmtBucket (histogram_test.py:test_fmt_bucket_labels)', () => {
+  it('SI prefix with step-scaled precision', () => {
+    expect(fmtBucket(300, 2200, 190, 2200)).toBe('0.3K–2.2K');
+  });
+  it('negative high bound switches the separator to avoid the double-dash', () => {
+    expect(fmtBucket(-100, -80, 2, 100)).toBe('-100<>-80');
+  });
+  it('negative low bound too', () => {
+    expect(fmtBucket(-0.5, 0.5, 0.1, 0.5)).toBe('-0.5<>0.5');
+  });
+  it('step=0 (constant column) must not crash', () => {
+    expect(fmtBucket(7, 7, 0, 7)).toBe('7–7');
+  });
+});
+
+describe('numericHistogramLabels', () => {
+  it('produces one label per bucket from the edges', () => {
+    expect(numericHistogramLabels([1.4, 1.6, 1.8])).toEqual(['1.4–1.6', '1.6–1.8']);
+  });
+});
+
+describe('numericHistogram (histogram_test.py:test_tail_label_precision)', () => {
+  const args: NumericHistogramArgs = {
+    meatCounts: [5, 5],
+    endpoints: [1.4, 1.6, 1.8],
+    lowTail: 1.4,
+    highTail: 1.8,
+  };
+
+  it('tail labels take precision from the meat width, not the outlier range', () => {
+    const result = numericHistogram(args, 1.2, 50_000, 0.0);
+    expect(result[0]).toEqual({ name: '1.2–1.4', tail: 1 });
+    expect(result[result.length - 1]).toEqual({ name: '1.8–50K', tail: 1 });
+  });
+
+  it('emits low tail, meat populations (0–100 %), high tail', () => {
+    expect(numericHistogram(args, 1.2, 1.9, 0.0)).toEqual([
+      { name: '1.2–1.4', tail: 1 },
+      { name: '1.4–1.6', population: 50 },
+      { name: '1.6–1.8', population: 50 },
+      { name: '1.8–1.9', tail: 1 },
+    ]);
+  });
+
+  it('appends an NA bucket when there are nulls', () => {
+    const result = numericHistogram(args, 1.2, 1.9, 0.25);
+    expect(result[result.length - 1]).toEqual({ name: 'NA', NA: 25 });
+  });
+
+  it('all-null column collapses to a single NA bar', () => {
+    expect(numericHistogram(args, 1.2, 1.9, 1.0)).toEqual([{ name: 'NA', NA: 100 }]);
+  });
+});
+
+describe('categoricalHistogram (histogram.py parity, 0–100 scale)', () => {
+  it('top categories become cat_pop bars', () => {
+    expect(
+      categoricalHistogram(
+        100,
+        [
+          { name: 'A', count: 50 },
+          { name: 'B', count: 30 },
+          { name: 'C', count: 20 },
+        ],
+        0,
+        0,
+        0,
+      ),
+    ).toEqual([
+      { name: 'A', cat_pop: 50 },
+      { name: 'B', cat_pop: 30 },
+      { name: 'C', cat_pop: 20 },
+    ]);
+  });
+
+  it('longtail and unique come last (test_categorical_mixed_frequencies)', () => {
+    expect(
+      categoricalHistogram(
+        100,
+        [
+          { name: 'bar', count: 50 },
+          { name: 'foo', count: 30 },
+        ],
+        20, // restSum
+        10, // uniqueCount → longtail = 20 - 10 = 10
+        0,
+      ),
+    ).toEqual([
+      { name: 'bar', cat_pop: 50 },
+      { name: 'foo', cat_pop: 30 },
+      { name: 'longtail', longtail: 10 },
+      { name: 'unique', unique: 10 },
+    ]);
+  });
+
+  it('appends an NA bucket when there are nulls', () => {
+    const bars = categoricalHistogram(100, [{ name: 'A', count: 67 }], 0, 0, 0.33);
+    expect(bars[bars.length - 1]).toEqual({ name: 'NA', NA: 33 });
+  });
+});
+
+describe('buildHistogram dispatcher (histogram.py:histogram)', () => {
+  const numericArgs: NumericHistogramArgs = {
+    meatCounts: [1, 2, 3, 4, 5, 4, 3, 2, 1, 1],
+    endpoints: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    lowTail: 0,
+    highTail: 10,
+  };
+  const categorical = { top: [{ name: 'x', count: 8 }], restSum: 0, uniqueCount: 0 };
+
+  it('uses the numeric histogram when numeric with >5 distinct values', () => {
+    const bars = buildHistogram({
+      isNumeric: true,
+      distinctCount: 50,
+      length: 100,
+      nanPer: 0,
+      min: -1,
+      max: 11,
+      numericArgs,
+      categorical,
+    });
+    // low tail + 10 meat + high tail = 12 bars
+    expect(bars).toHaveLength(12);
+    expect(bars.some((b) => b.population !== undefined)).toBe(true);
+  });
+
+  it('falls back to categorical for low-cardinality numeric columns', () => {
+    const bars = buildHistogram({
+      isNumeric: true,
+      distinctCount: 3,
+      length: 100,
+      nanPer: 0,
+      min: 0,
+      max: 2,
+      numericArgs,
+      categorical,
+    });
+    expect(bars).toEqual([{ name: 'x', cat_pop: 8 }]);
+  });
+
+  it('falls back to categorical when numeric args are missing (degenerate meat)', () => {
+    const bars = buildHistogram({
+      isNumeric: true,
+      distinctCount: 50,
+      length: 100,
+      nanPer: 0,
+      min: 0,
+      max: 2,
+      numericArgs: null,
+      categorical,
+    });
+    expect(bars).toEqual([{ name: 'x', cat_pop: 8 }]);
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/histogram.test.ts
+++ b/packages/buckaroo-duckdb-node/test/histogram.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   npRound0,
   fmtBucket,
@@ -137,46 +137,49 @@ describe('buildHistogram dispatcher (histogram.py:histogram)', () => {
   };
   const categorical = { top: [{ name: 'x', count: 8 }], restSum: 0, uniqueCount: 0 };
 
-  it('uses the numeric histogram when numeric with >5 distinct values', () => {
-    const bars = buildHistogram({
+  it('uses the numeric histogram (and skips the categorical fetch) when numeric with >5 distinct values', async () => {
+    const fetchCategorical = vi.fn(async () => categorical);
+    const bars = await buildHistogram({
       isNumeric: true,
       distinctCount: 50,
       length: 100,
       nanPer: 0,
       min: -1,
       max: 11,
-      numericArgs,
-      categorical,
+      fetchNumericArgs: async () => numericArgs,
+      fetchCategorical,
     });
     // low tail + 10 meat + high tail = 12 bars
     expect(bars).toHaveLength(12);
     expect(bars.some((b) => b.population !== undefined)).toBe(true);
+    // the numeric path won, so the categorical query must not run
+    expect(fetchCategorical).not.toHaveBeenCalled();
   });
 
-  it('falls back to categorical for low-cardinality numeric columns', () => {
-    const bars = buildHistogram({
+  it('falls back to categorical for low-cardinality numeric columns', async () => {
+    const bars = await buildHistogram({
       isNumeric: true,
       distinctCount: 3,
       length: 100,
       nanPer: 0,
       min: 0,
       max: 2,
-      numericArgs,
-      categorical,
+      fetchNumericArgs: async () => numericArgs,
+      fetchCategorical: async () => categorical,
     });
     expect(bars).toEqual([{ name: 'x', cat_pop: 8 }]);
   });
 
-  it('falls back to categorical when numeric args are missing (degenerate meat)', () => {
-    const bars = buildHistogram({
+  it('falls back to categorical when numeric args are missing (degenerate meat)', async () => {
+    const bars = await buildHistogram({
       isNumeric: true,
       distinctCount: 50,
       length: 100,
       nanPer: 0,
       min: 0,
       max: 2,
-      numericArgs: null,
-      categorical,
+      fetchNumericArgs: async () => null,
+      fetchCategorical: async () => categorical,
     });
     expect(bars).toEqual([{ name: 'x', cat_pop: 8 }]);
   });

--- a/packages/buckaroo-duckdb-node/test/histogramSql.test.ts
+++ b/packages/buckaroo-duckdb-node/test/histogramSql.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  numericHistogramSql,
+  categoricalHistogramSql,
+  parseNumericArgs,
+  parseCategorical,
+  MEAT_BINS,
+} from '../src/histogramSql';
+
+describe('numericHistogramSql', () => {
+  const sql = numericHistogramSql('SELECT * FROM t', 'a');
+
+  it('clips the meat to the 1st/99th percentile via quantile_cont', () => {
+    expect(sql).toContain('quantile_cont("a", 0.01)');
+    expect(sql).toContain('quantile_cont("a", 0.99)');
+  });
+
+  it('buckets the meat into 10 equal-width bins', () => {
+    expect(sql).toContain(`(_mm.meat_max - _mm.meat_min) / ${MEAT_BINS}.0`);
+  });
+});
+
+describe('categoricalHistogramSql', () => {
+  it('takes the top-N value counts plus the unique aggregate', () => {
+    const sql = categoricalHistogramSql('SELECT * FROM t', 'b', 7);
+    expect(sql).toContain('GROUP BY "b"');
+    expect(sql).toContain('FILTER (WHERE c = 1)');
+    expect(sql).toContain('LIMIT 7');
+  });
+});
+
+describe('parseNumericArgs', () => {
+  it('fills the 10-bin counts and derives evenly-spaced endpoints', () => {
+    const rows = [
+      { low_tail: 1.99, high_tail: 49, meat_min: 2, meat_max: 12, bin: 0, c: 3 },
+      { low_tail: 1.99, high_tail: 49, meat_min: 2, meat_max: 12, bin: 2, c: 7 },
+    ];
+    const args = parseNumericArgs(rows)!;
+    expect(args.lowTail).toBe(1.99);
+    expect(args.highTail).toBe(49);
+    expect(args.meatCounts).toEqual([3, 0, 7, 0, 0, 0, 0, 0, 0, 0]);
+    expect(args.endpoints).toHaveLength(MEAT_BINS + 1);
+    expect(args.endpoints[0]).toBe(2);
+    expect(args.endpoints[MEAT_BINS]).toBeCloseTo(12);
+  });
+
+  it('returns null for a degenerate (empty) meat range', () => {
+    expect(parseNumericArgs([])).toBeNull();
+  });
+});
+
+describe('parseCategorical', () => {
+  it('derives restSum from non_null minus the top counts', () => {
+    const rows = [
+      { name: 'bar', c: 50, non_null: 100, unique_count: 10 },
+      { name: 'foo', c: 30, non_null: 100, unique_count: 10 },
+    ];
+    const parsed = parseCategorical(rows);
+    expect(parsed.top).toEqual([
+      { name: 'bar', count: 50 },
+      { name: 'foo', count: 30 },
+    ]);
+    expect(parsed.restSum).toBe(20);
+    expect(parsed.uniqueCount).toBe(10);
+  });
+
+  it('handles an all-null column (no rows)', () => {
+    expect(parseCategorical([])).toEqual({ top: [], restSum: 0, uniqueCount: 0 });
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/rename.test.ts
+++ b/packages/buckaroo-duckdb-node/test/rename.test.ts
@@ -58,4 +58,22 @@ describe('buildRenamePlan', () => {
     expect(sql).toContain('(ROW_NUMBER() OVER ()) - 1 AS index');
     expect(sql).toContain('FROM (SELECT * FROM t) AS _buckaroo_src');
   });
+
+  it('statsRelation nulls non-finite floats but leaves other types untouched', () => {
+    const sql = plan.statsRelation('SELECT * FROM t');
+    // the DOUBLE column (alias a) is guarded against nan/±inf
+    expect(sql).toContain('CASE WHEN isfinite(a) THEN a ELSE NULL END AS a');
+    // BIGINT (b), VARCHAR (c), and the synthesized index pass through bare
+    expect(sql).not.toContain('isfinite(b)');
+    expect(sql).not.toContain('isfinite(c)');
+    expect(sql).toContain(`${INDEX_COL} FROM`);
+    // it wraps the renamed relation (so SUMMARIZE sees the aliased columns)
+    expect(sql).toContain('_buckaroo_src');
+  });
+
+  it('statsRelation does not guard DECIMAL (fixed-point cannot be non-finite)', () => {
+    const decPlan = buildRenamePlan([{ name: 'pnl', type: 'DECIMAL(12,4)' }]);
+    const sql = decPlan.statsRelation('SELECT * FROM t');
+    expect(sql).not.toContain('isfinite');
+  });
 });

--- a/packages/buckaroo-duckdb-node/test/spike.duckdb.test.ts
+++ b/packages/buckaroo-duckdb-node/test/spike.duckdb.test.ts
@@ -24,7 +24,31 @@ import type { DuckDBConnectionLike } from '../src/adapters/nodeApiDuckSource';
 import { buildRenamePlan } from '../src/rename';
 import { effectiveQuery, windowedQuery } from '../src/query';
 import { summarizeToSDType, sdTypeToStatRows } from '../src/stats';
+import { numericHistogramSql, parseNumericArgs, computeHistograms } from '../src/histogramSql';
+import { numericHistogram } from '../src/histogram';
 import type { DuckSource } from '../src/DuckSource';
+
+// The exact integer column from the Python producer's histogram test
+// (tests/unit/histogram_test.py:INT_ARR). DuckDB's quantile_cont +
+// width_bucket must reproduce numpy's 1st/99th-percentile meat histogram.
+const INT_ARR = [
+  33, 41, 11, 46, 42, 44, 31, 25, 16, 24, 26, 7, 19, 23, 20, 46, 10, 4, 31, 45, 40, 37, 48, 21,
+  19, 20, 19, 14, 14, 26, 36, 24, 21, 41, 19, 17, 24, 27, 32, 30, 19, 49, 22, 20, 16, 7, 45, 10,
+  23, 44, 28, 44, 15, 29, 34, 3, 44, 19, 20, 27, 1, 35, 34, 42, 12, 9, 21, 32, 40, 41, 49, 47,
+  16, 25, 20, 11, 28, 13, 30, 6, 34, 16, 37, 21, 7, 34, 34, 29, 24, 2, 7, 17, 13, 22, 13, 32, 11,
+  24, 24, 31, 11, 9, 39, 40, 36, 20, 46, 31, 37, 27, 25, 9, 27, 41, 13, 35, 33, 24, 8, 25, 12, 28,
+  26, 17, 7, 18, 12, 6, 45, 42, 32, 38, 31, 25, 33, 13, 24, 23, 40, 18, 33, 42, 7, 40, 48, 29, 27,
+  13, 38, 35, 33, 24, 40, 19, 47, 38, 8, 3, 6, 48, 9, 17, 13, 46, 6, 3, 34, 43, 6, 9, 28, 4, 49,
+  10, 14, 36, 48, 39, 1, 37, 41, 37, 43, 43, 6, 23, 6, 30, 27, 11, 19, 19, 34, 14, 37, 42, 15, 6,
+  48, 32,
+];
+
+// histogram_test.py:_assert_ha — the expected normalized meat populations.
+const EXPECTED_NORMALIZED = [
+  0.07179487179487179, 0.1076923076923077, 0.08205128205128205, 0.1282051282051282,
+  0.09743589743589744, 0.1076923076923077, 0.1282051282051282, 0.07692307692307693,
+  0.1076923076923077, 0.09230769230769231,
+];
 
 // Dynamically import the optional native module; skip the suite if absent.
 let connection: DuckDBConnectionLike | undefined;
@@ -145,5 +169,51 @@ describe.runIf(process.env.SKIP_DUCKDB !== '1')('DuckDB serialization spike', ()
     // 'name' (alias f): 101 rows, ~15 nulls (i%7==0 for i in 0..100)
     const nullRow = rows.find((r) => r.index === 'null_count')!;
     expect(Number(nullRow.f)).toBeGreaterThan(0);
+  });
+
+  it('numeric histogram clips to the 1st/99th percentile and matches numpy', async () => {
+    if (!source) return;
+    const stmt = effectiveQuery(`SELECT unnest([${INT_ARR.join(',')}]) AS a`);
+    const plan = buildRenamePlan(await source.describe(stmt));
+    const relation = plan.renamedRelation(stmt);
+
+    const argRows = await source.queryRows(numericHistogramSql(relation, 'a'));
+    const args = parseNumericArgs(argRows)!;
+
+    // 1st/99th percentile cut points (np.quantile linear == quantile_cont)
+    expect(args.lowTail).toBeCloseTo(1.99, 5);
+    expect(args.highTail).toBeCloseTo(49, 5);
+
+    // 10 meat bins whose normalized populations match the numpy fixture
+    expect(args.meatCounts).toHaveLength(10);
+    const total = args.meatCounts.reduce((a, b) => a + b, 0);
+    const normalized = args.meatCounts.map((c) => c / total);
+    normalized.forEach((p, i) => expect(p).toBeCloseTo(EXPECTED_NORMALIZED[i], 6));
+
+    // the rendered bars: low tail, 10 populations, high tail (no nulls → no NA)
+    const bars = numericHistogram(args, 1, 49, 0);
+    expect(bars).toHaveLength(12);
+    expect(bars[0].tail).toBe(1);
+    expect(bars[11].tail).toBe(1);
+    expect(bars.slice(1, 11).every((b) => typeof b.population === 'number')).toBe(true);
+  });
+
+  it('categorical histogram emits cat_pop bars for a string column', async () => {
+    if (!source) return;
+    // counts 4/3/3 (length 10) — no singleton category, so no unique/longtail bar
+    const stmt = effectiveQuery(
+      `SELECT unnest(['A','A','A','A','B','B','B','C','C','C']) AS cat`,
+    );
+    const plan = buildRenamePlan(await source.describe(stmt));
+    const relation = plan.renamedRelation(stmt);
+    const summarizeRows = await source.summarize(relation);
+    const sd = summarizeToSDType(summarizeRows);
+
+    const histos = await computeHistograms(source, relation, plan, sd, 10);
+    expect(histos.a).toEqual([
+      { name: 'A', cat_pop: 40 },
+      { name: 'B', cat_pop: 30 },
+      { name: 'C', cat_pop: 30 },
+    ]);
   });
 });


### PR DESCRIPTION
Adds the `histogram` summary stat to `buckaroo-duckdb-node`, the fast-follow #936 reserved (`stats.ts`: "Histograms/quantile displayers are a fast-follow"). A DuckDB column now renders the same histogram bars as the pandas/polars backends, through the existing `displayer: 'histogram'` pinned row.

**Stacked on #936.** Base is `feat/930-duckdb-node-backend` because the package only exists there. Once #936 merges, this retargets to `main` (automatic when the base branch is deleted).

## What's here

- **`histogram.ts`** — a faithful TS port of the Python producer (`customizations/histogram.py`):
  - **Numeric**: clips the meat to the **1st/99th percentile** (`np.quantile` ≡ DuckDB `quantile_cont`), 10 bins, low/high tail markers, NA bucket.
  - **Categorical**: top-7 categories (`cat_pop`), then `longtail` / `unique` / `NA`.
  - 0–100 scale, numpy round-half-to-even, SI-prefix bucket labels.
- **`histogramSql.ts`** — per-column quantile + equal-width-bin SQL (DuckDB has no `width_bucket`, so `floor((v-min)/width)` clamped to the last bin reproduces `np.histogram`'s edges) and the top-N value-counts query, plus the numeric-vs-categorical dispatcher matching `histogram.py:histogram`. A failure on any single column yields an empty histogram, never a broken `initial_state`.
- **`DuckSource.queryRows`** seam (implemented in the node-api adapter) for the small scalar aggregates; the no-coercion row path is untouched.
- **backend** injects the `histogram` row right after `dtype`; **columnConfig** pins it with the histogram displayer (`DefaultMainStyling.pinned_rows` parity).

## Validation

The real-DuckDB spike reproduces numpy's exact normalized meat populations for the Python `INT_ARR` fixture (1st/99th-percentile clipping verified end to end) plus a categorical column. Note CI runs `SKIP_DUCKDB=1`, so the spike runs locally — full suite (77 tests incl. spike) green locally; the non-DuckDB tests run on CI.

## TDD

First commit pushes the contract tests red (they reference the not-yet-added modules); the second commit makes them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)