### PR TITLE
feat(duckdb-node): search — filtered stats/rows + highlight_phrase

### DIFF
--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/README.md
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/README.md
@@ -13,17 +13,24 @@ pnpm install          # once, from packages/
 pnpm demo             # builds the package, then starts the server
 ```
 
-Then open **http://localhost:8780/**.
+Then open **http://localhost:9080/**.
 
 Scroll the grid (rows stream in on demand), click a column header to sort, and
 read the pinned summary-stats rows (dtype, null_count, distinct_count, mean,
 std, min, q25/q50/q75, max).
 
+Use the **View** dropdown at the top to switch between **DFViewer** and the
+**Infinite Buckaroo** widget — both render the same DuckDB-backed session and
+both support search. Switching reloads the session under `/s/<view>`.
+
+The default port (`9080`) is kept clear of tallyman's ports (`:7860`, `:8700`)
+so the demo never collides with a running tallyman.
+
 Knobs (env vars):
 
 | var | default | meaning |
 |---|---|---|
-| `PORT` | `8780` | HTTP + WS port |
+| `PORT` | `9080` | HTTP + WS port |
 | `ROWS` | `250000` | synthetic table size |
 | `BUCKAROO_STATIC` | `../../../../buckaroo/static` | dir holding the browser bundle |
 

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
@@ -52,6 +52,18 @@ function modeForView(view) {
   return VIEWS.find((v) => v.id === view)?.mode ?? 'viewer';
 }
 
+// Lightweight wire logging so the search/scroll message flow is visible — set
+// QUIET=1 to silence. Each WS client gets a short id so interleaved sessions
+// stay readable, and a monotonic ms clock makes redundant sends (the source of
+// search flicker) obvious.
+const QUIET = process.env.QUIET === '1';
+let clientSeq = 0;
+function log(cid, dir, ...rest) {
+  if (QUIET) return;
+  const t = `${Math.round(process.uptime() * 1000)}ms`.padStart(8);
+  console.log(`${t}  ws#${cid} ${dir}`, ...rest);
+}
+
 // The browser bundle + CSS the buckaroo Python package builds into buckaroo/static.
 const STATIC_DIR =
   process.env.BUCKAROO_STATIC ??
@@ -239,11 +251,14 @@ async function main() {
     // standalone render mode (DFViewer vs Infinite Buckaroo).
     const view = decodeURIComponent(req.url.slice('/ws/'.length).split(/[/?]/)[0]);
     const mode = modeForView(view);
+    const cid = ++clientSeq;
+    log(cid, 'open', `view=${view} mode=${mode}`);
     // Each client gets its own backend instance over the shared connection.
     const backend = new DuckBackend(source, BASE_STMT);
 
     try {
       const initial = await backend.initialState();
+      log(cid, '→ initial_state', `total=${initial.df_meta.total_rows} filtered=${initial.df_meta.filtered_rows}`);
       ws.send(JSON.stringify(toLegacyInitialState(initial, mode)));
     } catch (err) {
       console.error('initial_state failed:', err);
@@ -262,9 +277,11 @@ async function main() {
       if (msg.type === 'buckaroo_state_change') {
         const search = msg.new_state?.quick_command_args?.search;
         const term = Array.isArray(search) && search[0] != null ? String(search[0]) : '';
+        log(cid, '← state_change', `search=${JSON.stringify(term)}`);
         backend.setSearch(term);
         try {
           const refreshed = await backend.initialState();
+          log(cid, '→ initial_state', `search=${JSON.stringify(term)} total=${refreshed.df_meta.total_rows} filtered=${refreshed.df_meta.filtered_rows}`);
           ws.send(JSON.stringify(toLegacyInitialState(refreshed, mode)));
         } catch (err) {
           console.error('search state_change failed:', err);
@@ -274,8 +291,10 @@ async function main() {
       if (msg.type !== 'infinite_request') return; // read-only viewer: ignore the rest
 
       const args = msg.payload_args ?? {};
+      log(cid, '← infinite_request', `start=${args.start} end=${args.end}${args.sort ? ` sort=${args.sort} ${args.sort_direction ?? ''}` : ''}`);
       try {
         const resp = await backend.handleInfiniteRequest(args);
+        log(cid, '→ infinite_resp', `length=${resp.length} bytes=${resp.payload.data.length}`);
         // Re-frame the inline parquet_b64 envelope as the legacy two-frame wire.
         const bytes = Buffer.from(resp.payload.data, 'base64');
         ws.send(

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
@@ -215,6 +215,19 @@ async function main() {
       } catch {
         return;
       }
+      // Search: re-run with the new term and resend the (filtered) initial_state.
+      if (msg.type === 'buckaroo_state_change') {
+        const search = msg.new_state?.quick_command_args?.search;
+        const term = Array.isArray(search) && search[0] != null ? String(search[0]) : '';
+        backend.setSearch(term);
+        try {
+          const refreshed = await backend.initialState();
+          ws.send(JSON.stringify(toLegacyInitialState(refreshed)));
+        } catch (err) {
+          console.error('search state_change failed:', err);
+        }
+        return;
+      }
       if (msg.type !== 'infinite_request') return; // read-only viewer: ignore the rest
 
       const args = msg.payload_args ?? {};

--- a/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
+++ b/packages/buckaroo-duckdb-node/examples/duckdb-ws-server/server.mjs
@@ -16,7 +16,8 @@
  * The backend logic is identical; only the framing differs.)
  *
  * Run:  pnpm demo        (from packages/buckaroo-duckdb-node)
- * Then open the printed http://localhost:8780/ URL.
+ * Then open the printed http://localhost:9080/ URL. A view dropdown switches
+ * between DFViewer and the Infinite Buckaroo widget; search works in both.
  */
 
 import http from 'node:http';
@@ -31,7 +32,25 @@ import { DuckBackend } from '../../dist/index.js';
 import { createNodeApiDuckSource } from '../../dist/adapters/nodeApiDuckSource.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PORT = Number(process.env.PORT ?? 8780);
+// Default clear of tallyman's ports (companion :7860, Buckaroo subprocess :8700
+// and the 87xx band it allocates from) so the demo never collides with a
+// running tallyman. Override with PORT.
+const PORT = Number(process.env.PORT ?? 9080);
+
+// The two render paths the standalone bundle (packages/js/standalone.tsx)
+// exposes over the infinite/WS backend, selected by `initial_state.mode`.
+// The session id in the URL (/s/<view>) carries the choice; the dropdown in
+// the page just navigates between them.
+const VIEWS = [
+  { id: 'dfviewer', label: 'DFViewer', mode: 'viewer' },
+  { id: 'buckaroo', label: 'Buckaroo (Infinite)', mode: 'buckaroo' },
+];
+const DEFAULT_VIEW = VIEWS[0].id;
+
+/** Resolve a view id (from the URL) to the bundle's render mode; viewer by default. */
+function modeForView(view) {
+  return VIEWS.find((v) => v.id === view)?.mode ?? 'viewer';
+}
 
 // The browser bundle + CSS the buckaroo Python package builds into buckaroo/static.
 const STATIC_DIR =
@@ -82,7 +101,7 @@ function unwrapJsonEnvelope(value) {
   return value;
 }
 
-function toLegacyInitialState(msg) {
+function toLegacyInitialState(msg, mode = 'viewer') {
   const df_data_dict = {};
   for (const [k, v] of Object.entries(msg.df_data_dict)) {
     df_data_dict[k] = unwrapJsonEnvelope(v);
@@ -90,7 +109,7 @@ function toLegacyInitialState(msg) {
   return {
     type: 'initial_state',
     protocol_version: 1,
-    mode: 'viewer',
+    mode,
     prompt: '',
     metadata: { path: `duckdb://${TABLE}`, rows: msg.df_meta.total_rows },
     df_meta: msg.df_meta,
@@ -105,17 +124,22 @@ function toLegacyInitialState(msg) {
 // HTTP: session page + static assets.
 // ---------------------------------------------------------------------------
 
-function sessionHtml(sessionId) {
+function sessionHtml(view) {
+  const options = VIEWS.map(
+    (v) => `<option value="${v.id}"${v.id === view ? ' selected' : ''}>${v.label}</option>`,
+  ).join('');
   return `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
-  <title>Buckaroo (DuckDB) — ${sessionId}</title>
+  <title>Buckaroo (DuckDB) — ${view}</title>
   <link rel="stylesheet" href="/static/compiled.css">
   <link rel="stylesheet" href="/static/standalone.css">
   <style>
     html, body { margin: 0; padding: 0; width: 100%; height: 100vh; background: #181d1f; }
     body { display: flex; flex-direction: column; }
+    #view-bar { padding: 4px 10px; font-family: sans-serif; font-size: 13px; color: #ccc; background: #1f2426; border-bottom: 1px solid #333; flex-shrink: 0; display: flex; align-items: center; gap: 8px; }
+    #view-bar select { background: #2a3033; color: #eee; border: 1px solid #444; border-radius: 3px; padding: 2px 6px; font-size: 13px; }
     #filename-bar { padding: 4px 10px; font-family: sans-serif; font-size: 13px; color: #ccc; background: #222; border-bottom: 1px solid #333; flex-shrink: 0; }
     #filename-bar:empty { display: none; }
     #prompt-bar { padding: 4px 10px; font-family: sans-serif; font-size: 12px; color: #999; background: #222; border-bottom: 1px solid #333; flex-shrink: 0; }
@@ -130,9 +154,20 @@ function sessionHtml(sessionId) {
   </style>
 </head>
 <body>
+  <div id="view-bar">
+    <label for="view-select">View</label>
+    <select id="view-select">${options}</select>
+    <span style="color:#777">— search works in both; switching reloads the session</span>
+  </div>
   <div id="filename-bar"></div>
   <div id="prompt-bar"></div>
   <div id="root"></div>
+  <script>
+    // The session id in the path IS the selected view; switching navigates to it.
+    document.getElementById('view-select').addEventListener('change', (e) => {
+      window.location.pathname = '/s/' + e.target.value;
+    });
+  </script>
   <script type="module" src="/static/standalone.js"></script>
 </body>
 </html>`;
@@ -175,11 +210,15 @@ async function main() {
     try {
       const url = new URL(req.url, `http://localhost:${PORT}`);
       if (url.pathname === '/') {
-        res.writeHead(302, { location: '/s/demo' }).end();
+        res.writeHead(302, { location: `/s/${DEFAULT_VIEW}` }).end();
       } else if (url.pathname.startsWith('/s/')) {
+        const requested = decodeURIComponent(url.pathname.slice(3));
+        // Normalize unknown sessions to the default view so the dropdown always
+        // reflects a real render mode.
+        const view = VIEWS.some((v) => v.id === requested) ? requested : DEFAULT_VIEW;
         res
           .writeHead(200, { 'content-type': 'text/html' })
-          .end(sessionHtml(decodeURIComponent(url.pathname.slice(3))));
+          .end(sessionHtml(view));
       } else if (url.pathname.startsWith('/static/')) {
         await serveStatic(req, res, url.pathname.slice('/static/'.length));
       } else {
@@ -196,12 +235,16 @@ async function main() {
       ws.close();
       return;
     }
+    // The WS path mirrors the page path (/ws/<view>); the view selects the
+    // standalone render mode (DFViewer vs Infinite Buckaroo).
+    const view = decodeURIComponent(req.url.slice('/ws/'.length).split(/[/?]/)[0]);
+    const mode = modeForView(view);
     // Each client gets its own backend instance over the shared connection.
     const backend = new DuckBackend(source, BASE_STMT);
 
     try {
       const initial = await backend.initialState();
-      ws.send(JSON.stringify(toLegacyInitialState(initial)));
+      ws.send(JSON.stringify(toLegacyInitialState(initial, mode)));
     } catch (err) {
       console.error('initial_state failed:', err);
       ws.close();
@@ -222,7 +265,7 @@ async function main() {
         backend.setSearch(term);
         try {
           const refreshed = await backend.initialState();
-          ws.send(JSON.stringify(toLegacyInitialState(refreshed)));
+          ws.send(JSON.stringify(toLegacyInitialState(refreshed, mode)));
         } catch (err) {
           console.error('search state_change failed:', err);
         }

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -19,10 +19,12 @@ import { effectiveQuery, windowedQuery, type QueryTransform } from './query.js';
 import { buildDfViewerConfig } from './columnConfig.js';
 import { summarizeToSDType, sdTypeToStatRows } from './stats.js';
 import { computeHistograms } from './histogramSql.js';
+import { buildSearchTransform, isSearchableType, isActiveSearch } from './search.js';
 import type {
   BuckarooOptions,
   BuckarooState,
   DFEnvelope,
+  DFViewerConfig,
   InitialStateMessage,
   PayloadArgs,
   PayloadResponse,
@@ -31,8 +33,10 @@ import type {
 export interface DuckBackendOptions {
   /** summary-stats key. Defaults to `'all_stats'`. */
   summaryStatsKey?: string;
-  /** v1: empty. Reserved for search (`+ WHERE`) and quick-command transforms. */
+  /** Static transforms applied before search; reserved for quick commands. */
   transforms?: QueryTransform[];
+  /** Initial search term. Usually set later via `setSearch` on a state change. */
+  search?: string;
 }
 
 /**
@@ -72,17 +76,47 @@ export class DuckBackend {
   private readonly transforms: QueryTransform[];
 
   private plan?: RenamePlan;
+  /** Unfiltered row count — `df_meta.total_rows`. Stable across searches. */
   private totalRows = 0;
+  /** Rows after search — `df_meta.filtered_rows` and the infinite_resp length. */
+  private filteredRows = 0;
+  private cachedTotal?: number;
+  private searchTerm: string;
+  /** The effective SQL the row/stats queries run against (base + search). */
+  private activeSql: string;
 
   constructor(source: DuckSource, baseStmt: string, opts: DuckBackendOptions = {}) {
     this.source = source;
     this.baseStmt = baseStmt;
     this.summaryStatsKey = opts.summaryStatsKey ?? 'all_stats';
     this.transforms = opts.transforms ?? [];
+    this.searchTerm = opts.search ?? '';
+    this.activeSql = effectiveQuery(this.baseStmt, this.transforms);
   }
 
+  /** The base effective SQL, search excluded. */
   private get effectiveSql(): string {
     return effectiveQuery(this.baseStmt, this.transforms);
+  }
+
+  /**
+   * Set (or clear) the search term. The next `initialState` re-runs stats over
+   * the filtered set and re-points the row window; an empty term clears it.
+   */
+  setSearch(term: string): void {
+    this.searchTerm = term ?? '';
+  }
+
+  /** The original (pre-rename) text columns search targets. */
+  private searchColumns(plan: RenamePlan): string[] {
+    return plan.columns.filter((c) => isSearchableType(c.type)).map((c) => c.origName);
+  }
+
+  /** Effective SQL with the search `+ WHERE` folded in (base SQL when inactive). */
+  private searchEffectiveSql(plan: RenamePlan): string {
+    if (!isActiveSearch(this.searchTerm)) return this.effectiveSql;
+    const transform = buildSearchTransform(this.searchColumns(plan), this.searchTerm);
+    return effectiveQuery(this.baseStmt, [...this.transforms, transform]);
   }
 
   /** Describe the (renamed) relation and cache the rename plan. */
@@ -96,14 +130,30 @@ export class DuckBackend {
 
   async initialState(): Promise<InitialStateMessage> {
     const plan = await this.ensurePlan();
+    const active = isActiveSearch(this.searchTerm) && this.searchColumns(plan).length > 0;
+    this.activeSql = this.searchEffectiveSql(plan);
 
-    // Stats over the stats-safe relation (non-finite floats nulled so SUMMARIZE's
-    // STDDEV_SAMP doesn't overflow); column names come back as aliases. The
-    // relation includes the synthesized, non-null `index` column, so its
-    // SUMMARIZE count is the total row count — no extra count query needed.
-    const summarizeRows = await this.source.summarize(plan.statsRelation(this.effectiveSql));
+    // Stats over the stats-safe (non-finite floats nulled so SUMMARIZE's
+    // STDDEV_SAMP doesn't overflow), possibly search-filtered relation — pandas
+    // re-runs summary stats on the filtered df, so we do too. The relation
+    // includes the synthesized, non-null `index` column, so its SUMMARIZE count
+    // is the row count of that set (filtered under search), no extra count
+    // query needed.
+    const summarizeRows = await this.source.summarize(plan.statsRelation(this.activeSql));
     const indexRow = summarizeRows.find((r) => r.column_name === INDEX_COL);
-    this.totalRows = indexRow ? Number(indexRow.count) : 0;
+    this.filteredRows = indexRow ? Number(indexRow.count) : 0;
+
+    // total_rows is the unfiltered count and never changes with search. Cache it
+    // so repeated searches don't re-summarize the base relation; when search is
+    // inactive the filtered count IS the total.
+    if (!active) {
+      this.cachedTotal = this.filteredRows;
+    } else if (this.cachedTotal === undefined) {
+      const baseRows = await this.source.summarize(plan.renamedRelation(this.effectiveSql));
+      const baseIndex = baseRows.find((r) => r.column_name === INDEX_COL);
+      this.cachedTotal = baseIndex ? Number(baseIndex.count) : this.filteredRows;
+    }
+    this.totalRows = this.cachedTotal ?? this.filteredRows;
 
     const sd = summarizeToSDType(summarizeRows);
     const statRows = sdTypeToStatRows(sd);
@@ -122,14 +172,15 @@ export class DuckBackend {
     statRows.splice(1, 0, { [INDEX_COL]: 'histogram', level_0: 'histogram', ...histos });
 
     const dfViewerConfig = buildDfViewerConfig(plan);
+    if (active) this.applyHighlight(dfViewerConfig, this.searchTerm);
 
     return {
       type: 'initial_state',
       df_meta: {
         total_rows: this.totalRows,
         columns: plan.columns.length,
-        filtered_rows: this.totalRows,
-        rows_shown: this.totalRows,
+        filtered_rows: this.filteredRows,
+        rows_shown: this.filteredRows,
       },
       df_data_dict: {
         // main rows arrive on demand via infinite_request
@@ -150,13 +201,27 @@ export class DuckBackend {
   }
 
   /**
-   * Answer one `infinite_request`. The window is serialized through the
-   * COPY→parquet no-coercion path and returned inline as a `parquet_b64`
-   * envelope (single JSON message, no binary side-channel frame).
+   * Inject `highlight_phrase` into every string-column displayer so the matched
+   * term is highlighted in the grid — the wire shape the Python `Search`
+   * command produces via its SDResult `highlight_phrase` update.
+   */
+  private applyHighlight(cfg: DFViewerConfig, term: string): void {
+    for (const cc of cfg.column_config) {
+      if (cc.displayer_args.displayer === 'string') {
+        cc.displayer_args = { ...cc.displayer_args, highlight_phrase: [term] };
+      }
+    }
+  }
+
+  /**
+   * Answer one `infinite_request`. The window runs against the active
+   * (search-filtered) SQL, is serialized through the COPY→parquet no-coercion
+   * path and returned inline as a `parquet_b64` envelope. `length` is the
+   * filtered row count so the grid scrolls only the matching rows.
    */
   async handleInfiniteRequest(args: PayloadArgs): Promise<PayloadResponse> {
     const plan = await this.ensurePlan();
-    const sql = windowedQuery(this.effectiveSql, plan, {
+    const sql = windowedQuery(this.activeSql, plan, {
       start: args.start,
       end: args.end,
       sort: args.sort,
@@ -167,7 +232,7 @@ export class DuckBackend {
     return {
       type: 'infinite_resp',
       key: args,
-      length: this.totalRows,
+      length: this.filteredRows,
       payload,
     };
   }

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -204,7 +204,15 @@ export class DuckBackend {
           summary_stats_key: this.summaryStatsKey,
         },
       },
-      buckaroo_state: READONLY_STATE,
+      // Echo the active search term back in buckaroo_state. The StatusBar's
+      // search cell is controlled by quick_command_args.search; if we returned
+      // the bare READONLY_STATE (empty), its value would snap to '' while the
+      // input still holds the term, and its debounce effect would resubmit the
+      // search forever (a render-flicker loop). The Python path round-trips the
+      // term the same way.
+      buckaroo_state: isActiveSearch(this.searchTerm)
+        ? { ...READONLY_STATE, quick_command_args: { search: [this.searchTerm] } }
+        : READONLY_STATE,
       buckaroo_options: READONLY_OPTIONS,
     };
   }

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -78,12 +78,15 @@ export class DuckBackend {
   private plan?: RenamePlan;
   /** Unfiltered row count — `df_meta.total_rows`. Stable across searches. */
   private totalRows = 0;
-  /** Rows after search — `df_meta.filtered_rows` and the infinite_resp length. */
-  private filteredRows = 0;
+  /** Unfiltered count, cached so repeated searches don't re-summarize the base. */
   private cachedTotal?: number;
+  /**
+   * Rows after search — `df_meta.filtered_rows` and the infinite_resp `length`.
+   * Cached against the current `searchTerm`; `setSearch` invalidates it so a row
+   * window can never report a stale count. `undefined` means "not yet computed".
+   */
+  private cachedFiltered?: number;
   private searchTerm: string;
-  /** The effective SQL the row/stats queries run against (base + search). */
-  private activeSql: string;
 
   constructor(source: DuckSource, baseStmt: string, opts: DuckBackendOptions = {}) {
     this.source = source;
@@ -91,7 +94,6 @@ export class DuckBackend {
     this.summaryStatsKey = opts.summaryStatsKey ?? 'all_stats';
     this.transforms = opts.transforms ?? [];
     this.searchTerm = opts.search ?? '';
-    this.activeSql = effectiveQuery(this.baseStmt, this.transforms);
   }
 
   /** The base effective SQL, search excluded. */
@@ -100,11 +102,17 @@ export class DuckBackend {
   }
 
   /**
-   * Set (or clear) the search term. The next `initialState` re-runs stats over
-   * the filtered set and re-points the row window; an empty term clears it.
+   * Set (or clear) the search term. Invalidates the cached filtered count so the
+   * next `initialState`/`infinite_request` recomputes against the new term; an
+   * empty term clears the filter. The active SQL is derived on demand (no cached
+   * copy to go stale), so a row window is consistent regardless of call order.
    */
   setSearch(term: string): void {
-    this.searchTerm = term ?? '';
+    const next = term ?? '';
+    if (next !== this.searchTerm) {
+      this.searchTerm = next;
+      this.cachedFiltered = undefined;
+    }
   }
 
   /** The original (pre-rename) text columns search targets. */
@@ -131,29 +139,30 @@ export class DuckBackend {
   async initialState(): Promise<InitialStateMessage> {
     const plan = await this.ensurePlan();
     const active = isActiveSearch(this.searchTerm) && this.searchColumns(plan).length > 0;
-    this.activeSql = this.searchEffectiveSql(plan);
 
     // Stats over the stats-safe (non-finite floats nulled so SUMMARIZE's
     // STDDEV_SAMP doesn't overflow), possibly search-filtered relation — pandas
     // re-runs summary stats on the filtered df, so we do too. The relation
     // includes the synthesized, non-null `index` column, so its SUMMARIZE count
     // is the row count of that set (filtered under search), no extra count
-    // query needed.
-    const summarizeRows = await this.source.summarize(plan.statsRelation(this.activeSql));
+    // query needed. Seed the filtered-count cache from this same SUMMARIZE so a
+    // following `infinite_request` doesn't re-run it.
+    const summarizeRows = await this.source.summarize(plan.statsRelation(this.searchEffectiveSql(plan)));
     const indexRow = summarizeRows.find((r) => r.column_name === INDEX_COL);
-    this.filteredRows = indexRow ? Number(indexRow.count) : 0;
+    const filteredRows = indexRow ? Number(indexRow.count) : 0;
+    this.cachedFiltered = filteredRows;
 
     // total_rows is the unfiltered count and never changes with search. Cache it
     // so repeated searches don't re-summarize the base relation; when search is
     // inactive the filtered count IS the total.
     if (!active) {
-      this.cachedTotal = this.filteredRows;
+      this.cachedTotal = filteredRows;
     } else if (this.cachedTotal === undefined) {
       const baseRows = await this.source.summarize(plan.renamedRelation(this.effectiveSql));
       const baseIndex = baseRows.find((r) => r.column_name === INDEX_COL);
-      this.cachedTotal = baseIndex ? Number(baseIndex.count) : this.filteredRows;
+      this.cachedTotal = baseIndex ? Number(baseIndex.count) : filteredRows;
     }
-    this.totalRows = this.cachedTotal ?? this.filteredRows;
+    this.totalRows = this.cachedTotal ?? filteredRows;
 
     const sd = summarizeToSDType(summarizeRows);
     const statRows = sdTypeToStatRows(sd);
@@ -179,8 +188,8 @@ export class DuckBackend {
       df_meta: {
         total_rows: this.totalRows,
         columns: plan.columns.length,
-        filtered_rows: this.filteredRows,
-        rows_shown: this.filteredRows,
+        filtered_rows: filteredRows,
+        rows_shown: filteredRows,
       },
       df_data_dict: {
         // main rows arrive on demand via infinite_request
@@ -214,14 +223,33 @@ export class DuckBackend {
   }
 
   /**
+   * The filtered row count for the current search. Cached and invalidated by
+   * `setSearch`, recomputed with one SUMMARIZE-count only when stale.
+   * `initialState` seeds the cache from its own SUMMARIZE, so the common
+   * state_change → initial_state → infinite_request flow never double-counts;
+   * a standalone `setSearch` followed directly by `infinite_request` recomputes
+   * here rather than reporting a stale length.
+   */
+  private async ensureFiltered(plan: RenamePlan): Promise<number> {
+    if (this.cachedFiltered === undefined) {
+      const rows = await this.source.summarize(plan.renamedRelation(this.searchEffectiveSql(plan)));
+      const indexRow = rows.find((r) => r.column_name === INDEX_COL);
+      this.cachedFiltered = indexRow ? Number(indexRow.count) : 0;
+    }
+    return this.cachedFiltered;
+  }
+
+  /**
    * Answer one `infinite_request`. The window runs against the active
-   * (search-filtered) SQL, is serialized through the COPY→parquet no-coercion
-   * path and returned inline as a `parquet_b64` envelope. `length` is the
-   * filtered row count so the grid scrolls only the matching rows.
+   * (search-filtered) SQL — derived on demand from the current term, never a
+   * cached copy that could go stale — serialized through the COPY→parquet
+   * no-coercion path and returned inline as a `parquet_b64` envelope. `length`
+   * is the filtered row count so the grid scrolls only the matching rows.
    */
   async handleInfiniteRequest(args: PayloadArgs): Promise<PayloadResponse> {
     const plan = await this.ensurePlan();
-    const sql = windowedQuery(this.activeSql, plan, {
+    const length = await this.ensureFiltered(plan);
+    const sql = windowedQuery(this.searchEffectiveSql(plan), plan, {
       start: args.start,
       end: args.end,
       sort: args.sort,
@@ -232,7 +260,7 @@ export class DuckBackend {
     return {
       type: 'infinite_resp',
       key: args,
-      length: this.filteredRows,
+      length,
       payload,
     };
   }

--- a/packages/buckaroo-duckdb-node/src/backend.ts
+++ b/packages/buckaroo-duckdb-node/src/backend.ts
@@ -138,7 +138,10 @@ export class DuckBackend {
 
   async initialState(): Promise<InitialStateMessage> {
     const plan = await this.ensurePlan();
-    const active = isActiveSearch(this.searchTerm) && this.searchColumns(plan).length > 0;
+    // A search is active whenever there's a term — even on a table with no text
+    // columns, where it correctly matches nothing (filtered_rows = 0) rather
+    // than falling back to the unfiltered view.
+    const active = isActiveSearch(this.searchTerm);
 
     // Stats over the stats-safe (non-finite floats nulled so SUMMARIZE's
     // STDDEV_SAMP doesn't overflow), possibly search-filtered relation — pandas
@@ -181,7 +184,15 @@ export class DuckBackend {
     statRows.splice(1, 0, { [INDEX_COL]: 'histogram', level_0: 'histogram', ...histos });
 
     const dfViewerConfig = buildDfViewerConfig(plan);
-    if (active) this.applyHighlight(dfViewerConfig, this.searchTerm);
+    if (active) {
+      // Highlight only the columns the search predicate actually covers. BOOLEAN
+      // renders with the `string` displayer but is excluded from the search, so
+      // gating on the displayer kind would wrongly highlight boolean cells.
+      const searchableAliases = new Set(
+        plan.columns.filter((c) => isSearchableType(c.type)).map((c) => c.alias),
+      );
+      this.applyHighlight(dfViewerConfig, this.searchTerm, searchableAliases);
+    }
 
     return {
       type: 'initial_state',
@@ -218,13 +229,18 @@ export class DuckBackend {
   }
 
   /**
-   * Inject `highlight_phrase` into every string-column displayer so the matched
-   * term is highlighted in the grid — the wire shape the Python `Search`
-   * command produces via its SDResult `highlight_phrase` update.
+   * Inject `highlight_phrase` into the displayer of every searched column so the
+   * matched term is highlighted in the grid — the wire shape the Python `Search`
+   * command produces via its SDResult `highlight_phrase` update. Gated on the
+   * searched aliases (not the displayer kind) so BOOLEAN columns, which also use
+   * the `string` displayer but aren't searched, are left alone.
    */
-  private applyHighlight(cfg: DFViewerConfig, term: string): void {
+  private applyHighlight(cfg: DFViewerConfig, term: string, searchable: Set<string>): void {
     for (const cc of cfg.column_config) {
-      if (cc.displayer_args.displayer === 'string') {
+      // Searched columns always carry the `string` displayer (isSearchableType
+      // ⊆ string-displayer types); the displayer check also narrows the type so
+      // `highlight_phrase` is valid.
+      if (searchable.has(cc.col_name) && cc.displayer_args.displayer === 'string') {
         cc.displayer_args = { ...cc.displayer_args, highlight_phrase: [term] };
       }
     }

--- a/packages/buckaroo-duckdb-node/src/search.ts
+++ b/packages/buckaroo-duckdb-node/src/search.ts
@@ -1,0 +1,49 @@
+/**
+ * Search: turn a user search term into the `+ WHERE` transform the
+ * effective-query seam (query.ts) reserves.
+ *
+ * Mirrors buckaroo's pandas `Search` command (customizations/pandas_commands.py):
+ * a case-sensitive substring match (`Series.str.find` → DuckDB `contains`) over
+ * every text column, OR-ed together, keeping any row that matches in at least
+ * one column. The term is also surfaced to the viewer as `highlight_phrase` so
+ * the string displayer highlights the match (backend.ts).
+ */
+
+import { quoteIdent } from './rename.js';
+import { duckTypeToColType } from './duckTypes.js';
+
+/**
+ * Textual columns are the search targets. `duckTypeToColType` folds BOOLEAN
+ * into `string`, but a boolean column is not text — exclude it so search
+ * matches the pandas string/object semantics rather than matching 'true'.
+ */
+export function isSearchableType(duckType: string): boolean {
+  if (duckTypeToColType(duckType) !== 'string') return false;
+  const base = duckType.trim().toUpperCase().replace(/\(.*$/, '').trim();
+  return base !== 'BOOLEAN' && base !== 'BOOL';
+}
+
+/** A no-op term — empty or whitespace — means "no filter". */
+export function isActiveSearch(term: string | null | undefined): boolean {
+  return typeof term === 'string' && term.length > 0;
+}
+
+/**
+ * Build the search `QueryTransform`. `columns` are the original (pre-rename)
+ * text column names; the transform wraps the effective SQL in a `WHERE` that
+ * keeps rows where any column contains the term. An empty term or no columns
+ * makes `apply` a no-op so the seam composes cleanly either way.
+ */
+export function buildSearchTransform(columns: string[], term: string) {
+  const needle = term.replace(/'/g, "''");
+  return {
+    kind: 'search',
+    apply(sql: string): string {
+      if (!isActiveSearch(term) || columns.length === 0) return sql;
+      const preds = columns
+        .map((c) => `contains(CAST(${quoteIdent(c)} AS VARCHAR), '${needle}')`)
+        .join(' OR ');
+      return `SELECT * FROM (${sql}) AS _search WHERE (${preds})`;
+    },
+  };
+}

--- a/packages/buckaroo-duckdb-node/src/search.ts
+++ b/packages/buckaroo-duckdb-node/src/search.ts
@@ -23,7 +23,10 @@ export function isSearchableType(duckType: string): boolean {
   return base !== 'BOOLEAN' && base !== 'BOOL';
 }
 
-/** A no-op term — empty or whitespace — means "no filter". */
+/**
+ * An empty/absent term means "no filter". Whitespace is a real term — pandas
+ * `Search` no-ops only on `""` (`val == ""`), so we must not trim here.
+ */
 export function isActiveSearch(term: string | null | undefined): boolean {
   return typeof term === 'string' && term.length > 0;
 }

--- a/packages/buckaroo-duckdb-node/src/search.ts
+++ b/packages/buckaroo-duckdb-node/src/search.ts
@@ -34,15 +34,20 @@ export function isActiveSearch(term: string | null | undefined): boolean {
 /**
  * Build the search `QueryTransform`. `columns` are the original (pre-rename)
  * text column names; the transform wraps the effective SQL in a `WHERE` that
- * keeps rows where any column contains the term. An empty term or no columns
- * makes `apply` a no-op so the seam composes cleanly either way.
+ * keeps rows where any column contains the term. An empty term makes `apply` a
+ * no-op; an active term with no text columns matches nothing (an always-false
+ * filter), mirroring pandas `search_df_str` (all-false mask OR-ed over zero
+ * string columns → empty frame) rather than passing every row through.
  */
 export function buildSearchTransform(columns: string[], term: string) {
   const needle = term.replace(/'/g, "''");
   return {
     kind: 'search',
     apply(sql: string): string {
-      if (!isActiveSearch(term) || columns.length === 0) return sql;
+      if (!isActiveSearch(term)) return sql;
+      if (columns.length === 0) {
+        return `SELECT * FROM (${sql}) AS _search WHERE (1=0)`;
+      }
       const preds = columns
         .map((c) => `contains(CAST(${quoteIdent(c)} AS VARCHAR), '${needle}')`)
         .join(' OR ');

--- a/packages/buckaroo-duckdb-node/src/transport.ts
+++ b/packages/buckaroo-duckdb-node/src/transport.ts
@@ -88,26 +88,50 @@ export class IpcDuckModel implements IModel {
   }
 }
 
+/** Pull the search term out of a `buckaroo_state_change` message, or '' if none. */
+export function extractSearchTerm(msg: {
+  new_state?: { quick_command_args?: Record<string, unknown> };
+  quick_command_args?: Record<string, unknown>;
+}): string {
+  const qa = msg?.new_state?.quick_command_args ?? msg?.quick_command_args;
+  const search = qa?.search;
+  if (Array.isArray(search) && search.length > 0 && search[0] != null) {
+    return String(search[0]);
+  }
+  return '';
+}
+
 /**
  * The main-process handler. Register with
  * `ipcMain.handle('buckaroo:msg', makeIpcMainHandler(backend))`.
  *
- * Returns the reply object the renderer re-emits as `"msg:custom"`. Unknown
- * message types (e.g. `buckaroo_state_change` quick commands) are no-ops in v1.
+ * Returns the reply object the renderer re-emits as `"msg:custom"`. A
+ * `buckaroo_state_change` carrying `quick_command_args.search` re-runs the
+ * search and replies with a fresh `initial_state` (filtered stats +
+ * highlight_phrase); other state changes are no-ops.
  */
 export function makeIpcMainHandler(
   backend: DuckBackend,
-): (event: unknown, msg: { type?: string; payload_args?: unknown }) => Promise<
-  InitialStateMessage | PayloadResponse | null
-> {
+): (
+  event: unknown,
+  msg: {
+    type?: string;
+    payload_args?: unknown;
+    new_state?: { quick_command_args?: Record<string, unknown> };
+    quick_command_args?: Record<string, unknown>;
+  },
+) => Promise<InitialStateMessage | PayloadResponse | null> {
   return async (_event, msg) => {
     switch (msg?.type) {
       case 'initial_state':
         return backend.initialState();
       case 'infinite_request':
         return backend.handleInfiniteRequest(msg.payload_args as never);
+      case 'buckaroo_state_change':
+        backend.setSearch(extractSearchTerm(msg));
+        return backend.initialState();
       default:
-        // viewer mode is read-only: buckaroo_state_change et al. are no-ops
+        // other read-only state changes are no-ops
         return null;
     }
   };

--- a/packages/buckaroo-duckdb-node/src/transport.ts
+++ b/packages/buckaroo-duckdb-node/src/transport.ts
@@ -51,6 +51,7 @@ export class IpcDuckModel implements IModel {
   private readonly channel: string;
   private readonly listeners = new Map<string, Set<Handler>>();
   private readonly state = new Map<string, unknown>();
+  private readonly pendingChanges = new Set<string>();
 
   constructor(invoke: IpcInvoke, opts: { channel?: string } = {}) {
     this.invoke = invoke;
@@ -58,11 +59,7 @@ export class IpcDuckModel implements IModel {
   }
 
   send(msg: unknown): void {
-    void this.invoke(this.channel, msg).then((reply) => {
-      if (reply !== undefined && reply !== null) {
-        this.emit('msg:custom', reply);
-      }
-    });
+    void this.invoke(this.channel, msg).then((reply) => this.applyReply(reply));
   }
 
   get(key: string): unknown {
@@ -70,10 +67,41 @@ export class IpcDuckModel implements IModel {
   }
   set(key: string, value: unknown): void {
     this.state.set(key, value);
+    this.pendingChanges.add(key);
     this.emit('change:' + key, value);
   }
+  /**
+   * Flush a pending `buckaroo_state` edit to the main process as a
+   * `buckaroo_state_change` (mirrors `WebSocketModel.save_changes`), then apply
+   * the returned `initial_state`. Without this the React search UI's
+   * `set('buckaroo_state', …)` never reaches the backend over IPC.
+   */
   save_changes(): void {
-    /* no-op: read-only viewer, no state to persist upstream */
+    const hadStateChange = this.pendingChanges.has('buckaroo_state');
+    this.pendingChanges.clear();
+    if (!hadStateChange) return;
+    const msg = { type: 'buckaroo_state_change', new_state: this.state.get('buckaroo_state') };
+    void this.invoke(this.channel, msg).then((reply) => this.applyReply(reply));
+  }
+
+  /**
+   * Route a main-process reply. An `initial_state` is fanned out as `change:*`
+   * events so the React tree re-renders (the filtered grid + highlight);
+   * anything else (an `infinite_resp`) is re-emitted as `msg:custom` for the
+   * row cache.
+   */
+  private applyReply(reply: unknown): void {
+    if (reply === undefined || reply === null) return;
+    const r = reply as { type?: string } & Record<string, unknown>;
+    if (r.type === 'initial_state') {
+      for (const [k, v] of Object.entries(r)) {
+        if (k === 'type') continue;
+        this.state.set(k, v);
+        this.emit('change:' + k, v);
+      }
+      return;
+    }
+    this.emit('msg:custom', reply);
   }
 
   on(event: string, handler: Handler): void {

--- a/packages/buckaroo-duckdb-node/src/wireTypes.ts
+++ b/packages/buckaroo-duckdb-node/src/wireTypes.ts
@@ -26,6 +26,12 @@ export interface ObjDisplayerA {
 export interface StringDisplayerA {
   displayer: 'string';
   max_length?: number;
+  /**
+   * Substrings to highlight in the rendered cell. Set under active search so
+   * the matched term is highlighted, mirroring the Python `Search` command's
+   * `highlight_phrase` SDResult update (pandas_commands.py).
+   */
+  highlight_phrase?: string[];
 }
 
 export interface FloatDisplayerA {

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -231,6 +231,24 @@ describe('DuckBackend search', () => {
     expect(src.lastCopyQuery).toContain('contains(');
   });
 
+  it('a setSearch with no intervening initialState still windows the filtered set', async () => {
+    const src = searchableSource();
+    const backend = new DuckBackend(src, 'SELECT * FROM t');
+    await backend.initialState(); // seeds the unfiltered length (5)
+
+    // setSearch alone — the activeSql is derived on demand and the filtered
+    // length recomputed here, so the window can't serve the stale full count.
+    backend.setSearch('Al');
+    const resp = await backend.handleInfiniteRequest({
+      sourceName: 'main',
+      start: 0,
+      end: 10,
+      origEnd: 10,
+    });
+    expect(resp.length).toBe(2);
+    expect(src.lastCopyQuery).toContain('contains(');
+  });
+
   it('clearing the search restores the full view', async () => {
     const backend = new DuckBackend(searchableSource(), 'SELECT * FROM t');
     await backend.initialState();

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -180,6 +180,58 @@ function searchableSource(): DuckSource & { summarizeQueries: string[]; lastCopy
   return src;
 }
 
+/**
+ * A fake with NO text columns. An active search must match nothing (its SQL
+ * carries the always-false `1=0` predicate → 0 rows); the unfiltered base
+ * reports 5.
+ */
+function numericOnlySource(): DuckSource & { lastCopyQuery?: string } {
+  const src: DuckSource & { lastCopyQuery?: string } = {
+    async describe(): Promise<DescribeRow[]> {
+      return [
+        { name: 'x', type: 'DOUBLE' },
+        { name: 'y', type: 'BIGINT' },
+      ];
+    },
+    async summarize(stmt: string): Promise<SummarizeRow[]> {
+      const count = stmt.includes('1=0') ? 0 : 5;
+      const base = (column_name: string, column_type: string): SummarizeRow => ({
+        column_name, column_type, min: null, max: null, approx_unique: count,
+        avg: null, std: null, q25: null, q50: null, q75: null, count, null_percentage: 0,
+      });
+      return [base('a', 'DOUBLE'), base('b', 'BIGINT'), base('index', 'BIGINT')];
+    },
+    async copyToParquet(query: string): Promise<Uint8Array> {
+      src.lastCopyQuery = query;
+      return new Uint8Array([9]);
+    },
+  };
+  return src;
+}
+
+/** A fake with a VARCHAR (searchable) and a BOOLEAN (string displayer, NOT searched). */
+function varcharAndBooleanSource(): DuckSource {
+  return {
+    async describe(): Promise<DescribeRow[]> {
+      return [
+        { name: 'label', type: 'VARCHAR' },
+        { name: 'flag', type: 'BOOLEAN' },
+      ];
+    },
+    async summarize(stmt: string): Promise<SummarizeRow[]> {
+      const count = stmt.includes('contains(') ? 2 : 5;
+      const base = (column_name: string, column_type: string): SummarizeRow => ({
+        column_name, column_type, min: null, max: null, approx_unique: count,
+        avg: null, std: null, q25: null, q50: null, q75: null, count, null_percentage: 0,
+      });
+      return [base('a', 'VARCHAR'), base('b', 'BOOLEAN'), base('index', 'BIGINT')];
+    },
+    async copyToParquet(): Promise<Uint8Array> {
+      return new Uint8Array([9]);
+    },
+  };
+}
+
 describe('DuckBackend search', () => {
   it('without search, filtered_rows equals total_rows and no highlight', async () => {
     const backend = new DuckBackend(searchableSource(), 'SELECT * FROM t');
@@ -274,5 +326,31 @@ describe('DuckBackend search', () => {
     const msg = await backend.initialState();
     expect(msg.df_meta.filtered_rows).toBe(5);
     expect(msg.df_meta.total_rows).toBe(5);
+  });
+
+  // Codex P2: an active search on a table with no text columns matches nothing
+  // (pandas returns an empty frame), not every row.
+  it('a search with no text columns yields zero filtered rows, total unchanged', async () => {
+    const backend = new DuckBackend(numericOnlySource(), 'SELECT * FROM t');
+    await backend.initialState(); // total = 5
+    backend.setSearch('Al');
+    const msg = await backend.initialState();
+    expect(msg.df_meta.total_rows).toBe(5);
+    expect(msg.df_meta.filtered_rows).toBe(0);
+  });
+
+  // Codex P3: BOOLEAN renders with the string displayer but is not searched, so
+  // highlight_phrase must land only on the columns the search predicate covers.
+  it('highlights only searched columns, not BOOLEAN string-displayer columns', async () => {
+    const backend = new DuckBackend(varcharAndBooleanSource(), 'SELECT * FROM t');
+    await backend.initialState();
+    backend.setSearch('Al');
+    const msg = await backend.initialState();
+    const cols = msg.df_display_args.main.df_viewer_config.column_config;
+    const label = cols.find((c) => c.col_name === 'a')!; // VARCHAR — searched
+    const flag = cols.find((c) => c.col_name === 'b')!; // BOOLEAN — string displayer, not searched
+    expect(label.displayer_args).toMatchObject({ highlight_phrase: ['Al'] });
+    expect(flag.displayer_args.displayer).toBe('string');
+    expect(flag.displayer_args).not.toHaveProperty('highlight_phrase');
   });
 });

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -214,6 +214,22 @@ describe('DuckBackend search', () => {
     expect(stringCol.displayer_args).toMatchObject({ highlight_phrase: ['Al'] });
   });
 
+  it('echoes the active search term in buckaroo_state so the StatusBar stays in sync', async () => {
+    // Without the echo, the returned buckaroo_state has empty quick_command_args,
+    // so the search cell's controlled value snaps back to '' while its local input
+    // still holds the term — StatusBar's debounce effect then resubmits forever.
+    const backend = new DuckBackend(searchableSource(), 'SELECT * FROM t');
+    await backend.initialState();
+    backend.setSearch('Al');
+    const msg = await backend.initialState();
+    expect(msg.buckaroo_state.quick_command_args).toEqual({ search: ['Al'] });
+
+    // clearing the search empties quick_command_args again
+    backend.setSearch('');
+    const cleared = await backend.initialState();
+    expect(cleared.buckaroo_state.quick_command_args).toEqual({});
+  });
+
   it('windows the filtered relation and returns the filtered length', async () => {
     const src = searchableSource();
     const backend = new DuckBackend(src, 'SELECT * FROM t');

--- a/packages/buckaroo-duckdb-node/test/backend.test.ts
+++ b/packages/buckaroo-duckdb-node/test/backend.test.ts
@@ -138,3 +138,107 @@ describe('DuckBackend.handleInfiniteRequest', () => {
     expect(src.lastCopyQuery).toContain('LIMIT 10 OFFSET 0');
   });
 });
+
+/**
+ * A fake whose summarize varies by SQL: the search-filtered relation (its SQL
+ * carries `contains(`) reports 2 rows, the unfiltered base reports 5. The
+ * column 'a' is text (VARCHAR), so it is a search target.
+ */
+function searchableSource(): DuckSource & { summarizeQueries: string[]; lastCopyQuery?: string } {
+  const src: DuckSource & { summarizeQueries: string[]; lastCopyQuery?: string } = {
+    summarizeQueries: [],
+    async describe(): Promise<DescribeRow[]> {
+      return [
+        { name: 'name', type: 'VARCHAR' },
+        { name: 'price', type: 'DOUBLE' },
+      ];
+    },
+    async summarize(stmt: string): Promise<SummarizeRow[]> {
+      src.summarizeQueries.push(stmt);
+      const count = stmt.includes('contains(') ? 2 : 5;
+      const base = (column_name: string, column_type: string): SummarizeRow => ({
+        column_name,
+        column_type,
+        min: null,
+        max: null,
+        approx_unique: count,
+        avg: null,
+        std: null,
+        q25: null,
+        q50: null,
+        q75: null,
+        count,
+        null_percentage: 0,
+      });
+      return [base('a', 'VARCHAR'), base('b', 'DOUBLE'), base('index', 'BIGINT')];
+    },
+    async copyToParquet(query: string): Promise<Uint8Array> {
+      src.lastCopyQuery = query;
+      return new Uint8Array([9]);
+    },
+  };
+  return src;
+}
+
+describe('DuckBackend search', () => {
+  it('without search, filtered_rows equals total_rows and no highlight', async () => {
+    const backend = new DuckBackend(searchableSource(), 'SELECT * FROM t');
+    const msg = await backend.initialState();
+    expect(msg.df_meta.total_rows).toBe(5);
+    expect(msg.df_meta.filtered_rows).toBe(5);
+    const stringCol = msg.df_display_args.main.df_viewer_config.column_config.find(
+      (c) => c.displayer_args.displayer === 'string',
+    )!;
+    expect(stringCol.displayer_args).not.toHaveProperty('highlight_phrase');
+  });
+
+  it('filters stats, keeps total_rows, and sets highlight_phrase on text columns', async () => {
+    const src = searchableSource();
+    const backend = new DuckBackend(src, 'SELECT * FROM t');
+    await backend.initialState(); // caches the unfiltered total (5)
+
+    backend.setSearch('Al');
+    const msg = await backend.initialState();
+
+    // total stays the unfiltered count; filtered reflects the search
+    expect(msg.df_meta.total_rows).toBe(5);
+    expect(msg.df_meta.filtered_rows).toBe(2);
+
+    // the stats SUMMARIZE ran against a relation carrying the search WHERE
+    expect(src.summarizeQueries.some((q) => q.includes('contains('))).toBe(true);
+
+    // highlight_phrase plumbed onto the text column displayer
+    const stringCol = msg.df_display_args.main.df_viewer_config.column_config.find(
+      (c) => c.displayer_args.displayer === 'string',
+    )!;
+    expect(stringCol.displayer_args).toMatchObject({ highlight_phrase: ['Al'] });
+  });
+
+  it('windows the filtered relation and returns the filtered length', async () => {
+    const src = searchableSource();
+    const backend = new DuckBackend(src, 'SELECT * FROM t');
+    await backend.initialState();
+    backend.setSearch('Al');
+    await backend.initialState();
+
+    const resp = await backend.handleInfiniteRequest({
+      sourceName: 'main',
+      start: 0,
+      end: 10,
+      origEnd: 10,
+    });
+    expect(resp.length).toBe(2);
+    expect(src.lastCopyQuery).toContain('contains(');
+  });
+
+  it('clearing the search restores the full view', async () => {
+    const backend = new DuckBackend(searchableSource(), 'SELECT * FROM t');
+    await backend.initialState();
+    backend.setSearch('Al');
+    await backend.initialState();
+    backend.setSearch('');
+    const msg = await backend.initialState();
+    expect(msg.df_meta.filtered_rows).toBe(5);
+    expect(msg.df_meta.total_rows).toBe(5);
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/search.test.ts
+++ b/packages/buckaroo-duckdb-node/test/search.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { buildSearchTransform, isSearchableType, isActiveSearch } from '../src/search';
+
+describe('isSearchableType', () => {
+  it.each([
+    ['VARCHAR', true],
+    ['TEXT', true],
+    ['UUID', true],
+    ['BOOLEAN', false], // folded into "string" by colType, but not text
+    ['BIGINT', false],
+    ['DOUBLE', false],
+    ['DATE', false],
+    ['VARCHAR[]', false],
+  ])('%s → %s', (duckType, expected) => {
+    expect(isSearchableType(duckType)).toBe(expected);
+  });
+});
+
+describe('isActiveSearch', () => {
+  it.each([
+    ['', false],
+    [null, false],
+    [undefined, false],
+    ['x', true],
+  ])('%s → %s', (term, expected) => {
+    expect(isActiveSearch(term as string)).toBe(expected);
+  });
+});
+
+describe('buildSearchTransform', () => {
+  it('ORs a case-sensitive contains() over every text column', () => {
+    const sql = buildSearchTransform(['name', 'city'], 'Al').apply('SELECT * FROM t');
+    expect(sql).toBe(
+      `SELECT * FROM (SELECT * FROM t) AS _search WHERE (` +
+        `contains(CAST("name" AS VARCHAR), 'Al') OR ` +
+        `contains(CAST("city" AS VARCHAR), 'Al'))`,
+    );
+  });
+
+  it('escapes single quotes in the term', () => {
+    const sql = buildSearchTransform(['name'], "O'Brien").apply('SELECT 1');
+    expect(sql).toContain("contains(CAST(\"name\" AS VARCHAR), 'O''Brien')");
+  });
+
+  it('is a no-op for an empty term', () => {
+    expect(buildSearchTransform(['name'], '').apply('SELECT 1')).toBe('SELECT 1');
+  });
+
+  it('is a no-op when there are no text columns', () => {
+    expect(buildSearchTransform([], 'Al').apply('SELECT 1')).toBe('SELECT 1');
+  });
+
+  it('reports its kind for the effective-query seam', () => {
+    expect(buildSearchTransform(['name'], 'Al').kind).toBe('search');
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/search.test.ts
+++ b/packages/buckaroo-duckdb-node/test/search.test.ts
@@ -46,8 +46,13 @@ describe('buildSearchTransform', () => {
     expect(buildSearchTransform(['name'], '').apply('SELECT 1')).toBe('SELECT 1');
   });
 
-  it('is a no-op when there are no text columns', () => {
-    expect(buildSearchTransform([], 'Al').apply('SELECT 1')).toBe('SELECT 1');
+  it('filters to zero rows when active with no text columns (pandas: empty result)', () => {
+    // pandas search_df_str starts from an all-false mask and ORs only string/
+    // object columns, so with zero text columns nothing matches — an active
+    // search must yield an empty result, not pass every row through.
+    expect(buildSearchTransform([], 'Al').apply('SELECT 1')).toBe(
+      'SELECT * FROM (SELECT 1) AS _search WHERE (1=0)',
+    );
   });
 
   it('reports its kind for the effective-query seam', () => {

--- a/packages/buckaroo-duckdb-node/test/spike.duckdb.test.ts
+++ b/packages/buckaroo-duckdb-node/test/spike.duckdb.test.ts
@@ -26,6 +26,7 @@ import { effectiveQuery, windowedQuery } from '../src/query';
 import { summarizeToSDType, sdTypeToStatRows } from '../src/stats';
 import { numericHistogramSql, parseNumericArgs, computeHistograms } from '../src/histogramSql';
 import { numericHistogram } from '../src/histogram';
+import { DuckBackend } from '../src/backend';
 import type { DuckSource } from '../src/DuckSource';
 
 // The exact integer column from the Python producer's histogram test
@@ -215,5 +216,41 @@ describe.runIf(process.env.SKIP_DUCKDB !== '1')('DuckDB serialization spike', ()
       { name: 'B', cat_pop: 30 },
       { name: 'C', cat_pop: 30 },
     ]);
+  });
+
+  it('search filters rows, stats counts, and highlights end to end', async () => {
+    if (!source) return;
+    const stmt = `SELECT * FROM (VALUES ('Alice', 1), ('Bob', 2), ('Charlie', 3), ('Alfred', 4)) t(name, n)`;
+    const backend = new DuckBackend(source, stmt);
+
+    const full = await backend.initialState();
+    expect(full.df_meta.total_rows).toBe(4);
+    expect(full.df_meta.filtered_rows).toBe(4);
+
+    // case-sensitive substring 'Al' matches Alice + Alfred, not Bob/Charlie
+    backend.setSearch('Al');
+    const filtered = await backend.initialState();
+    expect(filtered.df_meta.total_rows).toBe(4); // total unchanged
+    expect(filtered.df_meta.filtered_rows).toBe(2);
+
+    const strCol = filtered.df_display_args.main.df_viewer_config.column_config.find(
+      (c) => c.displayer_args.displayer === 'string',
+    )!;
+    expect(strCol.displayer_args).toMatchObject({ highlight_phrase: ['Al'] });
+
+    const resp = await backend.handleInfiniteRequest({
+      sourceName: 'main',
+      start: 0,
+      end: 10,
+      origEnd: 10,
+    });
+    expect(resp.length).toBe(2);
+    const matchRows = await readParquet(Buffer.from(resp.payload.data, 'base64'));
+    expect(matchRows.map((r) => r.a).sort()).toEqual(['Alfred', 'Alice']);
+
+    // clearing the search restores the full view
+    backend.setSearch('');
+    const restored = await backend.initialState();
+    expect(restored.df_meta.filtered_rows).toBe(4);
   });
 });

--- a/packages/buckaroo-duckdb-node/test/transport.test.ts
+++ b/packages/buckaroo-duckdb-node/test/transport.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractSearchTerm, makeIpcMainHandler } from '../src/transport';
+import type { DuckBackend } from '../src/backend';
+
+describe('extractSearchTerm', () => {
+  it('reads new_state.quick_command_args.search[0]', () => {
+    expect(extractSearchTerm({ new_state: { quick_command_args: { search: ['Al'] } } })).toBe('Al');
+  });
+  it('falls back to a top-level quick_command_args', () => {
+    expect(extractSearchTerm({ quick_command_args: { search: ['Bo'] } })).toBe('Bo');
+  });
+  it('is empty when there is no search term', () => {
+    expect(extractSearchTerm({ new_state: { quick_command_args: {} } })).toBe('');
+    expect(extractSearchTerm({})).toBe('');
+  });
+});
+
+describe('makeIpcMainHandler', () => {
+  function stubBackend() {
+    return {
+      initialState: vi.fn(async () => ({ type: 'initial_state' })),
+      handleInfiniteRequest: vi.fn(async () => ({ type: 'infinite_resp' })),
+      setSearch: vi.fn(),
+    };
+  }
+
+  it('routes a buckaroo_state_change to setSearch + a fresh initial_state', async () => {
+    const backend = stubBackend();
+    const handler = makeIpcMainHandler(backend as unknown as DuckBackend);
+
+    const reply = await handler(null, {
+      type: 'buckaroo_state_change',
+      new_state: { quick_command_args: { search: ['Al'] } },
+    });
+
+    expect(backend.setSearch).toHaveBeenCalledWith('Al');
+    expect(backend.initialState).toHaveBeenCalledTimes(1);
+    expect(reply).toEqual({ type: 'initial_state' });
+  });
+
+  it('clears the search when the term is gone', async () => {
+    const backend = stubBackend();
+    const handler = makeIpcMainHandler(backend as unknown as DuckBackend);
+    await handler(null, { type: 'buckaroo_state_change', new_state: { quick_command_args: {} } });
+    expect(backend.setSearch).toHaveBeenCalledWith('');
+  });
+
+  it('still answers initial_state and infinite_request', async () => {
+    const backend = stubBackend();
+    const handler = makeIpcMainHandler(backend as unknown as DuckBackend);
+    await handler(null, { type: 'initial_state' });
+    await handler(null, { type: 'infinite_request', payload_args: {} });
+    expect(backend.initialState).toHaveBeenCalledTimes(1);
+    expect(backend.handleInfiniteRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/buckaroo-duckdb-node/test/transport.test.ts
+++ b/packages/buckaroo-duckdb-node/test/transport.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi } from 'vitest';
-import { extractSearchTerm, makeIpcMainHandler } from '../src/transport';
+import { extractSearchTerm, makeIpcMainHandler, IpcDuckModel } from '../src/transport';
 import type { DuckBackend } from '../src/backend';
+
+/** A tick to let the `invoke(...).then(...)` microtask in send/save_changes settle. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
 
 describe('extractSearchTerm', () => {
   it('reads new_state.quick_command_args.search[0]', () => {
@@ -52,5 +55,55 @@ describe('makeIpcMainHandler', () => {
     await handler(null, { type: 'infinite_request', payload_args: {} });
     expect(backend.initialState).toHaveBeenCalledTimes(1);
     expect(backend.handleInfiniteRequest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('IpcDuckModel state changes', () => {
+  it('save_changes forwards a buckaroo_state_change and applies the returned initial_state', async () => {
+    const refreshed = {
+      type: 'initial_state',
+      df_meta: { total_rows: 5, filtered_rows: 2 },
+    };
+    const invoke = vi.fn(async () => refreshed);
+    const model = new IpcDuckModel(invoke);
+
+    const changes: unknown[] = [];
+    model.on('change:df_meta', (v) => changes.push(v));
+
+    const newState = { quick_command_args: { search: ['Al'] } };
+    model.set('buckaroo_state', newState);
+    model.save_changes();
+    await flush();
+
+    // the pending buckaroo_state went over the wire as a state_change
+    expect(invoke).toHaveBeenCalledWith('buckaroo:msg', {
+      type: 'buckaroo_state_change',
+      new_state: newState,
+    });
+    // the reply's keys were fanned out as change:* events (not msg:custom)
+    expect(changes).toEqual([{ total_rows: 5, filtered_rows: 2 }]);
+    expect(model.get('df_meta')).toEqual({ total_rows: 5, filtered_rows: 2 });
+  });
+
+  it('save_changes is a no-op when buckaroo_state was not touched', async () => {
+    const invoke = vi.fn(async () => null);
+    const model = new IpcDuckModel(invoke);
+    model.set('something_else', 1);
+    model.save_changes();
+    await flush();
+    expect(invoke).not.toHaveBeenCalled();
+  });
+
+  it('send re-emits an infinite_resp reply as msg:custom', async () => {
+    const reply = { type: 'infinite_resp', length: 2 };
+    const invoke = vi.fn(async () => reply);
+    const model = new IpcDuckModel(invoke);
+
+    const custom: unknown[] = [];
+    model.on('msg:custom', (m) => custom.push(m));
+    model.send({ type: 'infinite_request', payload_args: {} });
+    await flush();
+
+    expect(custom).toEqual([reply]);
   });
 });


### PR DESCRIPTION
Implements search in `buckaroo-duckdb-node`, the `+ WHERE` fast-follow the effective-query seam reserved (#936, `query.ts`: "search (`+ WHERE`, re-run stats for `search_` keys)"). Mirrors buckaroo's pandas `Search` command (`customizations/pandas_commands.py`).

**Stacked on #936.** Base is `feat/930-duckdb-node-backend` because the package only exists there. Once #936 merges, this retargets to `main` (automatic when the base branch is deleted).

## What's here

- **`search.ts`** — `buildSearchTransform` ORs a case-sensitive DuckDB `contains()` over every text column (`Series.str.find` parity), wrapping the effective SQL. `isSearchableType` targets the VARCHAR family (BOOLEAN excluded).
- **backend** — `setSearch(term)` re-runs `SUMMARIZE` over the filtered relation so stats reflect the matches (pandas re-runs stats on the filtered df). `total_rows` stays the unfiltered count (cached, so repeated searches don't re-summarize the base); `filtered_rows` and the `infinite_resp` length follow the filter; the row window runs against the filtered SQL. `highlight_phrase` is injected onto string-column displayers (the wire shape the Python `Search` SDResult produces).
- **transport** — a `buckaroo_state_change` carrying `quick_command_args.search` routes to `setSearch` + a fresh `initial_state`; `extractSearchTerm` parses the term. The WS demo server handles the same message so search works live.

## Validation

Real-DuckDB spike: searching `Al` over `Alice/Bob/Charlie/Alfred` returns exactly `Alice`+`Alfred`, `total_rows` stays 4, `filtered_rows` is 2, and `highlight_phrase` is plumbed. Full suite (74 tests) green locally; CI runs the non-DuckDB subset (`SKIP_DUCKDB=1`).

## Scope note

This covers the full-rebuild search path (re-run stats on the filtered set + highlight). The per-keystroke live-overlay path (#851's `search_string`) is a separate follow-up.

## TDD

First commit pushes the contract tests red (they reference the not-yet-added `search.ts` and backend/transport APIs); the second commit makes them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)